### PR TITLE
Catch more cases of unsupported SMIRNOFF force fields

### DIFF
--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -114,13 +114,6 @@ class Interchange(DefaultModel):
                 continue
             if handler_name not in _SUPPORTED_SMIRNOFF_HANDLERS:
                 unsupported.append(handler_name)
-            if handler_name in {"Bonds", "ProperTorsions"}:
-                handler = force_field[handler_name]
-                if any([p.k_bondorder for p in handler.parameters]):
-                    raise SMIRNOFFHandlersNotImplementedError(
-                        "Bond order interpolation not supported. Found parameters with attribute"
-                        "`k_bondorder` in handler {handler_name}"
-                    )
 
         if unsupported:
             raise SMIRNOFFHandlersNotImplementedError(unsupported)
@@ -190,6 +183,7 @@ class Interchange(DefaultModel):
             #       move back to the constraint handler dealing with the logic (and
             #       depending on the bond handler)
             if potential_handler_type == SMIRNOFFBondHandler:
+                SMIRNOFFBondHandler.check_supported_parameters(force_field["Bonds"])
                 potential_handler = SMIRNOFFBondHandler._from_toolkit(
                     parameter_handler=force_field["Bonds"],
                     topology=topology,
@@ -219,6 +213,7 @@ class Interchange(DefaultModel):
                     topology=topology,
                 )
             else:
+                potential_handler_type.check_supported_parameters(parameter_handlers[0])
                 potential_handler = potential_handler_type._from_toolkit(  # type: ignore
                     parameter_handler=parameter_handlers[0],
                     topology=topology,

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -25,7 +25,10 @@ from simtk import unit as omm_unit
 from typing_extensions import Literal
 
 from openff.interchange.components.potentials import Potential, PotentialHandler
-from openff.interchange.exceptions import InvalidParameterHandlerError
+from openff.interchange.exceptions import (
+    InvalidParameterHandlerError,
+    SMIRNOFFParameterAttributeNotImplementedError,
+)
 from openff.interchange.models import PotentialKey, TopologyKey
 from openff.interchange.types import FloatQuantity
 
@@ -55,6 +58,20 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
     @abc.abstractmethod
     def allowed_parameter_handlers(cls):
         raise NotImplementedError()
+
+    @classmethod
+    @abc.abstractmethod
+    def supported_parameters(cls):
+        raise NotImplementedError()
+
+    @classmethod
+    def check_supported_parameters(cls, parameter_handler: ParameterHandler):
+        for parameter in parameter_handler.parameters:
+            for parameter_attribute in parameter._get_defined_parameter_attributes():
+                if parameter_attribute not in cls.supported_parameters():
+                    raise SMIRNOFFParameterAttributeNotImplementedError(
+                        parameter_attribute,
+                    )
 
     def store_matches(
         self,
@@ -107,6 +124,10 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
     @classmethod
     def allowed_parameter_handlers(cls):
         return [BondHandler]
+
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "k", "length"]
 
     def store_potentials(self, parameter_handler: "BondHandler") -> None:
         """
@@ -163,6 +184,10 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
     @classmethod
     def allowed_parameter_handlers(cls):
         return [BondHandler, ConstraintHandler]
+
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "k", "length", "distance"]
 
     @classmethod
     def _from_toolkit(
@@ -255,6 +280,10 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
     def allowed_parameter_handlers(cls):
         return [AngleHandler]
 
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "k", "angle"]
+
     def store_potentials(self, parameter_handler: "AngleHandler") -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
@@ -301,6 +330,10 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
     @classmethod
     def allowed_parameter_handlers(cls):
         return [ProperTorsionHandler]
+
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "k", "periodicity", "phase", "idivf"]
 
     def store_matches(
         self,
@@ -356,6 +389,10 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
     @classmethod
     def allowed_parameter_handlers(cls):
         return [ImproperTorsionHandler]
+
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "k", "periodicity", "phase", "idivf"]
 
     def store_matches(
         self, parameter_handler: "ImproperTorsionHandler", topology: "OFFBioTop"
@@ -465,6 +502,10 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
     def allowed_parameter_handlers(cls):
         return [vdWHandler]
 
+    @classmethod
+    def supported_parameters(cls):
+        return ["smirks", "id", "sigma", "epsilon", "rmin_half"]
+
     def store_potentials(self, parameter_handler: vdWHandler) -> None:
         """
         Populate self.potentials with key-val pairs of unique potential
@@ -551,6 +592,10 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
             ToolkitAM1BCCHandler,
             ElectrostaticsHandler,
         ]
