### PR TITLE
Add debug-statements hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
     exclude: '\.(pdb|gro|top|sdf)$'
+  - id: debug-statements
 - repo: https://github.com/psf/black
   rev: 21.6b0
   hooks:


### PR DESCRIPTION
### Description
I found this nice hook that enforces debug code, i.e. `import ipdb; ipdb.set_trace()` is not committed. I do this a lot, and automating away the fix seems like a good idea.
