### PR TITLE
Test against released version of OpenFF Recharge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,12 +36,6 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         auto-activate-base: false
 
-    - name: Install development version of OpenFF Recharge
-      shell: bash -l {0}
-      run: |
-        mamba install --only-deps openff-recharge -c conda-forge -c omnia
-        python -m pip install git+https://github.com/openforcefield/openff-recharge.git
-
     - name: Additional info about the build
       shell: bash
       run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -37,3 +37,4 @@ dependencies:
   - panedr
   - pandas-stubs
   - openff-evaluator
+  - openff-recharge


### PR DESCRIPTION
### Description
OpenFF Recharge v0.0.1 is now on `conda-forge` (and has been for quite some time, I think)