+
+    @classmethod
+    def supported_parameters(cls):
+        pass
 
     @property
     def charges(self) -> Dict[TopologyKey, unit.Quantity]:

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -1,3 +1,10 @@
+class SMIRNOFFParameterAttributeNotImplementedError(Exception):
+    """
+    Exception for when a parameter attribute is supported by the SMIRNOFF specification
+    but not yet implemented, i.e. k_bondorder for bond order interpolation.
+    """
+
+
 class SMIRNOFFHandlersNotImplementedError(Exception):
     """
     Exception for when some parameter handlers in the SMIRNOFF specification

--- a/openff/interchange/tests/components/test_interchange.py
+++ b/openff/interchange/tests/components/test_interchange.py
@@ -13,7 +13,10 @@ from pydantic import ValidationError
 from openff.interchange.components.interchange import Interchange
 from openff.interchange.components.mdtraj import OFFBioTop
 from openff.interchange.drivers import get_openmm_energies
-from openff.interchange.exceptions import SMIRNOFFHandlersNotImplementedError
+from openff.interchange.exceptions import (
+    SMIRNOFFHandlersNotImplementedError,
+    SMIRNOFFParameterAttributeNotImplementedError,
+)
 from openff.interchange.tests import BaseTest
 from openff.interchange.tests.energy_tests.test_energies import needs_gmx, needs_lmp
 from openff.interchange.utils import get_test_file_path
@@ -96,7 +99,9 @@ class TestUnimplementedSMIRNOFFCases(BaseTest):
 
         top = Molecule.from_smiles("CCO").to_topology()
 
-        with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="ond order"):
+        with pytest.raises(
+            SMIRNOFFParameterAttributeNotImplementedError, match="length_bondorder"
+        ):
             Interchange.from_smirnoff(force_field=forcefield, topology=top)
 
     def test_catch_bond_order_interpolation_torsions(self):
@@ -110,8 +115,9 @@ class TestUnimplementedSMIRNOFFCases(BaseTest):
         )
 
         top = Molecule.from_smiles("CCO").to_topology()
-
-        with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="ond order"):
+        with pytest.raises(
+            SMIRNOFFParameterAttributeNotImplementedError, match="k.*_bondorder"
+        ):
             Interchange.from_smirnoff(force_field=forcefield, topology=top)
 
     def test_catch_virtual_sites(self):

--- a/openff/interchange/tests/components/test_interchange.py
+++ b/openff/interchange/tests/components/test_interchange.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import mdtraj as md
 import numpy as np
 import pytest
+from openff.toolkit.tests.utils import get_data_file_path
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField, ParameterHandler
 from openff.units import unit
@@ -46,17 +47,6 @@ def test_box_setter():
         tmp.box = [2, 2, 3, 90, 90, 90]
 
 
-def test_unimplemented_smirnoff_handler():
-    top = Molecule.from_smiles("CC").to_topology()
-    parsley = ForceField("openff-1.0.0.offxml")
-
-    bogus_parameter_handler = ParameterHandler(version=0.3)
-    bogus_parameter_handler._TAGNAME = "bogus"
-    parsley.register_parameter_handler(bogus_parameter_handler)
-    with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="SMIRNOFF.*bogus"):
-        Interchange.from_smirnoff(force_field=parsley, topology=top)
-
-
 @pytest.mark.slow
 class TestInterchangeCombination(BaseTest):
     def test_basic_combination(self):
@@ -81,6 +71,63 @@ class TestInterchangeCombination(BaseTest):
 
         # Just see if it can be converted into OpenMM and run
         get_openmm_energies(combined)
+
+
+class TestUnimplementedSMIRNOFFCases(BaseTest):
+    def test_bogus_smirnoff_handler(self):
+        top = Molecule.from_smiles("CC").to_topology()
+        parsley = ForceField("openff-1.0.0.offxml")
+
+        bogus_parameter_handler = ParameterHandler(version=0.3)
+        bogus_parameter_handler._TAGNAME = "bogus"
+        parsley.register_parameter_handler(bogus_parameter_handler)
+        with pytest.raises(
+            SMIRNOFFHandlersNotImplementedError, match="SMIRNOFF.*bogus"
+        ):
+            Interchange.from_smirnoff(force_field=parsley, topology=top)
+
+    def test_catch_bond_order_interpolation_bonds(self):
+        from openff.toolkit.tests.test_forcefield import xml_ff_bo
+
+        forcefield = ForceField(
+            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            xml_ff_bo,
+        )
+
+        top = Molecule.from_smiles("CCO").to_topology()
+
+        with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="ond order"):
+            Interchange.from_smirnoff(force_field=forcefield, topology=top)
+
+    def test_catch_bond_order_interpolation_torsions(self):
+        from openff.toolkit.tests.test_forcefield import (
+            xml_ff_torsion_bo_standard_supersede,
+        )
+
+        forcefield = ForceField(
+            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            xml_ff_torsion_bo_standard_supersede,
+        )
+
+        top = Molecule.from_smiles("CCO").to_topology()
+
+        with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="ond order"):
+            Interchange.from_smirnoff(force_field=forcefield, topology=top)
+
+    def test_catch_virtual_sites(self):
+        from openff.toolkit.tests.test_forcefield import (
+            xml_ff_virtual_sites_monovalent_match_once,
+        )
+
+        forcefield = ForceField(
+            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            xml_ff_virtual_sites_monovalent_match_once,
+        )
+
+        top = Molecule.from_smiles("CCO").to_topology()
+
+        with pytest.raises(SMIRNOFFHandlersNotImplementedError, match="VirtualSites"):
+            Interchange.from_smirnoff(force_field=forcefield, topology=top)
 
 
 class TestInterchange(BaseTest):

--- a/openff/interchange/tests/components/test_interchange.py
+++ b/openff/interchange/tests/components/test_interchange.py
@@ -115,13 +115,11 @@ class TestUnimplementedSMIRNOFFCases(BaseTest):
             Interchange.from_smirnoff(force_field=forcefield, topology=top)
 
     def test_catch_virtual_sites(self):
-        from openff.toolkit.tests.test_forcefield import (
-            xml_ff_virtual_sites_monovalent_match_once,
-        )
+        from openff.toolkit.tests.test_forcefield import TestForceFieldVirtualSites
 
         forcefield = ForceField(
             get_data_file_path("test_forcefields/test_forcefield.offxml"),
-            xml_ff_virtual_sites_monovalent_match_once,
+            TestForceFieldVirtualSites.xml_ff_virtual_sites_monovalent_match_once,
         )
 
         top = Molecule.from_smiles("CCO").to_topology()

--- a/openff/interchange/tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/components/test_smirnoff.py
@@ -47,6 +47,10 @@ class TestSMIRNOFFPotentialHandler(BaseTest):
             def allowed_parameter_handlers(cls):
                 return [DummyParameterHandler]
 
+            @classmethod
+            def supported_parameters(cls):
+                return list()
+
         dummy_handler = DummySMIRNOFFHandler()
         angle_Handler = AngleHandler(version=0.3)
 


### PR DESCRIPTION
### Description
This beefs up error handling in some cases of unsupported SMIRNOFF force field contents, namely bond order interpolation (bonds and torsions) and virtual sites.

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
