### PR TITLE
LINT: Adopt flake8-typing-only-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
         'flake8-bugbear',
         'flake8-absolute-import',
         'flake8-pytest-style',
+        'flake8-typing-only-imports',
     ]
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.20.0

--- a/openff/interchange/drivers/amber.py
+++ b/openff/interchange/drivers/amber.py
@@ -1,19 +1,21 @@
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Dict, Union
+from typing import TYPE_CHECKING, Dict, Union
 
 from openff.utilities.utilities import requires_package, temporary_cd
 from simtk import unit as omm_unit
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.drivers.report import EnergyReport
 from openff.interchange.exceptions import SanderError
 from openff.interchange.utils import get_test_file_path
 
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
+
 
 def get_amber_energies(
-    off_sys: Interchange,
+    off_sys: "Interchange",
     writer: str = "parmed",
     electrostatics=True,
 ) -> EnergyReport:

--- a/openff/interchange/drivers/lammps.py
+++ b/openff/interchange/drivers/lammps.py
@@ -1,17 +1,19 @@
 import subprocess
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import numpy as np
 from openff.units import unit
 from simtk import unit as omm_unit
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.drivers.report import EnergyReport
 from openff.interchange.exceptions import LAMMPSRunError
 
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
+
 
 def get_lammps_energies(
-    off_sys: Interchange,
+    off_sys: "Interchange",
     round_positions=None,
     writer: str = "internal",
 ) -> EnergyReport:
@@ -95,7 +97,7 @@ def _parse_lammps_log(file_in) -> List[float]:
 
 
 def _write_lammps_input(
-    off_sys: Interchange,
+    off_sys: "Interchange",
     file_name="test.in",
 ):
     """Write a LAMMPS input file for running single-point energies."""

