### PR TITLE
Add gro decimal precision for `get_gromacs_energies`

### DIFF
--- a/openff/interchange/drivers/gromacs.py
+++ b/openff/interchange/drivers/gromacs.py
@@ -128,7 +128,7 @@ def get_gromacs_energies(
     off_sys: "Interchange",
     mdp: str = "auto",
     writer: str = "internal",
-    decimal: int = 8
+    decimal: int = 8,
 ) -> EnergyReport:
     """
     Given an OpenFF Interchange object, return single-point energies as computed by GROMACS.

--- a/openff/interchange/drivers/gromacs.py
+++ b/openff/interchange/drivers/gromacs.py
@@ -128,6 +128,7 @@ def get_gromacs_energies(
     off_sys: "Interchange",
     mdp: str = "auto",
     writer: str = "internal",
+    decimal: int = 8
 ) -> EnergyReport:
     """
     Given an OpenFF Interchange object, return single-point energies as computed by GROMACS.
@@ -143,6 +144,8 @@ def get_gromacs_energies(
     writer : str, default="internal"
         A string key identifying the backend to be used to write GROMACS files. The
         default value of `"internal"` results in this package's exporters being used.
+    decimal : int, default=8
+        A decimal precision for the positions in the `.gro` file.
 
     Returns
     -------
@@ -152,7 +155,7 @@ def get_gromacs_energies(
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         with temporary_cd(tmpdir):
-            off_sys.to_gro("out.gro", writer=writer)
+            off_sys.to_gro("out.gro", writer=writer, decimal=decimal)
             off_sys.to_top("out.top", writer=writer)
             if mdp == "auto":
                 _write_mdp_file(off_sys)
@@ -264,7 +267,7 @@ def _get_gmx_energy_torsion(gmx_energies: Dict):
 
 @requires_package("panedr")
 def _parse_gmx_energy(edr_path: str) -> EnergyReport:
-    """Parse an `.xvg` file written by `gmx energy`."""
+    """Parse an `.edr` file written by `gmx energy`."""
     import panedr
 
     if TYPE_CHECKING:


### PR DESCRIPTION
### Description
We realized some of the differences in our energy tests are due to differences in precision of the positions defined in the gromacs `.gro` file, but that variable could not be changed from the `get_gromacs_energies`. This PR added a `decimal` flag for the `get_gromacs_energies` to address that issue. Related to #182 

### Checklist
- [ ] Add tests
- [ ] Lint
- [x] Update docstrings
