### PR TITLE
Adopt flake8-pytest-style

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install linters
         run: |
-          pip install black isort flake8 flake8-bugbear flake8-absolute-import
+          pip install black isort flake8 flake8-bugbear flake8-absolute-import flake8-pytest-style
 
       - name: Run black
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     additional_dependencies: [
         'flake8-bugbear',
         'flake8-absolute-import',
+        'flake8-pytest-style',
     ]
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.19.4
@@ -41,7 +42,7 @@ repos:
     - id: interrogate
       args: [--fail-under=43, openff/interchange/]
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.13.0
+  rev: 0.13.1
   hooks:
     - id: nbqa-pyupgrade
       args:

--- a/openff/interchange/tests/__init__.py
+++ b/openff/interchange/tests/__init__.py
@@ -10,26 +10,26 @@ from openff.interchange.utils import get_test_file_path
 
 class BaseTest:
     @pytest.fixture(autouse=True)
-    def initdir(self, tmpdir):
+    def _initdir(self, tmpdir):
         tmpdir.chdir()
 
     # TODO: group fixtures up as dicts, i.e. argon['forcefield'], argon['topology'], ...
-    @pytest.fixture
+    @pytest.fixture()
     def argon_ff(self):
         """Fixture that loads an SMIRNOFF XML for argon"""
         return ForceField(get_test_file_path("argon.offxml"))
 
-    @pytest.fixture
+    @pytest.fixture()
     def argon_top(self):
         """Fixture that builds a simple arogon topology"""
         return top_from_smiles("[#18]")
 
-    @pytest.fixture
+    @pytest.fixture()
     def ammonia_ff(self):
         """Fixture that loads an SMIRNOFF XML for ammonia"""
         return ForceField(get_test_file_path("ammonia.offxml"))
 
-    @pytest.fixture
+    @pytest.fixture()
     def ammonia_top(self):
         """Fixture that builds a simple ammonia topology"""
         mol = Molecule.from_smiles("N")
@@ -37,15 +37,15 @@ class BaseTest:
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
         return top
 
-    @pytest.fixture
+    @pytest.fixture()
     def ethanol_top(self):
         """Fixture that builds a simple four ethanol topology"""
         return top_from_smiles("CCO", n_molecules=4)
 
-    @pytest.fixture
+    @pytest.fixture()
     def parsley(self):
         return ForceField("openff-1.0.0.offxml")
 
-    @pytest.fixture
+    @pytest.fixture()
     def parsley_unconstrained(self):
         return ForceField("openff_unconstrained-1.0.0.offxml")

--- a/openff/interchange/tests/components/test_foyer.py
+++ b/openff/interchange/tests/components/test_foyer.py
@@ -102,7 +102,7 @@ class TestFoyer(BaseTest):
         assert oplsaa_interchange_ethanol["Electrostatics"].scale_14 == 0.5
 
     @needs_gmx
-    @pytest.mark.slow
+    @pytest.mark.slow()
     @pytest.mark.skip(
         reason="Exporting to OpenMM with geometric mixing rules not yet implemented"
     )
@@ -127,7 +127,7 @@ class TestFoyer(BaseTest):
         argnames="molecule_path",
         argvalues=glob.glob(get_test_files_dir_path("foyer_test_molecules") + "/*.sdf"),
     )
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_interchange_energies(self, molecule_path, get_interchanges, oplsaa):
         if "ethanol" in molecule_path or "adamantane" in molecule_path:
             pytest.skip("Foyer/ParmEd bug with this molecule")
@@ -202,7 +202,7 @@ class TestRBTorsions(BaseTest):
         return out
 
     @needs_gmx
