### PR TITLE
Adopt interrogate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
     files: ^openff/interchange/
     exclude: openff/interchange/_version.py|setup.py
     args: [--py37-plus]
+- repo: https://github.com/econchick/interrogate
+  rev: 1.4.0
+  hooks:
+    - id: interrogate
+      args: [--quiet, --fail-under=45, openff/interchange]
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 0.13.0
   hooks:

--- a/openff/interchange/components/foyer.py
+++ b/openff/interchange/components/foyer.py
@@ -43,6 +43,7 @@ def _get_potential_key_id(atom_slots: Dict[TopologyKey, PotentialKey], idx):
 
 
 def get_handlers_callable() -> Dict[str, Type[PotentialHandler]]:
+    """Map Foyer-style handlers from string identifiers"""
     return {
         "vdW": FoyerVDWHandler,
         "Electrostatics": FoyerElectrostaticsHandler,
@@ -82,6 +83,7 @@ class FoyerVDWHandler(PotentialHandler):
             self.slot_map[top_key] = PotentialKey(id=val["atomtype"])
 
     def store_potentials(self, forcefield: "Forcefield") -> None:
+        """Extract specific force field parameters a Forcefield object"""
         for top_key in self.slot_map:
             atom_params = forcefield.get_parameters(
                 self.type, key=self.slot_map[top_key].id
@@ -111,6 +113,7 @@ class FoyerElectrostaticsHandler(PotentialHandler):
         atom_slots: Dict[TopologyKey, PotentialKey],
         forcefield: "Forcefield",
     ):
+        """Look up fixed charges (a.k.a. library charges) from the force field and store them in self.charges"""
         for top_key, pot_key in atom_slots.items():
             foyer_params = forcefield.get_parameters("atoms", pot_key.id)
             charge = foyer_params["charge"]

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -46,6 +46,8 @@ class PotentialHandler(DefaultModel):
 
     @property
     def independent_variables(self) -> Set[str]:
+        """Return a set of independent variables, as str, defined as variables in the
+        expression that are not found in any potentials."""
         vars_in_potentials = set([*self.potentials.values()][0].parameters.keys())
         vars_in_expression = {
             node.id
@@ -66,6 +68,7 @@ class PotentialHandler(DefaultModel):
 
     @requires_package("jax")
     def get_force_field_parameters(self):
+        """Return a flattened representation of the force field parameters"""
         import jax
 
         params: list = list()
@@ -77,6 +80,8 @@ class PotentialHandler(DefaultModel):
 
     @requires_package("jax")
     def get_system_parameters(self, p=None):
+        """Return a flattened representation of system parameters, effectively
+        force field parameters as applied to a chemical topology"""
         import jax
 
         if p is None:

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -57,11 +57,13 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
     @classmethod
     @abc.abstractmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes (toolkit)"""
         raise NotImplementedError()
 
     @classmethod
     @abc.abstractmethod
     def supported_parameters(cls):
+        """Return a list of parameter attributes supported by this handler"""
         raise NotImplementedError()
 
     @classmethod
@@ -662,7 +664,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
     @classmethod
     @functools.lru_cache(None)
     def _compute_partial_charges(cls, molecule: Molecule, method: str) -> unit.Quantity:
-
+        """Call out to the toolkit's toolkit wrappers to generate partial charges"""
         molecule = copy.deepcopy(molecule)
         molecule.assign_partial_charges(method)
 
@@ -965,6 +967,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
 def library_charge_from_molecule(
     molecule: "Molecule",
 ) -> LibraryChargeHandler.LibraryChargeType:
+    """Given an OpenFF Molecule with charges, generate a corresponding LibraryChargeType"""
     if molecule.partial_charges is None:
         raise ValueError("Input molecule is missing partial charges.")
 

--- a/openff/interchange/types.py
+++ b/openff/interchange/types.py
@@ -28,6 +28,7 @@ class FloatQuantity(float, metaclass=_FloatQuantityMeta):
 
     @classmethod
     def validate_type(cls, val):
+        """Process a value tagged with units into one tagged with "OpenFF" style units"""
         unit_ = getattr(cls, "__unit__", Any)
         if unit_ is Any:
             if isinstance(val, (float, int)):
@@ -115,6 +116,7 @@ class QuantityEncoder(json.JSONEncoder):
 
 
 def custom_quantity_encoder(v):
+    """Wrapper around json.dumps that uses QuantityEncoder"""
     return json.dumps(v, cls=QuantityEncoder)
 
 
@@ -152,6 +154,7 @@ else:
 
         @classmethod
         def validate_type(cls, val):
+            """Process an array tagged with units into one tagged with "OpenFF" style units"""
             unit_ = getattr(cls, "__unit__", Any)
             if unit_ is Any:
                 if isinstance(val, (list, np.ndarray)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-semiprivate = false
+ignore-private = true
+ignore-property-decorators = false
+ignore-module = false
+ignore-nested-functions = false
+ignore-nested-classes = true
+ignore-setters = true
+ignore-regex = ["^test_.*", "Test.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # .coveragerc to control coverage.py and pytest-cov
 omit =
     # Omit the tests
-    */*/tests/*
+    */*/tests/*test_*
     # Omit generated versioneer
     openff/interchange/_version.py
 


### PR DESCRIPTION
### Description
This PR adopts [`interrogate`](https://github.com/econchick/interrogate) by means of a pre-commit hook. It's  a tool that reports docstring coverage.

I set the threshold for passing to an abysmally low 45% and added just enough docstrings to cross that threshold. This should be raised in the future; for now it may serve as a rough check for if a PR adds a large number of docstring-less functions.


### Checklist
- [ ] Add tests
- [x] Lint
- [x] Update docstrings
