### PR TITLE
Update partial charges in some tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         'flake8-pytest-style',
     ]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.19.4
+  rev: v2.20.0
   hooks:
   - id: pyupgrade
     files: ^openff/interchange/

--- a/openff/interchange/tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/components/test_smirnoff.py
@@ -175,7 +175,7 @@ class TestSMIRNOFFHandlers(BaseTest):
 
         np.testing.assert_allclose(
             [charge.m_as(unit.e) for charge in electrostatics_handler.charges.values()],
-            [-0.1088, 0.0267, 0.0267, 0.0267, 0.0267],
+            [-0.10868, 0.02717, 0.02717, 0.02717, 0.02717],
         )
 
     def test_electrostatics_library_charges(self):
@@ -229,7 +229,8 @@ class TestSMIRNOFFHandlers(BaseTest):
         # sum is [-0.068,  0.068]
         np.testing.assert_allclose(
             [charge.m_as(unit.e) for charge in electrostatics_handler.charges.values()],
-            [-0.068, 0.068],
+            [-0.06806, 0.06806],
+            atol=1e-6,
         )
 
 


### PR DESCRIPTION
### Description
Leaving hanging until a 0.10.0 toolkit release (0.9.3 if I don't get my way on versioning). ~~Changes result from https://github.com/openforcefield/openff-toolkit/pull/948 https://github.com/openforcefield/openff-toolkit/pull/1007~~ hmm that's not merged. I'm not sure where these differences come from ... wrapped toolkit differences?

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