-    @pytest.mark.slow
+    @pytest.mark.slow()
     @pytest.mark.skip(reason="Something is broken with RBTorsions in OpenMM export")
     def test_rb_torsions(self, ethanol_with_rb_torsions):
         omm = get_openmm_energies(ethanol_with_rb_torsions, round_positions=3).energies[
@@ -214,7 +214,7 @@ class TestRBTorsions(BaseTest):
 
         assert (gmx - omm).m_as(kj_mol) < 1e-6
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     @skip_if_missing("foyer")
     @skip_if_missing("mbuild")
     @needs_gmx

--- a/openff/interchange/tests/components/test_interchange.py
+++ b/openff/interchange/tests/components/test_interchange.py
@@ -52,7 +52,7 @@ def test_box_setter():
         tmp.box = [2, 2, 3, 90, 90, 90]
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 class TestInterchangeCombination(BaseTest):
     def test_basic_combination(self, parsley_unconstrained):
         """Test basic use of Interchange.__add__() based on the README example"""
@@ -180,7 +180,7 @@ class TestInterchange(BaseTest):
 
     @needs_gmx
     @needs_lmp
-    @pytest.mark.slow
+    @pytest.mark.slow()
     @skip_if_missing("foyer")
     def test_atom_ordering(self):
         """Test that atom indices in bonds are ordered consistently between the slot map and topology"""

--- a/openff/interchange/tests/components/test_mdtraj.py
+++ b/openff/interchange/tests/components/test_mdtraj.py
@@ -16,7 +16,7 @@ from openff.interchange.drivers import get_openmm_energies
 from openff.interchange.utils import get_test_file_path
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_residues():
     pdb = app.PDBFile(get_test_file_path("ALA_GLY/ALA_GLY.pdb"))
     traj = md.load(get_test_file_path("ALA_GLY/ALA_GLY.pdb"))

--- a/openff/interchange/tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/components/test_smirnoff.py
@@ -235,7 +235,7 @@ class TestSMIRNOFFHandlers(BaseTest):
 
 class TestConstraints:
     @pytest.mark.parametrize(
-        "mol,n_constraints",
+        ("mol", "n_constraints"),
         [
             ("C", 4),
             ("CC", 6),
@@ -277,7 +277,7 @@ def test_library_charges_from_molecule():
 @skip_if_missing("jax")
 class TestMatrixRepresentations(BaseTest):
     @pytest.mark.parametrize(
-        "handler_name,n_ff_terms,n_sys_terms",
+        ("handler_name", "n_ff_terms", "n_sys_terms"),
         [("vdW", 10, 72), ("Bonds", 8, 64), ("Angles", 6, 104)],
     )
     def test_to_force_field_to_system_parameters(

--- a/openff/interchange/tests/energy_tests/test_energies.py
+++ b/openff/interchange/tests/energy_tests/test_energies.py
@@ -57,8 +57,8 @@ def test_energy_report():
 @skip_if_missing("mbuild")
 @needs_gmx
 @needs_lmp
-@pytest.mark.xfail
-@pytest.mark.slow
+@pytest.mark.xfail()
+@pytest.mark.slow()
 @pytest.mark.parametrize("constrained", [True, False])
 @pytest.mark.parametrize("mol_smi", ["C"])  # ["C", "CC"]
 def test_energies_single_mol(constrained, mol_smi):
@@ -134,7 +134,7 @@ def test_energies_single_mol(constrained, mol_smi):
 
 @needs_gmx
 @needs_lmp
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_liquid_argon():
     argon = Molecule.from_smiles("[#18]")
     pdbfile = app.PDBFile(get_test_file_path("packed-argon.pdb"))
@@ -252,7 +252,7 @@ def test_packmol_boxes(toolkit_file_path):
 
 
 @needs_lmp
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_water_dimer():
     tip3p = ForceField(get_test_file_path("tip3p.offxml"))
     water = Molecule.from_smiles("O")
@@ -297,7 +297,7 @@ def test_water_dimer():
 @needs_gmx
 @skip_if_missing("foyer")
 @skip_if_missing("mbuild")
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_process_rb_torsions():
     """Test that the GROMACS driver reports Ryckaert-Bellemans torsions"""
 
@@ -362,8 +362,8 @@ def test_gmx_14_energies_exist():
 
 @needs_gmx
 @needs_lmp
-@pytest.mark.xfail
-@pytest.mark.slow
+@pytest.mark.xfail()
+@pytest.mark.slow()
 def test_cutoff_electrostatics():
     ion_ff = ForceField(get_test_file_path("ions.offxml"))
     ions = Topology.from_molecules(

--- a/openff/interchange/tests/integration_tests/test_interoperability_pathways.py
+++ b/openff/interchange/tests/integration_tests/test_interoperability_pathways.py
@@ -80,7 +80,7 @@ def openff_pmd_gmx_direct(
 
 
 @needs_gmx
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.parametrize("smiles", ["C"])
 def test_parmed_openmm(tmpdir, smiles):
     tmpdir.chdir()

--- a/openff/interchange/tests/integration_tests/test_toolkit.py
+++ b/openff/interchange/tests/integration_tests/test_toolkit.py
@@ -156,7 +156,7 @@ def compare_condensed_systems(mol, force_field):
 
 @skip_if_missing("openff.evaluator")
 @pytest.mark.timeout(60)
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "rdmol",
     Chem.SDMolSupplier(get_test_file_path("MiniDrugBankTrimmed.sdf"), sanitize=False),

--- a/openff/interchange/tests/interop/internal/test_amber.py
+++ b/openff/interchange/tests/interop/internal/test_amber.py
@@ -14,7 +14,7 @@ kj_mol = unit.kilojoule / unit.mol
 
 @skip_if_missing("intermol")
 @needs_gmx
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_amber_energy():
     """Basic test to see if the amber energy driver is functional"""
     mol = Molecule.from_smiles("CCO")

--- a/openff/interchange/tests/interop/internal/test_gromacs.py
+++ b/openff/interchange/tests/interop/internal/test_gromacs.py
@@ -52,7 +52,7 @@ class TestGROMACS(BaseTest):
         with pytest.raises(UnsupportedExportError, match="rule `geometric` not compat"):
             openff_sys.to_top("out.top")
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_residue_names_in_gro_file(self):
         """Test that residue names > 5 characters don't break .gro file output"""
         benzene = Molecule.from_file(get_test_file_path("benzene.sdf"))

--- a/openff/interchange/tests/interop/internal/test_lammps.py
+++ b/openff/interchange/tests/interop/internal/test_lammps.py
@@ -13,7 +13,7 @@ from openff.interchange.tests.energy_tests.test_energies import needs_lmp
 
 
 @needs_lmp
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.parametrize("n_mols", [1, 2])
 @pytest.mark.parametrize(
     "mol",

--- a/openff/interchange/tests/interop/test_external.py
+++ b/openff/interchange/tests/interop/test_external.py
@@ -17,7 +17,7 @@ from openff.interchange.utils import get_test_file_path
 
 
 class TestFromOpenMM(BaseTest):
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_from_openmm_pdbfile(self, argon_ff, argon_top):
         pdb_file_path = get_test_file_path("10-argons.pdb")
         pdbfile = openmm.app.PDBFile(pdb_file_path)
@@ -46,14 +46,14 @@ class TestFromOpenMM(BaseTest):
             )
         )
 
-    @pytest.fixture
+    @pytest.fixture()
     def unique_molecules(self):
         molecules = ["O", "C1CCCCC1", "C", "CCC", "CCO", "CCCCO"]
         return [Molecule.from_smiles(mol) for mol in molecules]
         # What if, instead ...
         # Molecule.from_iupac(molecules)
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     @pytest.mark.parametrize(
         "pdb_path",
         [

--- a/openff/interchange/tests/interop/test_openmm.py
+++ b/openff/interchange/tests/interop/test_openmm.py
@@ -98,14 +98,14 @@ def test_openmm_nonbonded_methods(inputs):
             raise Exception
     elif issubclass(result, (BaseException, Exception)):
         exception = result
+        forcefield.get_parameter_handler("vdW", {}).method = vdw_method
+        forcefield.get_parameter_handler(
+            "Electrostatics", {}
+        ).method = electrostatics_method
+        openff_interchange = Interchange.from_smirnoff(
+            force_field=forcefield, topology=topology
+        )
         with pytest.raises(exception):
-            forcefield.get_parameter_handler("vdW", {}).method = vdw_method
-            forcefield.get_parameter_handler(
-                "Electrostatics", {}
-            ).method = electrostatics_method
-            openff_interchange = Interchange.from_smirnoff(
-                force_field=forcefield, topology=topology
-            )
             openff_interchange.to_openmm(combine_nonbonded_forces=True)
     else:
         raise Exception("uh oh")
@@ -126,7 +126,7 @@ def test_unsupported_mixing_rule():
         openff_sys.to_openmm(combine_nonbonded_forces=True)
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 @pytest.mark.parametrize("n_mols", [1, 2])
 @pytest.mark.parametrize(
     "mol",
@@ -187,7 +187,7 @@ def test_from_openmm_single_mols(mol, n_mols):
 @pytest.mark.xfail(
     reason="from_openmm does not correctly import vdW parameters from custom forces."
 )
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_openmm_roundtrip():
     mol = Molecule.from_smiles("CCO")
     mol.generate_conformers(n_conformers=1)
@@ -218,7 +218,7 @@ def test_openmm_roundtrip():
     )
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_combine_nonbonded_forces():
 
     mol = Molecule.from_smiles("ClC#CCl")

--- a/openff/interchange/tests/interop/test_parmed.py
+++ b/openff/interchange/tests/interop/test_parmed.py
@@ -99,8 +99,8 @@ class TestParmedConversion(BaseTest):
 
         assert np.allclose(struct.box, np.array([40, 40, 40, 90, 90, 90]))
 
-    @pytest.mark.slow
-    @pytest.mark.xfail
+    @pytest.mark.slow()
+    @pytest.mark.xfail()
     def test_parmed_roundtrip(self):
         original = pmd.load_file(get_test_file_path("ALA_GLY/ALA_GLY.top"))
         gro = pmd.load_file(get_test_file_path("ALA_GLY/ALA_GLY.gro"))
@@ -155,7 +155,7 @@ class TestParmedConversion(BaseTest):
 
 
 class TestParmEdAmber:
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_load_prmtop(self):
         struct = readparm.LoadParm(get_pmd_fn("trx.prmtop"))
         other_struct = readparm.AmberParm(get_pmd_fn("trx.prmtop"))
@@ -174,7 +174,7 @@ class TestParmEdAmber:
             prmtop_converted.box, np.eye(3) * 2.0 * unit.nanometer
         )
 
-    @pytest.mark.slow
+    @pytest.mark.slow()
     def test_read_box_parm7(self):
         top = readparm.LoadParm(get_pmd_fn("solv2.parm7"))
         out = Interchange._from_parmed(top)


### PR DESCRIPTION
### Description
Looks like a useful little flake8 plugin: https://github.com/m-burst/flake8-pytest-style

In the current test suite, it only found one minor/potential issue. Hopefully can safeguard against sketchy things that I might try to do in the future.

### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
