### PR TITLE
Partial re-parametrization

### DIFF
--- a/openff/system/exceptions.py
+++ b/openff/system/exceptions.py
@@ -49,6 +49,12 @@ class MissingDependencyError(BaseException):
         super().__init__(self.msg)
 
 
+class HandlerNotFoundError(ValueError):
+    """
+    Exception for when a handler is not found during a lookup
+    """
+
+
 class InvalidBoxError(ValueError):
     """
     Generic exception for errors reading box data

--- a/openff/system/tests/energy_tests/openmm.py
+++ b/openff/system/tests/energy_tests/openmm.py
@@ -1,6 +1,7 @@
 import numpy as np
 from simtk import openmm, unit
 
+from openff.system import unit as off_unit
 from openff.system.components.system import System
 from openff.system.tests.energy_tests.report import EnergyReport
 
@@ -84,10 +85,10 @@ def _get_openmm_energies(
     integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
     context = openmm.Context(omm_sys, integrator)
 
-    box_vectors = box_vectors.magnitude * unit.nanometer
+    box_vectors = box_vectors.to(off_unit.nanometer).magnitude * unit.nanometer
     context.setPeriodicBoxVectors(*box_vectors)
 
-    positions = positions.magnitude * unit.nanometer
+    positions = positions.to(off_unit.nanometer).magnitude * unit.nanometer
 
     if round_positions is not None:
         rounded = np.round(positions, round_positions)

--- a/openff/system/tests/test_reparametrize.py
+++ b/openff/system/tests/test_reparametrize.py
@@ -1,0 +1,40 @@
+import pytest
+from openff.toolkit.topology import Molecule
+
+from openff.system.exceptions import HandlerNotFoundError
+from openff.system.stubs import ForceField
+from openff.system.tests.energy_tests.openmm import get_openmm_energies
+
+
+def test_full_reparametrize():
+    mol = Molecule.from_smiles("OCCc1ccn2cnccc12")
+    top = mol.to_topology()
+
+    mol.generate_conformers(n_conformers=1)
+
+    parsley = ForceField("openff-1.0.0.offxml")
+    s99 = ForceField("smirnoff99frosst-1.1.0.offxml")
+
+    original = parsley.create_openff_system(top)
+    reference = s99.create_openff_system(top)
+
+    for out in [original, reference]:
+        out.positions = mol.conformers[0]
+        out.box = [4, 4, 4]
+
+    s99_energies = get_openmm_energies(reference)
+
+    with pytest.raises(HandlerNotFoundError):
+        original.reparametrize(other_force_field=s99, handler_name="LibraryCharges")
+
+    for energy_key, handler_names in zip(
+        ["Bond", "Angle", "Torsion", "Nonbonded"],
+        [["Bonds"], ["Angles"], ["ProperTorsions", "ImproperTorsions"], ["vdW"]],
+    ):
+        for handler_name in handler_names:
+            original.reparametrize(other_force_field=s99, handler_name=handler_name)
+        tmp_energies = get_openmm_energies(original)
+        assert tmp_energies.energies[energy_key] == s99_energies.energies[energy_key]
+
+    new_energies = get_openmm_energies(original)
+    new_energies.compare(s99_energies)

--- a/openff/system/tests/test_reparametrize.py
+++ b/openff/system/tests/test_reparametrize.py
@@ -13,7 +13,12 @@ def test_full_reparametrize():
     mol.generate_conformers(n_conformers=1)
 
     parsley = ForceField("openff-1.0.0.offxml")
-    s99 = ForceField("smirnoff99frosst-1.1.0.offxml")
+    try:
+        s99 = ForceField("smirnoff99frosst-1.1.0.offxml")
+    except OSError:
+        # Drop when below PR is in a release (0.9.2)
+        # https://github.com/openforcefield/openff-toolkit/pull/816
+        s99 = ForceField("smirnoff99Frosst-1.1.0.offxml")
 
     original = parsley.create_openff_system(top)
     reference = s99.create_openff_system(top)


### PR DESCRIPTION
### Description
This PR add a `System.reparametrize` method that allows for partial re-parametrization, i.e. reparametrizing an existing object handler-by-handler.

### Checklist
- [ ] Case of typing not changing, just parameters?
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