--- a/openff/interchange/drivers/openmm.py
+++ b/openff/interchange/drivers/openmm.py
@@ -1,16 +1,18 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import numpy as np
 from simtk import openmm, unit
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.drivers.report import EnergyReport
+
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
 
 kj_mol = unit.kilojoule_per_mole
 
 
 def get_openmm_energies(
-    off_sys: Interchange,
+    off_sys: "Interchange",
     round_positions=None,
     hard_cutoff: bool = False,
     electrostatics: bool = True,

--- a/openff/interchange/interop/external.py
+++ b/openff/interchange/interop/external.py
@@ -1,12 +1,14 @@
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.exceptions import (
     MissingBoxError,
     MissingPositionsError,
     UnsupportedExportError,
 )
+
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
 
 
 class InteroperabilityWrapper:

--- a/openff/interchange/interop/internal/lammps.py
+++ b/openff/interchange/interop/internal/lammps.py
@@ -1,15 +1,17 @@
 from pathlib import Path
-from typing import IO, Dict, Union
+from typing import IO, TYPE_CHECKING, Dict, Union
 
 import numpy as np
 from openff.units import unit
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.exceptions import UnsupportedExportError
 from openff.interchange.models import TopologyKey
 
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
 
-def to_lammps(openff_sys: Interchange, file_path: Union[Path, str]):
+
+def to_lammps(openff_sys: "Interchange", file_path: Union[Path, str]):
     """Write an Interchange object to a LAMMPS data file"""
 
     if isinstance(file_path, str):
@@ -127,7 +129,7 @@ def to_lammps(openff_sys: Interchange, file_path: Union[Path, str]):
             _write_impropers(lmp_file=lmp_file, openff_sys=openff_sys)
 
 
-def _write_pair_coeffs(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
+def _write_pair_coeffs(lmp_file: IO, openff_sys: "Interchange", atom_type_map: Dict):
     """Write the Pair Coeffs section of a LAMMPS data file"""
     lmp_file.write("Pair Coeffs\n\n")
 
@@ -144,7 +146,7 @@ def _write_pair_coeffs(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dic
     lmp_file.write("\n")
 
 
-def _write_bond_coeffs(lmp_file: IO, openff_sys: Interchange):
+def _write_bond_coeffs(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Bond Coeffs section of a LAMMPS data file"""
     lmp_file.write("Bond Coeffs\n\n")
 
@@ -163,7 +165,7 @@ def _write_bond_coeffs(lmp_file: IO, openff_sys: Interchange):
     lmp_file.write("\n")
 
 
-def _write_angle_coeffs(lmp_file: IO, openff_sys: Interchange):
+def _write_angle_coeffs(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Angle Coeffs section of a LAMMPS data file"""
     lmp_file.write("\nAngle Coeffs\n\n")
 
@@ -182,7 +184,7 @@ def _write_angle_coeffs(lmp_file: IO, openff_sys: Interchange):
     lmp_file.write("\n")
 
 
-def _write_proper_coeffs(lmp_file: IO, openff_sys: Interchange):
+def _write_proper_coeffs(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Dihedral Coeffs section of a LAMMPS data file"""
     lmp_file.write("\nDihedral Coeffs\n\n")
 
@@ -205,7 +207,7 @@ def _write_proper_coeffs(lmp_file: IO, openff_sys: Interchange):
     lmp_file.write("\n")
 
 
-def _write_improper_coeffs(lmp_file: IO, openff_sys: Interchange):
+def _write_improper_coeffs(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Improper Coeffs section of a LAMMPS data file"""
     lmp_file.write("\nImproper Coeffs\n\n")
 
@@ -255,7 +257,7 @@ def _write_improper_coeffs(lmp_file: IO, openff_sys: Interchange):
     lmp_file.write("\n")
 
 
-def _write_atoms(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
+def _write_atoms(lmp_file: IO, openff_sys: "Interchange", atom_type_map: Dict):
     """Write the Atoms section of a LAMMPS data file"""
     lmp_file.write("\nAtoms\n\n")
 
@@ -289,7 +291,7 @@ def _write_atoms(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
         )
 
 
-def _write_bonds(lmp_file: IO, openff_sys: Interchange):
+def _write_bonds(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Bonds section of a LAMMPS data file"""
     lmp_file.write("\nBonds\n\n")
 
@@ -323,7 +325,7 @@ def _write_bonds(lmp_file: IO, openff_sys: Interchange):
         )
 
 
-def _write_angles(lmp_file: IO, openff_sys: Interchange):
+def _write_angles(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Angles section of a LAMMPS data file"""
     from openff.interchange.components.mdtraj import (
         _iterate_angles,
@@ -357,7 +359,7 @@ def _write_angles(lmp_file: IO, openff_sys: Interchange):
         )
 
 
-def _write_propers(lmp_file: IO, openff_sys: Interchange):
+def _write_propers(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Dihedrals section of a LAMMPS data file"""
     from openff.interchange.components.mdtraj import (
         _iterate_propers,
@@ -393,7 +395,7 @@ def _write_propers(lmp_file: IO, openff_sys: Interchange):
                 )
 
 
-def _write_impropers(lmp_file: IO, openff_sys: Interchange):
+def _write_impropers(lmp_file: IO, openff_sys: "Interchange"):
     """Write the Impropers section of a LAMMPS data file"""
     from openff.interchange.components.mdtraj import (
         _iterate_impropers,

--- a/openff/interchange/tests/utils.py
+++ b/openff/interchange/tests/utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import mdtraj as md
 import numpy as np
@@ -9,8 +9,10 @@ from openff.utilities.utilities import has_executable
 from simtk import openmm
 from simtk import unit as simtk_unit
 
-from openff.interchange.components.interchange import Interchange
 from openff.interchange.components.mdtraj import OFFBioTop
+
+if TYPE_CHECKING:
+    from openff.interchange.components.interchange import Interchange
 
 HAS_GROMACS = any(has_executable(e) for e in ["gmx", "gmx_d"])
 HAS_LAMMPS = any(has_executable(e) for e in ["lammps", "lmp_mpi", "lmp_serial"])
@@ -89,7 +91,7 @@ def _get_lj_params_from_openmm_system(omm_sys: openmm.System):
     return sigmas, epsilons
 
 
-def _get_charges_from_openff_interchange(off_sys: Interchange):
+def _get_charges_from_openff_interchange(off_sys: "Interchange"):
     charges_ = [*off_sys.handlers["Electrostatics"].charges.values()]
     charges = np.asarray([charge.magnitude for charge in charges_])
     return charges


### PR DESCRIPTION
### Description
For cases in which something is imported not to be used but only to be included in a type annotation, mypy allows us to sneak this into a `if TYPE_CHECKING:` block, which leads to that thing not being imported at runtime. This can provide speedups when the thing being imported is potentially heavy, such as `Interchange`. I was doing this manually (read: inconsistently) but found a flake8 plugin to automatically warn when this could be used. I've found some downsides in that it doesn't play too nicely with pydantic, and also is fairly slow.

https://github.com/snok/flake8-type-checking

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
