### PR TITLE
Add more docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     exclude: '\.(pdb|gro|top|sdf)$'
   - id: debug-statements
 - repo: https://github.com/psf/black
-  rev: 21.6b0
+  rev: 21.7b0
   hooks:
   - id: black
     files: ^openff
     args: [--check]
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.1
+  rev: 5.9.3
   hooks:
   - id: isort
     files: ^openff
@@ -30,24 +30,30 @@ repos:
         'flake8-pytest-style',
     ]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.20.0
+  rev: v2.23.1
   hooks:
   - id: pyupgrade
-    files: ^openff/interchange/
+    files: ^openff/interchange
     exclude: openff/interchange/_version.py|setup.py
     args: [--py37-plus]
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.1.1
+  hooks:
+  - id: pydocstyle
+    files: ^openff/interchange
+    args: ["--config=setup.cfg"]
 - repo: https://github.com/econchick/interrogate
   rev: 1.4.0
   hooks:
     - id: interrogate
-      args: [--fail-under=43, openff/interchange/]
+      args: [--fail-under=60, openff/interchange/]
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.10.0
   hooks:
     - id: blacken-docs
       additional_dependencies: [black==21.6b0]
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.13.1
+  rev: 1.0.0
   hooks:
     - id: nbqa-pyupgrade
       args:

--- a/openff/interchange/__init__.py
+++ b/openff/interchange/__init__.py
@@ -1,3 +1,4 @@
+"""A project (and object) for storing, manipulating, and converting molecular mechanics data."""
 from openff.interchange._version import get_versions  # type: ignore
 
 # Handle versioneer

--- a/openff/interchange/_version.py
+++ b/openff/interchange/_version.py
@@ -1,4 +1,4 @@
-# type: ignore
+# type: ignore # noqa
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag

--- a/openff/interchange/components/__init__.py
+++ b/openff/interchange/components/__init__.py
@@ -1,0 +1,1 @@
+"""Components comprising Interchange objects."""

--- a/openff/interchange/components/foyer.py
+++ b/openff/interchange/components/foyer.py
@@ -1,3 +1,4 @@
+"""Models and utilities for processing Foyer data."""
 from abc import abstractmethod
 from copy import copy
 from typing import TYPE_CHECKING, Dict, Type
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from foyer.forcefield import Forcefield
     from foyer.topology_graph import TopologyGraph
 
-    from openff.interchange.components.mdtraj import OFFBioTop
+    from openff.interchange.components.mdtraj import _OFFBioTop
 
 # Is this the safest way to achieve PotentialKey id separation?
 POTENTIAL_KEY_SEPARATOR = "-"
@@ -26,7 +27,7 @@ if has_package("foyer"):
 def _copy_params(
     params: Dict[str, float], *drop_keys: str, param_units: Dict = None
 ) -> Dict:
-    """copy parameters from a dictionary"""
+    """Copy parameters from a dictionary."""
     params_copy = copy(params)
     for drop_key in drop_keys:
         params_copy.pop(drop_key, None)
@@ -37,13 +38,13 @@ def _copy_params(
 
 
 def _get_potential_key_id(atom_slots: Dict[TopologyKey, PotentialKey], idx):
-    """From a dictionary of TopologyKey: PotentialKey, get the PotentialKey id"""
+    """From a dictionary of TopologyKey: PotentialKey, get the PotentialKey id."""
     top_key = TopologyKey(atom_indices=(idx,))
     return atom_slots[top_key].id
 
 
 def get_handlers_callable() -> Dict[str, Type[PotentialHandler]]:
-    """Map Foyer-style handlers from string identifiers"""
+    """Map Foyer-style handlers from string identifiers."""
     return {
         "vdW": FoyerVDWHandler,
         "Electrostatics": FoyerElectrostaticsHandler,
@@ -57,6 +58,8 @@ def get_handlers_callable() -> Dict[str, Type[PotentialHandler]]:
 
 
 class FoyerVDWHandler(PotentialHandler):
+    """Handler storing vdW potentials as produced by a Foyer force field."""
+
     type: str = "atoms"
     expression: str = "4*epsilon*((sigma/r)**12-(sigma/r)**6)"
     mixing_rule: str = "geometric"
@@ -71,9 +74,9 @@ class FoyerVDWHandler(PotentialHandler):
     def store_matches(
         self,
         force_field: "Forcefield",
-        topology: "OFFBioTop",
+        topology: "_OFFBioTop",
     ) -> None:
-        """Populate slotmap with key-val pairs of slots and unique potential Identifiers"""
+        """Populate self.slot_map with key-val pairs of [TopologyKey, PotentialKey]."""
         from foyer.atomtyper import find_atomtypes
 
         top_graph = TopologyGraph.from_openff_topology(openff_topology=topology)
@@ -83,7 +86,7 @@ class FoyerVDWHandler(PotentialHandler):
             self.slot_map[top_key] = PotentialKey(id=val["atomtype"])
 
     def store_potentials(self, force_field: "Forcefield") -> None:
-        """Extract specific force field parameters a Forcefield object"""
+        """Extract specific force field potentials a Forcefield object."""
         for top_key in self.slot_map:
             atom_params = force_field.get_parameters(
                 self.type, key=self.slot_map[top_key].id
@@ -99,6 +102,8 @@ class FoyerVDWHandler(PotentialHandler):
 
 
 class FoyerElectrostaticsHandler(PotentialHandler):
+    """Handler storing electrostatics potentials as produced by a Foyer force field."""
+
     type: str = "Electrostatics"
     method: str = "pme"
     expression: str = "coul"
@@ -113,7 +118,7 @@ class FoyerElectrostaticsHandler(PotentialHandler):
         atom_slots: Dict[TopologyKey, PotentialKey],
         force_field: "Forcefield",
     ):
-        """Look up fixed charges (a.k.a. library charges) from the force field and store them in self.charges"""
+        """Look up fixed charges (a.k.a. library charges) from the force field and store them in self.charges."""
         for top_key, pot_key in atom_slots.items():
             foyer_params = force_field.get_parameters("atoms", pot_key.id)
             charge = foyer_params["charge"]
@@ -122,14 +127,17 @@ class FoyerElectrostaticsHandler(PotentialHandler):
 
 
 class FoyerConnectedAtomsHandler(PotentialHandler):
+    """Base class for handlers storing valence potentials produced by a Foyer force field."""
+
     connection_attribute: str = ""
     raise_on_missing_params = True
 
     def store_matches(
         self,
         atom_slots: Dict[TopologyKey, PotentialKey],
-        topology: "OFFBioTop",
+        topology: "_OFFBioTop",
     ) -> None:
+        """Populate self.slot_map with key-val pairs of [TopologyKey, PotentialKey]."""
         for connection in getattr(topology, self.connection_attribute):
             try:
                 atoms_iterable = connection.atoms
@@ -147,6 +155,7 @@ class FoyerConnectedAtomsHandler(PotentialHandler):
             )
 
     def store_potentials(self, force_field: "Forcefield") -> None:
+        """Populate self.potentials with key-val pairs of [PotentialKey, Potential]."""
         from foyer.exceptions import MissingForceError, MissingParametersError
 
         for _, pot_key in self.slot_map.items():
@@ -169,10 +178,13 @@ class FoyerConnectedAtomsHandler(PotentialHandler):
 
     @abstractmethod
     def get_params_with_units(self, params):
+        """Get the parameters of this handler, tagged with units."""
         raise NotImplementedError
 
 
 class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler):
+    """Handler storing bond potentials as produced by a Foyer force field."""
+
     type: str = "harmonic_bonds"
     expression: str = "1/2 * k * (r - length) ** 2"
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
@@ -180,6 +192,7 @@ class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler):
     connection_attribute = "topology_bonds"
 
     def get_params_with_units(self, params):
+        """Get the parameters of this handler, tagged with units."""
         return _copy_params(
             params,
             param_units={"k": unit.kJ / unit.mol / unit.nm ** 2, "length": unit.nm},
@@ -187,6 +200,8 @@ class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler):
+    """Handler storing angle potentials as produced by a Foyer force field."""
+
     type: str = "harmonic_angles"
     expression: str = "0.5 * k * (theta-angle)**2"
     slot_map: Dict[TopologyKey, PotentialKey] = dict()
@@ -194,6 +209,7 @@ class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler):
     connection_attribute: str = "angles"
 
     def get_params_with_units(self, params):
+        """Get the parameters of this handler, tagged with units."""
         return _copy_params(
             {"k": params["k"], "angle": params["theta"]},
             param_units={
@@ -204,6 +220,8 @@ class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerRBProperHandler(FoyerConnectedAtomsHandler):
+    """Handler storing Ryckaert-Bellemans proper torsion potentials as produced by a Foyer force field."""
+
     type: str = "rb_propers"
     expression: str = (
         "C0 * cos(phi)**0 + C1 * cos(phi)**1 + "
@@ -216,23 +234,29 @@ class FoyerRBProperHandler(FoyerConnectedAtomsHandler):
     raise_on_missing_params: bool = False
 
     def get_params_with_units(self, params):
+        """Get the parameters of this handler, tagged with units."""
         rb_params = {k.upper(): v for k, v in params.items()}
         param_units = {k: unit.kJ / unit.mol for k in rb_params}
         return _copy_params(rb_params, param_units=param_units)
 
 
 class FoyerRBImproperHandler(FoyerRBProperHandler):
+    """Handler storing Ryckaert-Bellemans improper torsion potentials as produced by a Foyer force field."""
+
     type: str = "rb_impropers"
     connection_attribute: str = "impropers"
 
 
 class FoyerPeriodicProperHandler(FoyerConnectedAtomsHandler):
+    """Handler storing periodic proper torsion potentials as produced by a Foyer force field."""
+
     type: str = "periodic_propers"
     expression: str = "k * (1 + cos(periodicity * phi - phase))"
     connection_attribute: str = "propers"
     raise_on_missing_params: bool = False
 
     def get_params_with_units(self, params):
+        """Get the parameters of this handler, tagged with units."""
         return _copy_params(
             params,
             param_units={
@@ -244,11 +268,14 @@ class FoyerPeriodicProperHandler(FoyerConnectedAtomsHandler):
 
 
 class FoyerPeriodicImproperHandler(FoyerPeriodicProperHandler):
+    """Handler storing periodic improper torsion potentials as produced by a Foyer force field."""
+
     type: str = "periodic_impropers"
     connection_attribute: str = "impropers"
 
 
-class RBTorsionHandler(PotentialHandler):
+class _RBTorsionHandler(PotentialHandler):
+    # TODO: Is this class superceded by FoyerRBProperHandler? Should it be removed?
     type = "Ryckaert-Bellemans"
     expression = (
         "C0 + C1 * (cos(phi - 180)) "

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -1,3 +1,4 @@
+"""An object for storing, manipulating, and converting molecular mechanics data."""
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -10,7 +11,7 @@ from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.utilities.utilities import requires_package
 from pydantic import Field, validator
 
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.components.potentials import PotentialHandler
 from openff.interchange.components.smirnoff import (
     SMIRNOFF_POTENTIAL_HANDLERS,
@@ -50,8 +51,11 @@ class Interchange(DefaultModel):
     """
 
     class InnerSystem(DefaultModel):
+        """Inner representation of Interchange components."""
+
+        # TODO: Ensure these fields are hidden from the user as intended
         handlers: Dict[str, PotentialHandler] = dict()
-        topology: Optional[OFFBioTop] = Field(None)
+        topology: Optional[_OFFBioTop] = Field(None)
         box: ArrayQuantity["nanometer"] = Field(None)  # type: ignore
         positions: ArrayQuantity["nanometer"] = Field(None)  # type: ignore
 
@@ -72,16 +76,20 @@ class Interchange(DefaultModel):
 
     @property
     def handlers(self):
+        """Get the PotentialHandler objects in this Interchange object."""
         return self._inner_data.handlers
 
     def add_handler(self, handler_name: str, handler):
+        """Add a ParameterHandler to this Interchange object."""
         self._inner_data.handlers.update({handler_name: handler})
 
     def remove_handler(self, handler_name: str):
+        """Remove a PotentialHandler in this Interchange object."""
         self._inner_data.handlers.pop(handler_name)
 
     @property
     def topology(self):
+        """Get the OpenFF Topology object in this Interchange object."""
         return self._inner_data.topology
 
     @topology.setter
@@ -90,6 +98,7 @@ class Interchange(DefaultModel):
 
     @property
     def positions(self):
+        """Get the positions of all particles."""
         return self._inner_data.positions
 
     @positions.setter
@@ -98,6 +107,7 @@ class Interchange(DefaultModel):
 
     @property
     def box(self):
+        """If periodic, an array representing the periodic boundary conditions."""
         return self._inner_data.box
 
     @box.setter
@@ -122,11 +132,11 @@ class Interchange(DefaultModel):
     def from_smirnoff(
         cls,
         force_field: ForceField,
-        topology: OFFBioTop,
+        topology: _OFFBioTop,
         box=None,
     ) -> "Interchange":
-        """Creates a new object by parameterizing a topology using the specified
-        SMIRNOFF force field.
+        """
+        Create a new object by parameterizing a topology with a SMIRNOFF force field.
 
         Parameters
         ----------
@@ -139,20 +149,19 @@ class Interchange(DefaultModel):
 
         Examples
         --------
-
         Generate an Interchange object from a single-molecule (OpenFF) topology and
         OpenFF 1.0.0 "Parsley"
 
         .. code-block:: pycon
 
             >>> from openff.interchange.components.interchange import Interchange
-            >>> from openff.interchange.components.mdtraj import OFFBioTop
+            >>> from openff.interchange.components.mdtraj import _OFFBioTop
             >>> from openff.toolkit.topology import Molecule
             >>> from openff.toolkit.typing.engines.smirnoff import ForceField
             >>> import mdtraj as md
             >>> mol = Molecule.from_smiles("CC")
             >>> mol.generate_conformers(n_conformers=1)
-            >>> top = OFFBioTop.from_molecules([mol])
+            >>> top = _OFFBioTop.from_molecules([mol])
             >>> top.mdtop = md.Topology.from_openmm(top.to_openmm())
             >>> parsley = ForceField("openff-1.0.0.offxml")
             >>> interchange = Interchange.from_smirnoff(topology=top, force_field=parsley)
@@ -164,17 +173,17 @@ class Interchange(DefaultModel):
 
         cls._check_supported_handlers(force_field)
 
-        if isinstance(topology, OFFBioTop):
+        if isinstance(topology, _OFFBioTop):
             # TODO: See if Topology(topology) is fixed
             # https://github.com/openforcefield/openff-toolkit/issues/946
             sys_out.topology = deepcopy(topology)
             sys_out.topology.mdtop = topology.mdtop
         elif isinstance(topology, Topology):
-            sys_out.topology = OFFBioTop(other=topology)
+            sys_out.topology = _OFFBioTop(other=topology)
             sys_out.topology.mdtop = md.Topology.from_openmm(topology.to_openmm())
         else:
             raise InvalidTopologyError(
-                "Could not process topology argument, expected Topology or OFFBioTop. "
+                "Could not process topology argument, expected Topology or _OFFBioTop. "
                 f"Found object of type {type(topology)}."
             )
 
@@ -256,8 +265,7 @@ class Interchange(DefaultModel):
         return sys_out
 
     def to_gro(self, file_path: Union[Path, str], writer="internal", decimal: int = 8):
-        """Export this Interchange object to a .gro file"""
-
+        """Export this Interchange object to a .gro file."""
         if self.positions is None:
             raise MissingPositionsError(
                 "Positions are required to write a `.gro` file but found None."
@@ -280,7 +288,7 @@ class Interchange(DefaultModel):
             to_gro(self, file_path, decimal=decimal)
 
     def to_top(self, file_path: Union[Path, str], writer="internal"):
-        """Export this interchange to a .top file using"""
+        """Export this interchange to a .top file."""
         if writer == "parmed":
             from openff.interchange.interop.external import ParmEdWrapper
 
@@ -292,6 +300,7 @@ class Interchange(DefaultModel):
             to_top(self, file_path)
 
     def to_lammps(self, file_path: Union[Path, str], writer="internal"):
+        """Write this Interchange to a LAMMPS data file."""
         if writer != "internal":
             raise UnsupportedExportError
 
@@ -300,13 +309,13 @@ class Interchange(DefaultModel):
         to_lammps(self, file_path)
 
     def to_openmm(self, combine_nonbonded_forces: bool = False):
-        """Export this interchange to an OpenMM System"""
+        """Export this interchange to an OpenMM System."""
         from openff.interchange.interop.openmm import to_openmm as to_openmm_
 
         return to_openmm_(self, combine_nonbonded_forces=combine_nonbonded_forces)
 
     def _to_prmtop(self, file_path: Union[Path, str], writer="parmed"):
-        """Export this interchange to an Amber .prmtop file"""
+        """Export this interchange to an Amber .prmtop file."""
         if writer == "parmed":
             from openff.interchange.interop.external import ParmEdWrapper
 
@@ -316,7 +325,7 @@ class Interchange(DefaultModel):
             raise UnsupportedExportError
 
     def _to_crd(self, file_path: Union[Path, str], writer="parmed"):
-        """Export this interchange to an Amber .crd file"""
+        """Export this interchange to an Amber .crd file."""
         if writer == "parmed":
             from openff.interchange.interop.external import ParmEdWrapper
 
@@ -326,7 +335,7 @@ class Interchange(DefaultModel):
             raise UnsupportedExportError
 
     def _to_parmed(self):
-        """Export this interchange to a ParmEd Structure"""
+        """Export this interchange to a ParmEd Structure."""
         from openff.interchange.interop.parmed import _to_parmed
 
         return _to_parmed(self)
@@ -340,26 +349,26 @@ class Interchange(DefaultModel):
     @classmethod
     @requires_package("foyer")
     def from_foyer(
-        cls, topology: "OFFBioTop", force_field: "Forcefield", **kwargs
+        cls, topology: "_OFFBioTop", force_field: "Forcefield", **kwargs
     ) -> "Interchange":
-        """Create an Interchange object from a Foyer force field and an OpenFF topology.
+        """
+        Create an Interchange object from a Foyer force field and an OpenFF topology.
 
         Examples
         --------
-
         Generate an Interchange object from a single-molecule (OpenFF) topology and
         the Foyer implementation of OPLS-AA
 
         .. code-block:: pycon
 
             >>> from openff.interchange.components.interchange import Interchange
-            >>> from openff.interchange.components.mdtraj import OFFBioTop
+            >>> from openff.interchange.components.mdtraj import _OFFBioTop
             >>> from openff.toolkit.topology import Molecule
             >>> from foyer import Forcefield
             >>> import mdtraj as md
             >>> mol = Molecule.from_smiles("CC")
             >>> mol.generate_conformers(n_conformers=1)
-            >>> top = OFFBioTop.from_molecules([mol])
+            >>> top = _OFFBioTop.from_molecules([mol])
             >>> top.mdtop = md.Topology.from_openmm(top.to_openmm())
             >>> oplsaa = Forcefield(name="oplsaa")
             >>> interchange = Interchange.from_foyer(topology=top, force_field=oplsaa)
@@ -424,7 +433,7 @@ class Interchange(DefaultModel):
         return object.__getattribute__(self, name)
 
     def __getitem__(self, item: str):
-        """Syntax sugar for looking up potential handlers or other components"""
+        """Syntax sugar for looking up potential handlers or other components."""
         if type(item) != str:
             raise LookupError(
                 "Only str arguments can be currently be used for lookups.\n"

--- a/openff/interchange/components/mbuild.py
+++ b/openff/interchange/components/mbuild.py
@@ -1,3 +1,4 @@
+"""Utilities for processing and interfacing with mBuild models."""
 from typing import TYPE_CHECKING
 
 from openff.toolkit.topology import Molecule, Topology
@@ -10,11 +11,11 @@ if has_package("mbuild") or TYPE_CHECKING:
 
 @requires_package("mbuild")
 def offmol_to_compound(off_mol: "Molecule") -> "mb.Compound":
-    """Covert an OpenFF Molecule into an mBuild Compound.
+    """
+    Covert an OpenFF Molecule into an mBuild Compound.
 
     Examples
     --------
-
     .. code-block:: pycon
 
         >>> from openff.toolkit.topology import Molecule
@@ -48,11 +49,11 @@ def offmol_to_compound(off_mol: "Molecule") -> "mb.Compound":
 
 @requires_package("mbuild")
 def offtop_to_compound(off_top: "Topology") -> "mb.Compound":
-    """Covert an OpenFF Topology into an mBuild Compound.
+    """
+    Covert an OpenFF Topology into an mBuild Compound.
 
     Examples
     --------
-
     .. code-block:: pycon
 
         >>> from openff.toolkit.topology import Molecule, Topology

--- a/openff/interchange/components/mdtraj.py
+++ b/openff/interchange/components/mdtraj.py
@@ -1,10 +1,13 @@
+"""Temporary utilities to use an MDTraj Trajectory with an OpenFF Trajectory."""
 import copy
 
 import mdtraj as md
 from openff.toolkit.topology import Topology
 
 
-class OFFBioTop(Topology):
+class _OFFBioTop(Topology):
+    """A subclass of an OpenFF Topology that carries around an MDTraj topology."""
+
     def __init__(self, mdtop=None, *args, **kwargs):
         self.mdtop = mdtop
         super().__init__(*args, **kwargs)
@@ -104,7 +107,7 @@ def _iterate_pairs(mdtop):
 
 
 def _get_num_h_bonds(mdtop):
-    """Get the number of (covalent) bonds containing a hydrogen atom"""
+    """Get the number of (covalent) bonds containing a hydrogen atom."""
     n_bonds_containing_hydrogen = 0
 
     for bond in mdtop.bonds:

--- a/openff/interchange/components/nonbonded.py
+++ b/openff/interchange/components/nonbonded.py
@@ -1,3 +1,4 @@
+"""Models for non-standard non-bonded treatments."""
 from typing import Dict
 
 from typing_extensions import Literal
@@ -7,6 +8,8 @@ from openff.interchange.models import PotentialKey, TopologyKey
 
 
 class BuckinghamvdWHandler(PotentialHandler):
+    """Handler storing Buckingham-style vdW potentials."""
+
     type: Literal["Buckingham-6"] = "Buckingham-6"
     expression: Literal["a*exp(-b*r)-c*r**-6"] = "a*exp(-b*r)-c*r**-6"
     mixing_rule: Literal["buckingham"] = "buckingham"

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -1,3 +1,4 @@
+"""Models for storing applied force field parameters."""
 import ast
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
@@ -9,11 +10,11 @@ from openff.interchange.models import DefaultModel, PotentialKey, TopologyKey
 from openff.interchange.types import ArrayQuantity, FloatQuantity
 
 if TYPE_CHECKING:
-    from openff.interchange.components.mdtraj import OFFBioTop
+    from openff.interchange.components.mdtraj import _OFFBioTop
 
 
 class Potential(DefaultModel):
-    """Base class for storing applied parameters"""
+    """Base class for storing applied parameters."""
 
     parameters: Dict[str, FloatQuantity] = dict()
     map_key: Optional[int] = None
@@ -32,9 +33,11 @@ class Potential(DefaultModel):
 
 
 class WrappedPotential(DefaultModel):
-    """Model storing other Potential model(s) inside inner data"""
+    """Model storing other Potential model(s) inside inner data."""
 
     class InnerData(DefaultModel):
+        """The potentials being wrapped."""
+
         data: Dict[Potential, float]
 
     _inner_data: InnerData = PrivateAttr()
@@ -47,6 +50,7 @@ class WrappedPotential(DefaultModel):
 
     @property
     def parameters(self):
+        """Get the parameters as represented by the stored potentials and coefficients."""
         keys = {
             pot for pot in self._inner_data.data.keys() for pot in pot.parameters.keys()
         }
@@ -64,7 +68,7 @@ class WrappedPotential(DefaultModel):
 
 
 class PotentialHandler(DefaultModel):
-    """Base class for storing parametrized force field data"""
+    """Base class for storing parametrized force field data."""
 
     type: str = Field(..., description="The type of potentials this handler stores.")
     expression: str = Field(
@@ -82,8 +86,9 @@ class PotentialHandler(DefaultModel):
 
     @property
     def independent_variables(self) -> Set[str]:
-        """Return a set of independent variables, as str, defined as variables in the
-        expression that are not found in any potentials."""
+        """
+        Return a set of variables found in the expression but not in any potentials.
+        """
         vars_in_potentials = set([*self.potentials.values()][0].parameters.keys())
         vars_in_expression = {
             node.id
@@ -95,16 +100,18 @@ class PotentialHandler(DefaultModel):
     def store_matches(
         self,
         parameter_handler: ParameterHandler,
-        topology: "OFFBioTop",
+        topology: "_OFFBioTop",
     ) -> None:
+        """Populate self.slot_map with key-val pairs of [TopologyKey, PotentialKey]."""
         raise NotImplementedError
 
     def store_potentials(self, parameter_handler: ParameterHandler) -> None:
+        """Populate self.potentials with key-val pairs of [PotentialKey, Potential]."""
         raise NotImplementedError
 
     @requires_package("jax")
     def get_force_field_parameters(self):
-        """Return a flattened representation of the force field parameters"""
+        """Return a flattened representation of the force field parameters."""
         import jax
 
         params: list = list()
@@ -122,8 +129,11 @@ class PotentialHandler(DefaultModel):
 
     @requires_package("jax")
     def get_system_parameters(self, p=None):
-        """Return a flattened representation of system parameters, effectively
-        force field parameters as applied to a chemical topology"""
+        """
+        Return a flattened representation of system parameters.
+
+        These values are effectively force field parameters as applied to a chemical topology.
+        """
         import jax
 
         if p is None:
@@ -143,6 +153,7 @@ class PotentialHandler(DefaultModel):
         return jax.numpy.array(q)
 
     def get_mapping(self) -> Dict:
+        """Get a mapping between potentials and array indices."""
         mapping: Dict = dict()
         idx = 0
         for key, pot in self.potentials.items():
@@ -161,12 +172,14 @@ class PotentialHandler(DefaultModel):
         return mapping
 
     def parametrize(self, p=None):
+        """Return an array of system parameters, given an array of force field parameters."""
         if p is None:
             p = self.get_force_field_parameters()
 
         return self.get_system_parameters(p=p)
 
     def parametrize_partial(self):
+        """Return parametrize() modified with functools.partial gluing on `mapping`."""
         from functools import partial
 
         return partial(
@@ -175,6 +188,7 @@ class PotentialHandler(DefaultModel):
         )
 
     def get_param_matrix(self):
+        """Get a matrix representing the mapping between force field and system parameters."""
         from functools import partial
 
         import jax

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -1,3 +1,4 @@
+"""Models and utilities for processing SMIRNOFF data."""
 import abc
 import copy
 import functools
@@ -46,7 +47,7 @@ kcal_mol_radians = kcal_mol / omm_unit.radian ** 2
 if TYPE_CHECKING:
     from openff.toolkit.topology import Topology
 
-    from openff.interchange.components.mdtraj import OFFBioTop
+    from openff.interchange.components.mdtraj import _OFFBioTop
 
     ElectrostaticsHandlerType = Union[
         ElectrostaticsHandler,
@@ -61,20 +62,23 @@ T_ = TypeVar("T_", bound="PotentialHandler")
 
 
 class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
+    """Base class for handlers storing potentials produced by SMIRNOFF force fields."""
+
     @classmethod
     @abc.abstractmethod
     def allowed_parameter_handlers(cls):
-        """Return a list of allowed types of ParameterHandler classes (toolkit)"""
+        """Return a list of allowed types of ParameterHandler classes."""
         raise NotImplementedError()
 
     @classmethod
     @abc.abstractmethod
     def supported_parameters(cls):
-        """Return a list of parameter attributes supported by this handler"""
+        """Return a list of parameter attributes supported by this handler."""
         raise NotImplementedError()
 
     @classmethod
     def check_supported_parameters(cls, parameter_handler: ParameterHandler):
+        """Verify that a parameter handler is in an allowed list of handlers."""
         for parameter in parameter_handler.parameters:
             for parameter_attribute in parameter._get_defined_parameter_attributes():
                 if parameter_attribute not in cls.supported_parameters():
@@ -85,13 +89,9 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
     def store_matches(
         self,
         parameter_handler: ParameterHandler,
-        topology: Union["Topology", "OFFBioTop"],
+        topology: Union["Topology", "_OFFBioTop"],
     ) -> None:
-        """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
-
-        """
+        """Populate self.slot_map with key-val pairs of [TopologyKey, PotentialKey]."""
         parameter_handler_name = getattr(parameter_handler, "_TAGNAME", None)
         if self.slot_map:
             # TODO: Should the slot_map always be reset, or should we be able to partially
@@ -143,6 +143,7 @@ class SMIRNOFFPotentialHandler(PotentialHandler, abc.ABC):
 
 
 class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
+    """Handler storing bond potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["Bonds"] = "Bonds"
     expression: Literal["k/2*(r-length)**2"] = "k/2*(r-length)**2"
@@ -151,25 +152,26 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [BondHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "k", "length", "k_bondorder", "length_bondorder"]
 
     @classmethod
     def valence_terms(cls, topology):
+        """Return all bonds in this topology."""
         return [list(b.atoms) for b in topology.topology_bonds]
 
     def store_matches(
         self,
         parameter_handler: ParameterHandler,
-        topology: Union["Topology", "OFFBioTop"],
+        topology: Union["Topology", "_OFFBioTop"],
     ) -> None:
         """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
-
+        Populate self.slot_map with key-val pairs of slots and unique potential identifiers.
         """
         parameter_handler_name = getattr(parameter_handler, "_TAGNAME", None)
         if self.slot_map:
@@ -208,8 +210,7 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
 
     def store_potentials(self, parameter_handler: "BondHandler") -> None:
         """
-        Populate self.potentials with key-val pairs of unique potential
-        identifiers and their associated Potential objects
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
         if self.potentials:
@@ -296,6 +297,7 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
 
 
 class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
+    """Handler storing constraint potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["Constraints"] = "Constraints"
     expression: Literal[""] = ""
@@ -306,10 +308,12 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [BondHandler, ConstraintHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "k", "length", "distance"]
 
     @classmethod
@@ -341,9 +345,9 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
     def store_constraints(
         self,
         parameter_handlers: Any,
-        topology: "OFFBioTop",
+        topology: "_OFFBioTop",
     ) -> None:
-
+        """Store constraints."""
         if self.slot_map:
             self.slot_map = dict()
 
@@ -393,26 +397,29 @@ class SMIRNOFFConstraintHandler(SMIRNOFFPotentialHandler):
 
 
 class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
+    """Handler storing angle potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["Angles"] = "Angles"
     expression: Literal["k/2*(theta-angle)**2"] = "k/2*(theta-angle)**2"
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [AngleHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "k", "angle"]
 
     @classmethod
     def valence_terms(cls, topology):
+        """Return all angles in this topology."""
         return list(topology.angles)
 
     def store_potentials(self, parameter_handler: "AngleHandler") -> None:
         """
-        Populate self.potentials with key-val pairs of unique potential
-        identifiers and their associated Potential objects
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
         for potential_key in self.slot_map.values():
@@ -446,6 +453,7 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
 
 
 class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
+    """Handler storing proper torsions potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["ProperTorsions"] = "ProperTorsions"
     expression: Literal[
@@ -456,20 +464,21 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [ProperTorsionHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "k", "periodicity", "phase", "idivf", "k_bondorder"]
 
     def store_matches(
         self,
         parameter_handler: "ProperTorsionHandler",
-        topology: "OFFBioTop",
+        topology: "_OFFBioTop",
     ) -> None:
         """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
+        Populate self.slot_map with key-val pairs of slots and unique potential identifiers.
 
         """
         if self.slot_map:
@@ -509,8 +518,7 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
 
     def store_potentials(self, parameter_handler: "ProperTorsionHandler") -> None:
         """
-        Populate self.potentials with key-val pairs of unique potential
-        identifiers and their associated Potential objects
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
         for topology_key, potential_key in self.slot_map.items():
@@ -555,6 +563,7 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
 
 
 class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
+    """Handler storing improper torsions potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["ImproperTorsions"] = "ImproperTorsions"
     expression: Literal[
@@ -563,18 +572,19 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [ImproperTorsionHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "k", "periodicity", "phase", "idivf"]
 
     def store_matches(
-        self, parameter_handler: "ImproperTorsionHandler", topology: "OFFBioTop"
+        self, parameter_handler: "ImproperTorsionHandler", topology: "_OFFBioTop"
     ) -> None:
         """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
+        Populate self.slot_map with key-val pairs of slots and unique potential identifiers.
 
         """
         if self.slot_map:
@@ -614,8 +624,7 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
 
     def store_potentials(self, parameter_handler: "ImproperTorsionHandler") -> None:
         """
-        Populate self.potentials with key-val pairs of unique potential
-        identifiers and their associated Potential objects
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
         for potential_key in self.slot_map.values():
@@ -633,7 +642,7 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
 
 
 class _SMIRNOFFNonbondedHandler(SMIRNOFFPotentialHandler, abc.ABC):
-    """The base class for handlers which store nonbonded potentials."""
+    """Base class for handlers storing non-bonded potentials produced by SMIRNOFF force fields."""
 
     type: Literal["nonbonded"] = "nonbonded"
 
@@ -654,6 +663,7 @@ class _SMIRNOFFNonbondedHandler(SMIRNOFFPotentialHandler, abc.ABC):
 
 
 class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
+    """Handler storing vdW potentials as produced by a SMIRNOFF force field."""
 
     type: Literal["vdW"] = "vdW"
 
@@ -675,16 +685,17 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [vdWHandler]
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         return ["smirks", "id", "sigma", "epsilon", "rmin_half"]
 
     def store_potentials(self, parameter_handler: vdWHandler) -> None:
         """
-        Populate self.potentials with key-val pairs of unique potential
-        identifiers and their associated Potential objects
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
         self.method = parameter_handler.method.lower()
@@ -720,7 +731,6 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
         Create a SMIRNOFFvdWHandler from toolkit data.
 
         """
-
         if type(parameter_handler) not in cls.allowed_parameter_handlers():
             raise InvalidParameterHandlerError
 
@@ -740,7 +750,8 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
 
 
 class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
-    """A handler which stores any electrostatic parameters applied to a topology.
+    """
+    A handler which stores any electrostatic parameters applied to a topology.
 
     This handler is responsible for grouping together
 
@@ -761,6 +772,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
 
     @classmethod
     def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
         return [
             LibraryChargeHandler,
             ChargeIncrementModelHandler,
@@ -770,12 +782,14 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
 
     @classmethod
     def supported_parameters(cls):
+        """Return a list of supported parameter attributes."""
         pass
 
     @property
     def charges(self) -> Dict[TopologyKey, unit.Quantity]:
-        """Returns the total partial charge on each particle in the associated interchange."""
-
+        """
+        Return the total partial charge on each particle in the associated interchange.
+        """
         charges = defaultdict(lambda: 0.0 * unit.e)
 
         for topology_key, potential_key in self.slot_map.items():
@@ -797,8 +811,8 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
 
     @classmethod
     def charge_precedence(cls) -> List[str]:
-        """The order in which parameter handlers take precedence when computing the
-        charges
+        """
+        Return the order in which parameter handlers take precedence when computing the charges.
         """
         return ["LibraryCharges", "ChargeIncrementModel", "ToolkitAM1BCC"]
 
@@ -837,7 +851,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
     @classmethod
     @functools.lru_cache(None)
     def _compute_partial_charges(cls, molecule: Molecule, method: str) -> unit.Quantity:
-        """Call out to the toolkit's toolkit wrappers to generate partial charges"""
+        """Call out to the toolkit's toolkit wrappers to generate partial charges."""
         molecule = copy.deepcopy(molecule)
         molecule.assign_partial_charges(method)
 
@@ -849,8 +863,9 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         atom_indices: Tuple[int, ...],
         parameter: LibraryChargeHandler.LibraryChargeType,
     ) -> Tuple[Dict[TopologyKey, PotentialKey], Dict[PotentialKey, Potential]]:
-        """Maps a matched library charge parameter to a set of potentials."""
-
+        """
+        Map a matched library charge parameter to a set of potentials.
+        """
         matches = {}
         potentials = {}
 
@@ -872,8 +887,9 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         atom_indices: Tuple[int, ...],
         parameter: ChargeIncrementModelHandler.ChargeIncrementType,
     ) -> Tuple[Dict[TopologyKey, PotentialKey], Dict[PotentialKey, Potential]]:
-        """Maps a matched charge increment parameter to a set of potentials."""
-
+        """
+        Map a matched charge increment parameter to a set of potentials.
+        """
         matches = {}
         potentials = {}
 
@@ -902,8 +918,9 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         parameter_handler: Union["LibraryChargeHandler", "ChargeIncrementModelHandler"],
         reference_molecule: Molecule,
     ) -> Tuple[Dict[TopologyKey, PotentialKey], Dict[PotentialKey, Potential]]:
-        """Constructs a slot and potential map for a slot based parameter handler."""
-
+        """
+        Construct a slot and potential map for a slot based parameter handler.
+        """
         # Ideally this would be made redundant by OpenFF TK #971
         unique_parameter_matches = {
             tuple(sorted(key)): (key, val)
@@ -948,8 +965,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         parameter_handler: Union["ToolkitAM1BCCHandler", ChargeIncrementModelHandler],
         reference_molecule: Molecule,
     ) -> Tuple[Dict[TopologyKey, PotentialKey], Dict[PotentialKey, Potential]]:
-        """Constructs a slot and potential map for a charge model based parameter handler."""
-
+        """Construct a slot and potential map for a charge model based parameter handler."""
         reference_molecule = copy.deepcopy(reference_molecule)
         reference_smiles = reference_molecule.to_smiles(
             isomeric=True, explicit_hydrogens=True, mapped=True
@@ -981,9 +997,9 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         parameter_handlers: Dict[str, "ElectrostaticsHandlerType"],
         reference_molecule: Molecule,
     ) -> Tuple[Dict[TopologyKey, PotentialKey], Dict[PotentialKey, Potential]]:
-        """Constructs a slot and potential map for a particular reference molecule
-        and set of parameter handlers."""
-
+        """
+        Construct a slot and potential map for a particular reference molecule and set of parameter handlers.
+        """
         matches = {}
         potentials = {}
 
@@ -1074,13 +1090,11 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
         parameter_handler: Union[
             "ElectrostaticsHandlerType", List["ElectrostaticsHandlerType"]
         ],
-        topology: Union["Topology", "OFFBioTop"],
+        topology: Union["Topology", "_OFFBioTop"],
     ) -> None:
         """
-        Populate self.slot_map with key-val pairs of slots
-        and unique potential identifiers
+        Populate self.slot_map with key-val pairs of slots and unique potential identifiers.
         """
-
         # Reshape the parameter handlers into a dictionary for easier referencing.
         parameter_handlers = {
             handler._TAGNAME: handler
@@ -1132,6 +1146,10 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
             "ElectrostaticsHandlerType", List["ElectrostaticsHandlerType"]
         ],
     ) -> None:
+        """
+        Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
+
+        """
         # This logic is handled by ``store_matches`` as we may need to create potentials
         # to store depending on the handler type.
         pass
@@ -1140,7 +1158,7 @@ class SMIRNOFFElectrostaticsHandler(_SMIRNOFFNonbondedHandler):
 def library_charge_from_molecule(
     molecule: "Molecule",
 ) -> LibraryChargeHandler.LibraryChargeType:
-    """Given an OpenFF Molecule with charges, generate a corresponding LibraryChargeType"""
+    """Given an OpenFF Molecule with charges, generate a corresponding LibraryChargeType."""
     if molecule.partial_charges is None:
         raise ValueError("Input molecule is missing partial charges.")
 

--- a/openff/interchange/drivers/__init__.py
+++ b/openff/interchange/drivers/__init__.py
@@ -1,3 +1,4 @@
+"""Functions for running energy evluations with molecular simulation engines."""
 from openff.interchange.drivers.amber import get_amber_energies
 from openff.interchange.drivers.gromacs import get_gromacs_energies
 from openff.interchange.drivers.lammps import get_lammps_energies

--- a/openff/interchange/drivers/amber.py
+++ b/openff/interchange/drivers/amber.py
@@ -1,3 +1,4 @@
+"""Functions for running energy evluations with Amber."""
 import subprocess
 import tempfile
 from pathlib import Path
@@ -73,7 +74,7 @@ def _run_sander(
         calculation.
 
     Returns
-    -------gg
+    -------
     report : EnergyReport
         An `EnergyReport` object containing the single-point energies.
 

--- a/openff/interchange/drivers/gromacs.py
+++ b/openff/interchange/drivers/gromacs.py
@@ -1,3 +1,4 @@
+"""Functions for running energy evluations with GROMACS."""
 import subprocess
 import tempfile
 from pathlib import Path

--- a/openff/interchange/drivers/lammps.py
+++ b/openff/interchange/drivers/lammps.py
@@ -1,3 +1,4 @@
+"""Functions for running energy evluations with LAMMPS."""
 import subprocess
 from typing import List
 
@@ -39,7 +40,6 @@ def get_lammps_energies(
         An `EnergyReport` object containing the single-point energies.
 
     """
-
     if round_positions is not None:
         off_sys.positions = np.round(off_sys.positions, round_positions)
 

--- a/openff/interchange/drivers/openmm.py
+++ b/openff/interchange/drivers/openmm.py
@@ -1,3 +1,4 @@
+"""Functions for running energy evluations with OpenMM."""
 from typing import Dict
 
 import numpy as np
@@ -38,6 +39,9 @@ def get_openmm_energies(
     electrostatics : bool, default=True
         A boolean indicating whether or not electrostatics should be included in the energy
         calculation.
+    combine_nonbonded_forces : bool, default=False
+        Whether or not to combine all non-bonded interactions (vdW, short- and long-range
+        ectrostaelectrostatics, and 1-4 interactions) into a single openmm.NonbondedForce.
 
     Returns
     -------
@@ -45,7 +49,6 @@ def get_openmm_energies(
         An `EnergyReport` object containing the single-point energies.
 
     """
-
     omm_sys: openmm.System = off_sys.to_openmm(
         combine_nonbonded_forces=combine_nonbonded_forces
     )

--- a/openff/interchange/drivers/report.py
+++ b/openff/interchange/drivers/report.py
@@ -1,25 +1,15 @@
+"""Storing and processing results of energy evaluations."""
 from typing import Dict, Optional
 
 import pandas as pd
 from openff.units import unit
 from pydantic import validator
 
+from openff.interchange.exceptions import EnergyError, MissingEnergyError
 from openff.interchange.models import DefaultModel
 from openff.interchange.types import FloatQuantity
 
 kj_mol = unit.kilojoule / unit.mol
-
-
-class EnergyError(BaseException):
-    """
-    Base class for energies in reports not matching.
-    """
-
-
-class MissingEnergyError(BaseException):
-    """
-    Exception for when one report has a value for an energy group but the other does not.
-    """
 
 
 class EnergyReport(DefaultModel):
@@ -53,14 +43,16 @@ class EnergyReport(DefaultModel):
             return None
 
     def update_energies(self, new_energies):
+        """Update the energies in this report with new value(s)."""
         self.energies.update(self.validate_energies(new_energies))
 
     # TODO: Better way of exposing tolerances
     def compare(self, other: "EnergyReport", custom_tolerances=None):
         """
-        Compare this `EnergyReport` to another `EnergyReport`. Energies are grouped into
-        four categories (bond, angle, torsion, and nonbonded) with default tolerances for
-        each set to 1e-3 kJ/mol.
+        Compare this `EnergyReport` to another `EnergyReport`.
+
+        Energies are grouped into four categories (bond, angle, torsion, and nonbonded) with
+        default tolerances for each set to 1e-3 kJ/mol.
 
         .. warning :: This API is experimental and subject to change.
 

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -1,14 +1,18 @@
+"""Custom exceptions used in Interchange."""
+
+
 class SMIRNOFFParameterAttributeNotImplementedError(Exception):
     """
-    Exception for when a parameter attribute is supported by the SMIRNOFF specification
-    but not yet implemented, i.e. k_bondorder for bond order interpolation.
+    Exception for when a parameter attribute is supported by the SMIRNOFF specification but not yet implemented.
+
+    For example, this was raised when k_bondorder (used in bond order-based interpolation of force constants)
+    before the behavior was supported.
     """
 
 
 class SMIRNOFFHandlersNotImplementedError(Exception):
     """
-    Exception for when some parameter handlers in the SMIRNOFF specification
-    are not implemented here
+    Exception for when some parameter handlers in the SMIRNOFF specification are not implemented here.
     """
 
     def __init__(self, *args):
@@ -27,8 +31,7 @@ class SMIRNOFFHandlersNotImplementedError(Exception):
 
 class ToolkitTopologyConformersNotFoundError(Exception):
     """
-    Exception for when reference molecules in a toolkit topology is required to contain
-    conformers, but they are not found
+    Exception for when reference molecules in a toolkit topology lack conformers.
     """
 
     def __init__(self, *args):
@@ -43,61 +46,61 @@ class ToolkitTopologyConformersNotFoundError(Exception):
 
 class InvalidParameterHandlerError(ValueError):
     """
-    Generic exception for mismatch between expected and found ParameterHandler types
+    Generic exception for mismatch between expected and found ParameterHandler types.
     """
 
 
 class InvalidBoxError(ValueError):
     """
-    Generic exception for errors reading box data
+    Generic exception for errors reading box data.
     """
 
 
 class InvalidTopologyError(ValueError):
     """
-    Generic exception for errors reading chemical topology data
+    Generic exception for errors reading chemical topology data.
     """
 
 
 class NonbondedEnergyError(AssertionError):
     """
-    Exception for when non-bonded energies computed from different objects differ
+    Exception for when non-bonded energies computed from different objects differ.
     """
 
 
 class InvalidExpressionError(ValueError):
     """
-    Exception for when an expression cannot safely be interpreted
+    Exception for when an expression cannot safely be interpreted.
     """
 
 
 class UnsupportedCutoffMethodError(BaseException):
     """
-    Exception for a cutoff method that is invalid or not supported by an engine
+    Exception for a cutoff method that is invalid or not supported by an engine.
     """
 
 
 class UnimplementedCutoffMethodError(BaseException):
     """
-    Exception for a cutoff method that should be supported but it not yet implemented
+    Exception for a cutoff method that should be supported but it not yet implemented.
     """
 
 
 class UnsupportedParameterError(ValueError):
     """
-    Exception for parameters having unsupported values, i.e. non-1.0 idivf
+    Exception for parameters having unsupported values, i.e. non-1.0 idivf.
     """
 
 
 class UnsupportedBoxError(ValueError):
     """
-    Exception for processing an unsupported box, probably non-orthogonal
+    Exception for processing an unsupported box, probably non-orthogonal.
     """
 
 
 class UnsupportedExportError(BaseException):
     """
-    Exception for attempting to write to an unsupported file format
+    Exception for attempting to write to an unsupported file format.
     """
 
     def __init__(self, *args):
@@ -114,56 +117,57 @@ class UnsupportedExportError(BaseException):
 
 class MissingBoxError(BaseException):
     """
-    Exception for when box vectors are needed but missing
+    Exception for when box vectors are needed but missing.
     """
 
 
 class MissingPositionsError(BaseException):
     """
-    Exception for when positions are needed but missing
+    Exception for when positions are needed but missing.
     """
 
 
 class MissingParametersError(BaseException):
     """
-    Exception for when parameters are needed but missing
+    Exception for when parameters are needed but missing.
     """
 
 
 class MissingBondOrdersError(BaseException):
     """
-    Exception for when a parameter handler needs fractional bond orders but they are missing
+    Exception for when a parameter handler needs fractional bond orders but they are missing.
     """
 
 
 class MissingUnitError(ValueError):
     """
-    Exception for data missing a unit tag
+    Exception for data missing a unit tag.
     """
 
 
 class UnitValidationError(ValueError):
     """
-    Exception for bad behavior when validating unit-tagged data
+    Exception for bad behavior when validating unit-tagged data.
     """
 
 
 class NonbondedCompatibilityError(BaseException):
     """
-    Exception for unsupported combination of nonbonded methods
+    Exception for unsupported combination of nonbonded methods.
     """
 
 
 class MissingNonbondedCompatibilityError(BaseException):
     """
-    Exception for uncovered combination of nonbonded methods
+    Exception for uncovered combination of nonbonded methods.
     """
 
 
 class InternalInconsistencyError(BaseException):
     """
-    Fallback exception for bad behavior. These should not be reached but
-    are raised to safeguard against problematic edge cases silently passing.
+    Fallback exception for bad behavior releating to a self-inconsistent internal state.
+
+    These should not be reached but are raised to safeguard against problematic edge cases silently passing.
     """
 
 
@@ -194,4 +198,16 @@ class GMXMdrunError(GMXRunError):
 class LAMMPSRunError(BaseException):
     """
     Exception for when a LAMMPS subprocess fails.
+    """
+
+
+class EnergyError(BaseException):
+    """
+    Base class for energies in reports not matching.
+    """
+
+
+class MissingEnergyError(BaseException):
+    """
+    Exception for when one report has a value for an energy group but the other does not.
     """

--- a/openff/interchange/interop/__init__.py
+++ b/openff/interchange/interop/__init__.py
@@ -1,0 +1,1 @@
+"""The interoperability layer of the Interchange project."""

--- a/openff/interchange/interop/external.py
+++ b/openff/interchange/interop/external.py
@@ -1,3 +1,4 @@
+"""Interfaces to external libraries (without explicitly writing to files)."""
 from pathlib import Path
 from typing import Union
 
@@ -10,23 +11,23 @@ from openff.interchange.exceptions import (
 
 
 class InteroperabilityWrapper:
-    """Base class for writer wrappers"""
+    """Base class for writer wrappers."""
 
     @property
     def write_formats(self):
-        """Return a list of supported writing formats"""
+        """Return a list of supported writing formats."""
         return self._write_formats
 
 
 class ParmEdWrapper(InteroperabilityWrapper):
-    """Wrapper around ParmEd writers"""
+    """Wrapper around ParmEd writers."""
 
     def __init__(self):
         self._write_formats = [".gro", ".top", ".prmtop", ".crd"]
 
     def to_file(self, openff_sys: Interchange, file_path: Union[str, Path]):
         """
-        Convert an OpenFF Iterchange object to a ParmEd Structure and write it to a file
+        Convert an Iterchange object to a ParmEd Structure and write it to a file.
 
         """
         if isinstance(file_path, str):

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -1,3 +1,4 @@
+"""Interfaces with GROMACS."""
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Dict, Set, Tuple, Union
 
@@ -21,8 +22,9 @@ if TYPE_CHECKING:
 
 def to_gro(openff_sys: "Interchange", file_path: Union[Path, str], decimal=8):
     """
-    Write a .gro file. See
-    https://manual.gromacs.org/documentation/current/reference-manual/file-formats.html#gro
+    Write a GROMACS coordinate (.gro) file.
+
+    See https://manual.gromacs.org/documentation/current/reference-manual/file-formats.html#gro
     for more details, including the recommended C-style one-liners
 
     This code is partially copied from InterMol, see
@@ -87,8 +89,9 @@ def to_gro(openff_sys: "Interchange", file_path: Union[Path, str], decimal=8):
 
 def to_top(openff_sys: "Interchange", file_path: Union[Path, str]):
     """
-    Write a .gro file. See
-    https://manual.gromacs.org/documentation/current/reference-manual/file-formats.html#top
+    Write a GROMACS topology (.top) file.
+
+    See https://manual.gromacs.org/documentation/current/reference-manual/file-formats.html#top
     for more details.
 
     This code is partially copied from InterMol, see
@@ -116,7 +119,7 @@ def to_top(openff_sys: "Interchange", file_path: Union[Path, str]):
 
 
 def _write_top_defaults(openff_sys: "Interchange", top_file: IO):
-    """Write [ defaults ] section"""
+    """Write [ defaults ] section."""
     top_file.write("[ defaults ]\n")
     top_file.write("; nbfunc\tcomb-rule\tgen-pairs\tfudgeLJ\tfudgeQQ\n")
 
@@ -188,8 +191,7 @@ def _build_typemap(openff_sys: "Interchange") -> Dict:
 
 
 def _write_atomtypes(openff_sys: "Interchange", top_file: IO, typemap: Dict):
-    """Write [ atomtypes ] section"""
-
+    """Write [ atomtypes ] section."""
     if "vdW" in openff_sys.handlers:
         if "Buckingham-6" in openff_sys.handlers:
             raise UnsupportedExportError(
@@ -205,7 +207,7 @@ def _write_atomtypes(openff_sys: "Interchange", top_file: IO, typemap: Dict):
 
 
 def _write_atomtypes_lj(openff_sys: "Interchange", top_file: IO, typemap: Dict):
-
+    """Write the [ atomtypes ] section when all atoms use the LJ potential."""
     top_file.write("[ atomtypes ]\n")
     top_file.write(
         ";type, bondingtype, atomic_number, mass, charge, ptype, sigma, epsilon\n"
@@ -234,7 +236,7 @@ def _write_atomtypes_lj(openff_sys: "Interchange", top_file: IO, typemap: Dict):
 
 
 def _write_atomtypes_buck(openff_sys: "Interchange", top_file: IO, typemap: Dict):
-
+    """Write the [ atomtypes ] section when all atoms use the Buckingham-6 potential."""
     top_file.write("[ atomtypes ]\n")
     top_file.write(
         ";type, bondingtype, atomic_number, mass, charge, ptype, sigma, epsilon\n"
@@ -265,7 +267,7 @@ def _write_atomtypes_buck(openff_sys: "Interchange", top_file: IO, typemap: Dict
 
 
 def _write_moleculetype(top_file: IO):
-    """Write the [ moleculetype ] section"""
+    """Write the [ moleculetype ] section."""
     top_file.write("[ moleculetype ]\n")
     top_file.write("; Name\tnrexcl\n")
     top_file.write("MOL\t3\n\n")
@@ -276,7 +278,7 @@ def _write_atoms(
     openff_sys: "Interchange",
     typemap: Dict,
 ):
-    """Write the [ atoms ] and [ pairs ] sections for a molecule"""
+    """Write the [ atoms ] and [ pairs ] sections for a molecule."""
     top_file.write("[ atoms ]\n")
     top_file.write(";num, type, resnum, resname, atomname, cgnr, q, m\n")
 
@@ -347,7 +349,7 @@ def _write_valence(
     top_file: IO,
     openff_sys: "Interchange",
 ):
-    """Write the [ bonds ], [ angles ], and [ dihedrals ] sections"""
+    """Write the [ bonds ], [ angles ], and [ dihedrals ] sections."""
     _write_bonds(top_file, openff_sys)
     _write_angles(top_file, openff_sys)
     _write_dihedrals(top_file, openff_sys)
@@ -530,7 +532,7 @@ def _write_dihedrals(top_file: IO, openff_sys: "Interchange"):
 
 
 def _write_system(top_file: IO, openff_sys: "Interchange"):
-    """Write the [ system ] section"""
+    """Write the [ system ] section."""
     top_file.write("[ system ]\n")
     top_file.write("; name \n")
     top_file.write("System name\n\n")

--- a/openff/interchange/interop/internal/lammps.py
+++ b/openff/interchange/interop/internal/lammps.py
@@ -1,3 +1,4 @@
+"""Interfaces with LAMMPS."""
 from pathlib import Path
 from typing import IO, Dict, Union
 
@@ -10,8 +11,7 @@ from openff.interchange.models import TopologyKey
 
 
 def to_lammps(openff_sys: Interchange, file_path: Union[Path, str]):
-    """Write an Interchange object to a LAMMPS data file"""
-
+    """Write an Interchange object to a LAMMPS data file."""
     if isinstance(file_path, str):
         path = Path(file_path)
     if isinstance(file_path, Path):
@@ -128,7 +128,7 @@ def to_lammps(openff_sys: Interchange, file_path: Union[Path, str]):
 
 
 def _write_pair_coeffs(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
-    """Write the Pair Coeffs section of a LAMMPS data file"""
+    """Write the Pair Coeffs section of a LAMMPS data file."""
     lmp_file.write("Pair Coeffs\n\n")
 
     vdw_handler = openff_sys["vdW"]
@@ -145,7 +145,7 @@ def _write_pair_coeffs(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dic
 
 
 def _write_bond_coeffs(lmp_file: IO, openff_sys: Interchange):
-    """Write the Bond Coeffs section of a LAMMPS data file"""
+    """Write the Bond Coeffs section of a LAMMPS data file."""
     lmp_file.write("Bond Coeffs\n\n")
 
     bond_handler = openff_sys.handlers["Bonds"]
@@ -164,7 +164,7 @@ def _write_bond_coeffs(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_angle_coeffs(lmp_file: IO, openff_sys: Interchange):
-    """Write the Angle Coeffs section of a LAMMPS data file"""
+    """Write the Angle Coeffs section of a LAMMPS data file."""
     lmp_file.write("\nAngle Coeffs\n\n")
 
     angle_handler = openff_sys.handlers["Angles"]
@@ -183,7 +183,7 @@ def _write_angle_coeffs(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_proper_coeffs(lmp_file: IO, openff_sys: Interchange):
-    """Write the Dihedral Coeffs section of a LAMMPS data file"""
+    """Write the Dihedral Coeffs section of a LAMMPS data file."""
     lmp_file.write("\nDihedral Coeffs\n\n")
 
     proper_handler = openff_sys.handlers["ProperTorsions"]
@@ -206,7 +206,7 @@ def _write_proper_coeffs(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_improper_coeffs(lmp_file: IO, openff_sys: Interchange):
-    """Write the Improper Coeffs section of a LAMMPS data file"""
+    """Write the Improper Coeffs section of a LAMMPS data file."""
     lmp_file.write("\nImproper Coeffs\n\n")
 
     improper_handler = openff_sys.handlers["ImproperTorsions"]
@@ -256,7 +256,7 @@ def _write_improper_coeffs(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_atoms(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
-    """Write the Atoms section of a LAMMPS data file"""
+    """Write the Atoms section of a LAMMPS data file."""
     lmp_file.write("\nAtoms\n\n")
 
     atom_type_map_inv = dict({v: k for k, v in atom_type_map.items()})
@@ -290,7 +290,7 @@ def _write_atoms(lmp_file: IO, openff_sys: Interchange, atom_type_map: Dict):
 
 
 def _write_bonds(lmp_file: IO, openff_sys: Interchange):
-    """Write the Bonds section of a LAMMPS data file"""
+    """Write the Bonds section of a LAMMPS data file."""
     lmp_file.write("\nBonds\n\n")
 
     bond_handler = openff_sys["Bonds"]
@@ -324,7 +324,7 @@ def _write_bonds(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_angles(lmp_file: IO, openff_sys: Interchange):
-    """Write the Angles section of a LAMMPS data file"""
+    """Write the Angles section of a LAMMPS data file."""
     from openff.interchange.components.mdtraj import (
         _iterate_angles,
         _store_bond_partners,
@@ -358,7 +358,7 @@ def _write_angles(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_propers(lmp_file: IO, openff_sys: Interchange):
-    """Write the Dihedrals section of a LAMMPS data file"""
+    """Write the Dihedrals section of a LAMMPS data file."""
     from openff.interchange.components.mdtraj import (
         _iterate_propers,
         _store_bond_partners,
@@ -394,7 +394,7 @@ def _write_propers(lmp_file: IO, openff_sys: Interchange):
 
 
 def _write_impropers(lmp_file: IO, openff_sys: Interchange):
-    """Write the Impropers section of a LAMMPS data file"""
+    """Write the Impropers section of a LAMMPS data file."""
     from openff.interchange.components.mdtraj import (
         _iterate_impropers,
         _store_bond_partners,

--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -1,3 +1,4 @@
+"""Interfaces with ParmEd."""
 from openff.units import unit as off_unit
 from openff.units.simtk import from_simtk
 from simtk import openmm, unit
@@ -22,7 +23,8 @@ kj_rad = kj_mol / unit.radian ** 2
 
 
 def to_openmm(openff_sys, combine_nonbonded_forces: bool = False) -> openmm.System:
-    """Convert an OpenFF Interchange to a ParmEd Structure
+    """
+    Convert an Interchange to a ParmEd Structure.
 
     Parameters
     ----------
@@ -38,7 +40,6 @@ def to_openmm(openff_sys, combine_nonbonded_forces: bool = False) -> openmm.Syst
         The corresponding OpenMM System object
 
     """
-
     openmm_sys = openmm.System()
 
     # OpenFF box stored implicitly as nm, and that happens to be what
@@ -64,8 +65,9 @@ def to_openmm(openff_sys, combine_nonbonded_forces: bool = False) -> openmm.Syst
 
 
 def _process_constraints(openff_sys, openmm_sys):
-    """Process the Constraints section of an OpenFF Interchange object
-    into a corresponding constraints in the OpenMM System"""
+    """
+    Process the Constraints section of an Interchange object.
+    """
     try:
         constraint_handler = openff_sys.handlers["Constraints"]
     except KeyError:
@@ -81,7 +83,9 @@ def _process_constraints(openff_sys, openmm_sys):
 
 
 def _process_bond_forces(openff_sys, openmm_sys):
-    """Process the Bonds section of an OpenFF Interchange into a corresponding openmm.HarmonicBondForce"""
+    """
+    Process the Bonds section of an Interchange object.
+    """
     harmonic_bond_force = openmm.HarmonicBondForce()
     openmm_sys.addForce(harmonic_bond_force)
 
@@ -118,7 +122,9 @@ def _process_bond_forces(openff_sys, openmm_sys):
 
 
 def _process_angle_forces(openff_sys, openmm_sys):
-    """Process the Angles section of an OpenFF Interchange into a corresponding openmm.HarmonicAngleForce"""
+    """
+    Process the Angles section of an Interchange object.
+    """
     harmonic_angle_force = openmm.HarmonicAngleForce()
     openmm_sys.addForce(harmonic_angle_force)
 
@@ -150,8 +156,9 @@ def _process_torsion_forces(openff_sys, openmm_sys):
 
 
 def _process_proper_torsion_forces(openff_sys, openmm_sys):
-    """Process the Propers section of an OpenFF Interchange into corresponding
-    forces within an openmm.PeriodicTorsionForce"""
+    """
+    Process the Propers section of an Interchange object.
+    """
     torsion_force = openmm.PeriodicTorsionForce()
     openmm_sys.addForce(torsion_force)
 
@@ -177,7 +184,9 @@ def _process_proper_torsion_forces(openff_sys, openmm_sys):
 
 
 def _process_rb_torsion_forces(openff_sys, openmm_sys):
-    """Process Ryckaert-Bellemans torsions"""
+    """
+    Process Ryckaert-Bellemans torsions.
+    """
     rb_force = openmm.RBTorsionForce()
     openmm_sys.addForce(rb_force)
 
@@ -209,8 +218,9 @@ def _process_rb_torsion_forces(openff_sys, openmm_sys):
 
 
 def _process_improper_torsion_forces(openff_sys, openmm_sys):
-    """Process the Impropers section of an OpenFF Interchange into corresponding
-    forces within an openmm.PeriodicTorsionForce"""
+    """
+    Process the Impropers section of an Interchange object.
+    """
     if "ImproperTorsions" not in openff_sys.handlers.keys():
         return
 
@@ -244,8 +254,15 @@ def _process_improper_torsion_forces(openff_sys, openmm_sys):
 
 
 def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=False):
-    """Process the vdW and Electrostatics sections of an OpenFF Interchange into a corresponding openmm.NonbondedForce
-    or a collection of other forces (NonbondedForce, CustomNonbondedForce, CustomBondForce)"""
+    """
+    Process the non-bonded handlers in an Interchange into corresponding openmm objects.
+
+    This typically involves processing the vdW and Electrostatics sections of an Interchange object
+    into a corresponding openmm.NonbondedForce (if `combine_nonbonded_forces=True`) or a
+    collection of other forces (NonbondedForce, CustomNonbondedForce, CustomBondForce) if
+    `combine_nonbondoed_forces=False`.
+
+    """
     if "vdW" in openff_sys.handlers:
         vdw_handler = openff_sys.handlers["vdW"]
 
@@ -509,6 +526,7 @@ def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=F
 
 
 def from_openmm(topology=None, system=None, positions=None, box_vectors=None):
+    """Create an Interchange object from OpenMM data."""
     from openff.interchange.components.interchange import Interchange
 
     openff_sys = Interchange()
@@ -534,10 +552,10 @@ def from_openmm(topology=None, system=None, positions=None, box_vectors=None):
     if topology:
         import mdtraj as md
 
-        from openff.interchange.components.mdtraj import OFFBioTop
+        from openff.interchange.components.mdtraj import _OFFBioTop
 
         mdtop = md.Topology.from_openmm(topology)
-        top = OFFBioTop()
+        top = _OFFBioTop()
         top.mdtop = mdtop
 
         openff_sys.topoology = top

--- a/openff/interchange/interop/parmed.py
+++ b/openff/interchange/interop/parmed.py
@@ -1,3 +1,4 @@
+"""Interfaces with ParmEd."""
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import mdtraj as md
@@ -26,7 +27,7 @@ kcal_mol_rad2 = unit.Unit("kilocalories / mol / rad ** 2")
 
 
 def _to_parmed(off_system: "Interchange") -> "pmd.Structure":
-    """Convert an OpenFF Interchange to a ParmEd Structure"""
+    """Convert an OpenFF Interchange to a ParmEd Structure."""
     import parmed as pmd
 
     structure = pmd.Structure()
@@ -261,11 +262,11 @@ def _from_parmed(cls, structure) -> "Interchange":
 
     from openff.toolkit.topology import Molecule
 
-    from openff.interchange.components.mdtraj import OFFBioTop
+    from openff.interchange.components.mdtraj import _OFFBioTop
 
     if structure.topology is not None:
         mdtop = md.Topology.from_openmm(structure.topology)  # type: ignore[attr-defined]
-        top = OFFBioTop(mdtop=mdtop)
+        top = _OFFBioTop(mdtop=mdtop)
         out.topology = top
     else:
         # TODO: Remove this case
@@ -275,7 +276,7 @@ def _from_parmed(cls, structure) -> "Interchange":
         mdtop = md.Topology()  # type: ignore[attr-defined]
 
         main_chain = md.core.topology.Chain(index=0, topology=mdtop)  # type: ignore[attr-defined]
-        top = OFFBioTop(mdtop=None)
+        top = _OFFBioTop(mdtop=None)
 
         # There is no way to tell if ParmEd residues are connected (cannot be processed
         # as separate OFFMols) or disconnected (can be). For now, will have to accept the

--- a/openff/interchange/models.py
+++ b/openff/interchange/models.py
@@ -1,3 +1,4 @@
+"""Custom Pydantic models."""
 from typing import Optional, Tuple
 
 from openff.units import unit
@@ -10,6 +11,8 @@ class DefaultModel(BaseModel):
     """A custom Pydantic model used by other components."""
 
     class Config:
+        """Custom Pydantic configuration."""
+
         json_encoders = {
             unit.Quantity: custom_quantity_encoder,
         }
@@ -19,7 +22,8 @@ class DefaultModel(BaseModel):
 
 
 class TopologyKey(DefaultModel):
-    """A unique identifier of a segment of a chemical topology.
+    """
+    A unique identifier of a segment of a chemical topology.
 
     These refer to a single portion of a chemical graph, i.e. a single valence term,
     (a bond, angle, or dihedral) or a single atom. These target only the information in
@@ -30,7 +34,6 @@ class TopologyKey(DefaultModel):
 
     Examples
     --------
-
     Create a TopologyKey identifying some speicfic angle
 
     .. code-block:: pycon
@@ -75,7 +78,8 @@ class TopologyKey(DefaultModel):
 
 
 class PotentialKey(DefaultModel):
-    """A unique identifier of an instance of physical parameters as applied to a segment of a chemical topology.
+    """
+    A unique identifier of an instance of physical parameters as applied to a segment of a chemical topology.
 
     These refer to a single term in a force field as applied to a single segment of a chemical
     topology, i.e. a single atom or dihedral. For example, a PotentialKey corresponding to a
@@ -85,7 +89,6 @@ class PotentialKey(DefaultModel):
 
     Examples
     --------
-
     Create a PotentialKey corresponding to the parameter with id `b55` in OpenFF "Parsley" 1.0.0
 
     .. code-block:: pycon

--- a/openff/interchange/tests/__init__.py
+++ b/openff/interchange/tests/__init__.py
@@ -3,12 +3,12 @@ import pytest
 from openff.toolkit.topology.molecule import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 
-from openff.interchange.components.mdtraj import OFFBioTop
-from openff.interchange.tests.utils import top_from_smiles
+from openff.interchange.components.mdtraj import _OFFBioTop
+from openff.interchange.tests.utils import _top_from_smiles
 from openff.interchange.utils import get_test_file_path
 
 
-class BaseTest:
+class _BaseTest:
     @pytest.fixture(autouse=True)
     def _initdir(self, tmpdir):
         tmpdir.chdir()
@@ -16,31 +16,31 @@ class BaseTest:
     # TODO: group fixtures up as dicts, i.e. argon['forcefield'], argon['topology'], ...
     @pytest.fixture()
     def argon_ff(self):
-        """Fixture that loads an SMIRNOFF XML for argon"""
+        """Fixture that loads an SMIRNOFF XML for argon."""
         return ForceField(get_test_file_path("argon.offxml"))
 
     @pytest.fixture()
     def argon_top(self):
-        """Fixture that builds a simple arogon topology"""
-        return top_from_smiles("[#18]")
+        """Fixture that builds a simple arogon topology."""
+        return _top_from_smiles("[#18]")
 
     @pytest.fixture()
     def ammonia_ff(self):
-        """Fixture that loads an SMIRNOFF XML for ammonia"""
+        """Fixture that loads an SMIRNOFF XML for ammonia."""
         return ForceField(get_test_file_path("ammonia.offxml"))
 
     @pytest.fixture()
     def ammonia_top(self):
-        """Fixture that builds a simple ammonia topology"""
+        """Fixture that builds a simple ammonia topology."""
         mol = Molecule.from_smiles("N")
-        top = OFFBioTop.from_molecules(4 * [mol])
+        top = _OFFBioTop.from_molecules(4 * [mol])
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
         return top
 
     @pytest.fixture()
     def ethanol_top(self):
-        """Fixture that builds a simple four ethanol topology"""
-        return top_from_smiles("CCO", n_molecules=4)
+        """Fixture that builds a simple four ethanol topology."""
+        return _top_from_smiles("CCO", n_molecules=4)
 
     @pytest.fixture()
     def parsley(self):

--- a/openff/interchange/tests/components/test_foyer.py
+++ b/openff/interchange/tests/components/test_foyer.py
@@ -11,13 +11,13 @@ from openff.units import unit
 from openff.utilities.testing import has_package, skip_if_missing
 from simtk import unit as omm_unit
 
-from openff.interchange.components.foyer import RBTorsionHandler
+from openff.interchange.components.foyer import _RBTorsionHandler
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.components.potentials import Potential
 from openff.interchange.drivers import get_openmm_energies
 from openff.interchange.models import PotentialKey, TopologyKey
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.tests.utils import HAS_GROMACS, needs_gmx
 from openff.interchange.utils import get_test_files_dir_path
 
@@ -35,7 +35,7 @@ kj_mol = unit.Unit("kilojoule / mol")
 
 
 @skip_if_missing("foyer")
-class TestFoyer(BaseTest):
+class TestFoyer(_BaseTest):
     @pytest.fixture(scope="session")
     def oplsaa(self):
         return foyer.forcefields.load_OPLSAA()
@@ -48,7 +48,7 @@ class TestFoyer(BaseTest):
         )
         molecule.name = "ETH"
 
-        top = OFFBioTop.from_molecules(molecule)
+        top = _OFFBioTop.from_molecules(molecule)
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
         oplsaa = foyer.Forcefield(name="oplsaa")
         interchange = Interchange.from_foyer(topology=top, force_field=oplsaa)
@@ -68,7 +68,7 @@ class TestFoyer(BaseTest):
             else:
                 molecule_or_molecules.name = mol_name
 
-            off_bio_top = OFFBioTop.from_molecules(molecule_or_molecules)
+            off_bio_top = _OFFBioTop.from_molecules(molecule_or_molecules)
             off_bio_top.mdtop = md.Topology.from_openmm(off_bio_top.to_openmm())
             openff_interchange = Interchange.from_foyer(off_bio_top, oplsaa)
 
@@ -160,7 +160,7 @@ class TestFoyer(BaseTest):
         )
 
 
-class TestRBTorsions(BaseTest):
+class TestRBTorsions(_BaseTest):
     @pytest.fixture(scope="class")
     def ethanol_with_rb_torsions(self):
         mol = Molecule.from_smiles("CC")
@@ -172,7 +172,7 @@ class TestRBTorsions(BaseTest):
         out.positions = mol.conformers[0]
         out.positions = np.round(out.positions, 2)
 
-        rb_torsions = RBTorsionHandler()
+        rb_torsions = _RBTorsionHandler()
         smirks = "[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]"
         pot_key = PotentialKey(id=smirks)
         for proper in top.propers:

--- a/openff/interchange/tests/components/test_interchange.py
+++ b/openff/interchange/tests/components/test_interchange.py
@@ -11,14 +11,14 @@ from openff.utilities.testing import skip_if_missing
 from pydantic import ValidationError
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.drivers import get_openmm_energies
 from openff.interchange.exceptions import (
     InvalidTopologyError,
     MissingPositionsError,
     SMIRNOFFHandlersNotImplementedError,
 )
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.tests.energy_tests.test_energies import needs_gmx, needs_lmp
 from openff.interchange.utils import get_test_file_path
 
@@ -52,12 +52,12 @@ def test_box_setter():
 
 
 @pytest.mark.slow()
-class TestInterchangeCombination(BaseTest):
+class TestInterchangeCombination(_BaseTest):
     def test_basic_combination(self, parsley_unconstrained):
         """Test basic use of Interchange.__add__() based on the README example"""
         mol = Molecule.from_smiles("C")
         mol.generate_conformers(n_conformers=1)
-        top = OFFBioTop.from_molecules([mol])
+        top = _OFFBioTop.from_molecules([mol])
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
 
         openff_sys = Interchange.from_smirnoff(parsley_unconstrained, top)
@@ -76,7 +76,7 @@ class TestInterchangeCombination(BaseTest):
         get_openmm_energies(combined)
 
 
-class TestUnimplementedSMIRNOFFCases(BaseTest):
+class TestUnimplementedSMIRNOFFCases(_BaseTest):
     def test_bogus_smirnoff_handler(self, parsley):
         top = Molecule.from_smiles("CC").to_topology()
 
@@ -102,7 +102,7 @@ class TestUnimplementedSMIRNOFFCases(BaseTest):
             Interchange.from_smirnoff(force_field=forcefield, topology=top)
 
 
-class TestBadExports(BaseTest):
+class TestBadExports(_BaseTest):
     def test_invalid_topology(self, parsley):
         """Test that InvalidTopologyError is caught when passing an unsupported
         topology type to Interchange.from_smirnoff"""
@@ -125,12 +125,12 @@ class TestBadExports(BaseTest):
             zero_positions.to_gro("foo.gro")
 
 
-class TestInterchange(BaseTest):
+class TestInterchange(_BaseTest):
     def test_from_parsley(self):
 
         force_field = ForceField("openff-1.3.0.offxml")
 
-        top = OFFBioTop.from_molecules(
+        top = _OFFBioTop.from_molecules(
             [Molecule.from_smiles("CCO"), Molecule.from_smiles("CC")]
         )
 
@@ -142,7 +142,7 @@ class TestInterchange(BaseTest):
         assert "ProperTorsions" in out.handlers.keys()
         assert "vdW" in out.handlers.keys()
 
-        assert type(out.topology) == OFFBioTop
+        assert type(out.topology) == _OFFBioTop
         assert type(out.topology) != Topology
         assert isinstance(out.topology, Topology)
 
@@ -165,7 +165,7 @@ class TestInterchange(BaseTest):
 
         benzene = Molecule.from_file(get_test_file_path("benzene.sdf"))
         benzene.name = "BENZ"
-        biotop = OFFBioTop.from_molecules(benzene)
+        biotop = _OFFBioTop.from_molecules(benzene)
         biotop.mdtop = md.Topology.from_openmm(biotop.to_openmm())
         out = Interchange.from_foyer(force_field=oplsaa, topology=biotop)
         out.box = [4, 4, 4]

--- a/openff/interchange/tests/components/test_mdtraj.py
+++ b/openff/interchange/tests/components/test_mdtraj.py
@@ -6,10 +6,10 @@ from simtk.openmm import app
 
 from openff.interchange.components.interchange import Interchange
 from openff.interchange.components.mdtraj import (
-    OFFBioTop,
     _get_num_h_bonds,
     _iterate_pairs,
     _iterate_propers,
+    _OFFBioTop,
     _store_bond_partners,
 )
 from openff.interchange.drivers import get_openmm_energies
@@ -22,7 +22,7 @@ def test_residues():
     traj = md.load(get_test_file_path("ALA_GLY/ALA_GLY.pdb"))
     mol = Molecule(get_test_file_path("ALA_GLY/ALA_GLY.sdf"), file_format="sdf")
 
-    top = OFFBioTop.from_openmm(pdb.topology, unique_molecules=[mol])
+    top = _OFFBioTop.from_openmm(pdb.topology, unique_molecules=[mol])
     top.mdtop = traj.top
 
     assert top.n_topology_atoms == 29

--- a/openff/interchange/tests/components/test_potentials.py
+++ b/openff/interchange/tests/components/test_potentials.py
@@ -6,10 +6,10 @@ from openff.interchange.components.potentials import (
     PotentialHandler,
     WrappedPotential,
 )
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 
 
-class TestWrappedPotential(BaseTest):
+class TestWrappedPotential(_BaseTest):
     def test_interpolated_potentials(self):
         """Test the construction of and .parameters getter of WrappedPotential"""
 
@@ -40,7 +40,7 @@ class TestWrappedPotential(BaseTest):
         assert simple.parameters == pot2.parameters
 
 
-class TestPotentialHandlerSubclassing(BaseTest):
+class TestPotentialHandlerSubclassing(_BaseTest):
     def test_dummy_potential_handler(self):
         handler = PotentialHandler(
             type="foo",

--- a/openff/interchange/tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/components/test_smirnoff.py
@@ -23,7 +23,7 @@ from simtk import openmm
 from simtk import unit as simtk_unit
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.components.smirnoff import (
     SMIRNOFFAngleHandler,
     SMIRNOFFBondHandler,
@@ -37,14 +37,14 @@ from openff.interchange.components.smirnoff import (
 from openff.interchange.drivers.openmm import _get_openmm_energies, get_openmm_energies
 from openff.interchange.exceptions import InvalidParameterHandlerError
 from openff.interchange.models import TopologyKey
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.utils import get_test_file_path
 
 kcal_mol_a2 = unit.Unit("kilocalorie / (angstrom ** 2 * mole)")
 kcal_mol_rad2 = unit.Unit("kilocalorie / (mole * radian ** 2)")
 
 
-class TestSMIRNOFFPotentialHandler(BaseTest):
+class TestSMIRNOFFPotentialHandler(_BaseTest):
     def test_allowed_parameter_handler_types(self):
         class DummyParameterHandler(ParameterHandler):
             pass
@@ -86,9 +86,9 @@ class TestSMIRNOFFPotentialHandler(BaseTest):
             )
 
 
-class TestSMIRNOFFHandlers(BaseTest):
+class TestSMIRNOFFHandlers(_BaseTest):
     def test_bond_potential_handler(self):
-        top = OFFBioTop.from_molecules(Molecule.from_smiles("O=O"))
+        top = _OFFBioTop.from_molecules(Molecule.from_smiles("O=O"))
 
         bond_handler = BondHandler(version=0.3)
         bond_parameter = BondHandler.BondType(
@@ -116,7 +116,7 @@ class TestSMIRNOFFHandlers(BaseTest):
         assert pot.parameters["k"].to(kcal_mol_a2).magnitude == pytest.approx(1.5)
 
     def test_angle_potential_handler(self):
-        top = OFFBioTop.from_molecules(Molecule.from_smiles("CCC"))
+        top = _OFFBioTop.from_molecules(Molecule.from_smiles("CCC"))
 
         angle_handler = AngleHandler(version=0.3)
         angle_parameter = AngleHandler.AngleType(
@@ -170,7 +170,7 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
     def test_electrostatics_am1_handler(self):
-        top = OFFBioTop.from_molecules(Molecule.from_smiles("C"))
+        top = _OFFBioTop.from_molecules(Molecule.from_smiles("C"))
 
         parameter_handlers = [
             ElectrostaticsHandler(version=0.3),
@@ -187,7 +187,7 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
     def test_electrostatics_library_charges(self):
-        top = OFFBioTop.from_molecules(Molecule.from_smiles("C"))
+        top = _OFFBioTop.from_molecules(Molecule.from_smiles("C"))
 
         library_charge_handler = LibraryChargeHandler(version=0.3)
         library_charge_handler.add_parameter(
@@ -213,7 +213,7 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
     def test_electrostatics_charge_increments(self):
-        top = OFFBioTop.from_molecules(Molecule.from_mapped_smiles("[Cl:1][H:2]"))
+        top = _OFFBioTop.from_molecules(Molecule.from_mapped_smiles("[Cl:1][H:2]"))
 
         charge_increment_handler = ChargeIncrementModelHandler(version=0.3)
         charge_increment_handler.add_parameter(
@@ -241,7 +241,7 @@ class TestSMIRNOFFHandlers(BaseTest):
         )
 
 
-class TestUnassignedParameters(BaseTest):
+class TestUnassignedParameters(_BaseTest):
     def test_catch_unassigned_bonds(self, parsley, ethanol_top):
         for param in parsley["Bonds"].parameters:
             param.smirks = "[#99:1]-[#99:2]"
@@ -317,7 +317,7 @@ def test_library_charges_from_molecule():
     assert library_charges.charge == [*mol.partial_charges]
 
 
-class TestBondOrderInterpolation(BaseTest):
+class TestBondOrderInterpolation(_BaseTest):
     xml_ff_bo_bonds = """<?xml version='1.0' encoding='ASCII'?>
     <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
       <Bonds version="0.3" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
@@ -467,7 +467,7 @@ class TestBondOrderInterpolation(BaseTest):
 
 
 @skip_if_missing("jax")
-class TestMatrixRepresentations(BaseTest):
+class TestMatrixRepresentations(_BaseTest):
     @pytest.mark.parametrize(
         ("handler_name", "n_ff_terms", "n_sys_terms"),
         [("vdW", 10, 72), ("Bonds", 8, 64), ("Angles", 6, 104)],
@@ -521,7 +521,7 @@ class TestMatrixRepresentations(BaseTest):
             )
 
 
-class TestParameterInterpolation(BaseTest):
+class TestParameterInterpolation(_BaseTest):
     xml_ff_bo = """<?xml version='1.0' encoding='ASCII'?>
     <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
       <Bonds version="0.3" fractional_bondorder_method="AM1-Wiberg"

--- a/openff/interchange/tests/conftest.py
+++ b/openff/interchange/tests/conftest.py
@@ -1,4 +1,8 @@
+"""Custom pytest behavior."""
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Raise an exception if too many tests are skipped while running the entire test suites."""
     # do not error based on number of skipped tests if running "minimal" tests
     if "not slow" not in terminalreporter.config.option.markexpr:
         if "skipped" in terminalreporter.stats:

--- a/openff/interchange/tests/energy_tests/test_energies.py
+++ b/openff/interchange/tests/energy_tests/test_energies.py
@@ -12,7 +12,7 @@ from simtk import unit as simtk_unit
 from simtk.openmm import app
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.drivers import get_openmm_energies
 from openff.interchange.drivers.openmm import _get_openmm_energies
 from openff.interchange.drivers.report import EnergyError, EnergyReport
@@ -199,7 +199,7 @@ def test_packmol_boxes(toolkit_file_path):
     ethanol = Molecule.from_smiles("CCO")
     cyclohexane = Molecule.from_smiles("C1CCCCC1")
     omm_topology = pdbfile.topology
-    off_topology = OFFBioTop.from_openmm(
+    off_topology = _OFFBioTop.from_openmm(
         omm_topology, unique_molecules=[ethanol, cyclohexane]
     )
     off_topology.mdtop = md.Topology.from_openmm(omm_topology)

--- a/openff/interchange/tests/files/smi_to_sdf.py
+++ b/openff/interchange/tests/files/smi_to_sdf.py
@@ -1,3 +1,4 @@
+"""Script used to convert molecules.smi to molecules.sdf."""
 from openff.toolkit.topology.molecule import Molecule
 from rdkit import Chem
 

--- a/openff/interchange/tests/files/trim_drug_bank.py
+++ b/openff/interchange/tests/files/trim_drug_bank.py
@@ -1,3 +1,4 @@
+"""Script to generate a subset of MiniDrugBank."""
 from openff.toolkit.topology import Molecule
 from openff.toolkit.utils import get_data_file_path
 from rdkit import Chem

--- a/openff/interchange/tests/interop/internal/test_gromacs.py
+++ b/openff/interchange/tests/interop/internal/test_gromacs.py
@@ -8,19 +8,19 @@ from openff.units import unit
 from openff.utilities.testing import skip_if_missing
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.components.nonbonded import BuckinghamvdWHandler
 from openff.interchange.components.potentials import Potential
 from openff.interchange.drivers import get_gromacs_energies, get_openmm_energies
 from openff.interchange.exceptions import GMXMdrunError, UnsupportedExportError
 from openff.interchange.models import PotentialKey, TopologyKey
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.tests.energy_tests.test_energies import needs_gmx
 from openff.interchange.utils import get_test_file_path
 
 
 @needs_gmx
-class TestGROMACS(BaseTest):
+class TestGROMACS(_BaseTest):
     @skip_if_missing("parmed")
     def test_set_mixing_rule(self, ethanol_top, parsley):
         import parmed as pmd
@@ -57,7 +57,7 @@ class TestGROMACS(BaseTest):
         """Test that residue names > 5 characters don't break .gro file output"""
         benzene = Molecule.from_file(get_test_file_path("benzene.sdf"))
         benzene.name = "supercalifragilisticexpialidocious"
-        top = OFFBioTop.from_molecules(benzene)
+        top = _OFFBioTop.from_molecules(benzene)
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
 
         # Populate an entire interchange because ...
@@ -76,7 +76,7 @@ class TestGROMACS(BaseTest):
         from openff.interchange.components.smirnoff import SMIRNOFFElectrostaticsHandler
 
         mol = Molecule.from_smiles("[#18]")
-        top = OFFBioTop.from_molecules([mol, mol])
+        top = _OFFBioTop.from_molecules([mol, mol])
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
 
         # http://www.sklogwiki.org/SklogWiki/index.php/Argon#Buckingham_potential

--- a/openff/interchange/tests/interop/internal/test_lammps.py
+++ b/openff/interchange/tests/interop/internal/test_lammps.py
@@ -6,7 +6,7 @@ from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit as omm_unit
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.drivers import get_lammps_energies, get_openmm_energies
 from openff.interchange.drivers.lammps import _write_lammps_input
 from openff.interchange.tests.energy_tests.test_energies import needs_lmp
@@ -38,7 +38,7 @@ def test_to_lammps_single_mols(mol, n_mols):
 
     mol = Molecule.from_smiles(mol)
     mol.generate_conformers(n_conformers=1)
-    top = OFFBioTop.from_molecules(n_mols * [mol])
+    top = _OFFBioTop.from_molecules(n_mols * [mol])
     mol.conformers[0] -= np.min(mol.conformers) * omm_unit.angstrom
 
     top.box_vectors = np.eye(3) * np.asarray([10, 10, 10]) * omm_unit.nanometer

--- a/openff/interchange/tests/interop/test_external.py
+++ b/openff/interchange/tests/interop/test_external.py
@@ -9,21 +9,21 @@ from simtk import openmm
 from simtk.unit import nanometer as nm
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.drivers import get_openmm_energies
 from openff.interchange.drivers.openmm import _get_openmm_energies
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.utils import get_test_file_path
 
 
-class TestFromOpenMM(BaseTest):
+class TestFromOpenMM(_BaseTest):
     @pytest.mark.slow()
     def test_from_openmm_pdbfile(self, argon_ff, argon_top):
         pdb_file_path = get_test_file_path("10-argons.pdb")
         pdbfile = openmm.app.PDBFile(pdb_file_path)
 
         mol = Molecule.from_smiles("[#18]")
-        top = OFFBioTop.from_openmm(pdbfile.topology, unique_molecules=[mol])
+        top = _OFFBioTop.from_openmm(pdbfile.topology, unique_molecules=[mol])
         top.mdtop = md.Topology.from_openmm(top.to_openmm())
         box = pdbfile.topology.getPeriodicBoxVectors()
         box = box.value_in_unit(nm) * unit.nanometer
@@ -73,7 +73,7 @@ class TestFromOpenMM(BaseTest):
 
         pdb_file_path = get_data_file_path("systems/packmol_boxes/" + pdb_path)
         pdbfile = openmm.app.PDBFile(pdb_file_path)
-        top = OFFBioTop.from_openmm(
+        top = _OFFBioTop.from_openmm(
             pdbfile.topology,
             unique_molecules=unique_molecules,
         )

--- a/openff/interchange/tests/interop/test_openmm.py
+++ b/openff/interchange/tests/interop/test_openmm.py
@@ -10,7 +10,7 @@ from simtk import unit as simtk_unit
 from simtk.openmm import app
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 from openff.interchange.drivers.openmm import _get_openmm_energies, get_openmm_energies
 from openff.interchange.exceptions import (
     UnsupportedCutoffMethodError,
@@ -114,7 +114,7 @@ def test_openmm_nonbonded_methods(inputs):
 def test_unsupported_mixing_rule():
     molecules = [create_ethanol()]
     pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
-    topology = OFFBioTop.from_openmm(pdbfile.topology, unique_molecules=molecules)
+    topology = _OFFBioTop.from_openmm(pdbfile.topology, unique_molecules=molecules)
     topology.mdtop = md.Topology.from_openmm(topology.to_openmm())
 
     forcefield = ForceField("test_forcefields/test_forcefield.offxml")

--- a/openff/interchange/tests/interop/test_parmed.py
+++ b/openff/interchange/tests/interop/test_parmed.py
@@ -14,12 +14,12 @@ from openff.interchange.drivers.gromacs import (
     _run_gmx_energy,
     get_gromacs_energies,
 )
-from openff.interchange.tests import BaseTest
-from openff.interchange.tests.utils import top_from_smiles
+from openff.interchange.tests import _BaseTest
+from openff.interchange.tests.utils import _top_from_smiles
 from openff.interchange.utils import get_test_file_path
 
 
-class TestParmedConversion(BaseTest):
+class TestParmedConversion(_BaseTest):
     @pytest.fixture()
     def box(self):
         return np.array([4.0, 4.0, 4.0])
@@ -52,7 +52,7 @@ class TestParmedConversion(BaseTest):
         assert np.allclose(struct.box, np.array([40, 40, 40, 90, 90, 90]))
 
     def test_basic_conversion_params(self, box):
-        top = top_from_smiles("C")
+        top = _top_from_smiles("C")
         parsley = ForceField("openff_unconstrained-1.0.0.offxml")
 
         off_sys = Interchange.from_smirnoff(force_field=parsley, topology=top, box=box)

--- a/openff/interchange/tests/test_utils.py
+++ b/openff/interchange/tests/test_utils.py
@@ -4,12 +4,12 @@ from openff.units import unit
 from openff.units.simtk import from_simtk
 from simtk import unit as simtk_unit
 
-from openff.interchange.tests import BaseTest
+from openff.interchange.tests import _BaseTest
 from openff.interchange.utils import (
+    _unwrap_list_of_pint_quantities,
     compare_forcefields,
     get_partial_charges_from_openmm_system,
     pint_to_simtk,
-    unwrap_list_of_pint_quantities,
 )
 
 simtk_quantitites = [
@@ -40,7 +40,7 @@ def test_pint_to_simtk():
     assert pint_to_simtk(q) == 0.5 / simtk_unit.angstrom
 
 
-class TestUtils(BaseTest):
+class TestUtils(_BaseTest):
     def test_compare_forcefields(self, parsley):
         parsley_name = "openff-1.0.0.offxml"
         compare_forcefields(parsley, parsley)
@@ -52,10 +52,10 @@ class TestUtils(BaseTest):
         wrapped = [1 * unit.m, 1.5 * unit.m]
         unwrapped = [1, 1.5] * unit.m
 
-        assert all(unwrapped == unwrap_list_of_pint_quantities(wrapped))
+        assert all(unwrapped == _unwrap_list_of_pint_quantities(wrapped))
 
 
-class TestOpenMM(BaseTest):
+class TestOpenMM(_BaseTest):
     def test_openmm_partial_charges(self, argon_ff, argon_top):
         omm_system = argon_ff.create_openmm_system(argon_top)
         partial_charges = get_partial_charges_from_openmm_system(omm_system)

--- a/openff/interchange/tests/utils.py
+++ b/openff/interchange/tests/utils.py
@@ -1,3 +1,4 @@
+"""Assorted utilities used in testing."""
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -10,7 +11,7 @@ from simtk import openmm
 from simtk import unit as simtk_unit
 
 from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.mdtraj import _OFFBioTop
 
 HAS_GROMACS = any(has_executable(e) for e in ["gmx", "gmx_d"])
 HAS_LAMMPS = any(has_executable(e) for e in ["lammps", "lmp_mpi", "lmp_serial"])
@@ -23,11 +24,12 @@ kj_nm2_mol = simtk_unit.kilojoule_per_mole / simtk_unit.nanometer ** 2
 kj_rad2_mol = simtk_unit.kilojoule_per_mole / simtk_unit.radian ** 2
 
 
-def top_from_smiles(
+def _top_from_smiles(
     smiles: str,
     n_molecules: int = 1,
-) -> OFFBioTop:
-    """Create a gas phase OpenFF Topology from a single-molecule SMILES
+) -> _OFFBioTop:
+    """
+    Create a gas phase OpenFF Topology from a single-molecule SMILES.
 
     Parameters
     ----------
@@ -39,13 +41,13 @@ def top_from_smiles(
 
     Returns
     -------
-    top : opennff.interchange.components.mdtraj.OFFBioTop
+    top : opennff.interchange.components.mdtraj._OFFBioTop
         A single-molecule, gas phase-like topology
 
     """
     mol = Molecule.from_smiles(smiles)
     mol.generate_conformers(n_conformers=1)
-    top = OFFBioTop.from_molecules(n_molecules * [mol])
+    top = _OFFBioTop.from_molecules(n_molecules * [mol])
     top.mdtop = md.Topology.from_openmm(top.to_openmm())  # type: ignore[attr-defined]
     # Add dummy box vectors
     # TODO: Revisit if/after Topology.is_periodic

--- a/openff/interchange/types.py
+++ b/openff/interchange/types.py
@@ -1,3 +1,4 @@
+"""Custom models for dealing with unit-bearing quantities in a Pydantic-compatible manner."""
 import json
 from typing import TYPE_CHECKING, Any, Dict
 
@@ -22,13 +23,15 @@ class _FloatQuantityMeta(type):
 
 
 class FloatQuantity(float, metaclass=_FloatQuantityMeta):
+    """A model for unit-bearing floats."""
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate_type
 
     @classmethod
     def validate_type(cls, val):
-        """Process a value tagged with units into one tagged with "OpenFF" style units"""
+        """Process a value tagged with units into one tagged with "OpenFF" style units."""
         unit_ = getattr(cls, "__unit__", Any)
         if unit_ is Any:
             if isinstance(val, (float, int)):
@@ -66,8 +69,9 @@ class FloatQuantity(float, metaclass=_FloatQuantityMeta):
 
 
 def _from_omm_quantity(val: simtk_unit.Quantity):
-    """Helper function to convert float or array quantities tagged with SimTK/OpenMM units to
-    a Pint-compatible quantity"""
+    """
+    Convert float or array quantities tagged with SimTK/OpenMM units to a Pint-compatible quantity.
+    """
     unit_ = val.unit
     val_ = val.value_in_unit(unit_)
     if type(val_) in {float, int}:
@@ -85,7 +89,7 @@ def _from_omm_quantity(val: simtk_unit.Quantity):
 
 @requires_package("unyt")
 def _from_unyt_quantity(val: "unyt.unyt_array"):
-    """Helper function to convert unyt arrays to Pint quantities"""
+    """Convert unyt arrays to Pint quantities."""
     quantity = val.to_pint()
     # Ensure a float-like quantity is a float, not a scalar array
     if isinstance(val, unyt.unyt_quantity):
@@ -94,10 +98,13 @@ def _from_unyt_quantity(val: "unyt.unyt_array"):
 
 
 class QuantityEncoder(json.JSONEncoder):
-    """JSON encoder for unit-wrapped floats and np arrays. Should work
-    for both FloatQuantity and ArrayQuantity"""
+    """
+    JSON encoder for unit-wrapped floats and NumPy arrays.
 
-    def default(self, obj):
+    This is intended to operate on FloatQuantity and ArrayQuantity objects.
+    """
+
+    def default(self, obj):  # noqa
         if isinstance(obj, unit.Quantity):
             if isinstance(obj.magnitude, (float, int)):
                 data = obj.magnitude
@@ -116,11 +123,12 @@ class QuantityEncoder(json.JSONEncoder):
 
 
 def custom_quantity_encoder(v):
-    """Wrapper around json.dumps that uses QuantityEncoder"""
+    """Wrap json.dump to use QuantityEncoder."""
     return json.dumps(v, cls=QuantityEncoder)
 
 
 def json_loader(data: str) -> dict:
+    """Load JSON containing custom unit-tagged quantities."""
     # TODO: recursively call this function for nested models
     out: Dict = json.loads(data)
     for key, val in out.items():
@@ -138,7 +146,7 @@ def json_loader(data: str) -> dict:
     return out
 
 
-class ArrayQuantityMeta(type):
+class _ArrayQuantityMeta(type):
     def __getitem__(self, t):
         return type("ArrayQuantity", (ArrayQuantity,), {"__unit__": t})
 
@@ -147,14 +155,16 @@ if TYPE_CHECKING:
     ArrayQuantity = np.ndarray
 else:
 
-    class ArrayQuantity(float, metaclass=ArrayQuantityMeta):
+    class ArrayQuantity(float, metaclass=_ArrayQuantityMeta):
+        """A model for unit-bearing arrays."""
+
         @classmethod
         def __get_validators__(cls):
             yield cls.validate_type
 
         @classmethod
         def validate_type(cls, val):
-            """Process an array tagged with units into one tagged with "OpenFF" style units"""
+            """Process an array tagged with units into one tagged with "OpenFF" style units."""
             unit_ = getattr(cls, "__unit__", Any)
             if unit_ is Any:
                 if isinstance(val, (list, np.ndarray)):

--- a/openff/interchange/utils.py
+++ b/openff/interchange/utils.py
@@ -1,3 +1,4 @@
+"""Assorted utilities."""
 import pathlib
 from collections import OrderedDict
 
@@ -31,7 +32,7 @@ def pint_to_simtk(quantity):
         raise NotImplementedError(f"caught units {str(quantity.units)}")
 
 
-def unwrap_list_of_pint_quantities(quantities):
+def _unwrap_list_of_pint_quantities(quantities):
     assert {val.units for val in quantities} == {quantities[0].units}
     parsed_unit = quantities[0].units
     vals = [val.magnitude for val in quantities]
@@ -39,7 +40,7 @@ def unwrap_list_of_pint_quantities(quantities):
 
 
 def get_test_file_path(test_file) -> str:
-    """Given a filename in the collection of data files, return its full path"""
+    """Given a filename in the collection of data files, return its full path."""
     dir_path = resource_filename("openff.interchange", "tests/files/")
     test_file_path = pathlib.Path(dir_path).joinpath(test_file)
 
@@ -50,7 +51,7 @@ def get_test_file_path(test_file) -> str:
 
 
 def get_test_files_dir_path(dirname):
-    """Given a directory with a collection of test data files, return its full path"""
+    """Given a directory with a collection of test data files, return its full path."""
     dir_path = resource_filename("openff.interchange", "tests/files/")
     test_dir = pathlib.Path(dir_path).joinpath(dirname)
 
@@ -63,7 +64,7 @@ def get_test_files_dir_path(dirname):
 
 
 def get_nonbonded_force_from_openmm_system(omm_system):
-    """Get a single NonbondedForce object with an OpenMM System"""
+    """Get a single NonbondedForce object with an OpenMM System."""
     for force in omm_system.getForces():
         if type(force) == openmm.NonbondedForce:
             return force
@@ -85,7 +86,7 @@ def get_partial_charges_from_openmm_system(omm_system):
 
 
 def _check_forcefield_dict(forcefield):
-    """Ensure an OpenFF ForceField is represented as a dict and convert it if it is not"""
+    """Ensure an OpenFF ForceField is represented as a dict and convert it if it is not."""
     if isinstance(forcefield, ForceField):
         return forcefield._to_smirnoff_data()
     elif isinstance(forcefield, OrderedDict):
@@ -93,7 +94,7 @@ def _check_forcefield_dict(forcefield):
 
 
 def compare_forcefields(ff1, ff2):
-    """Compare dict representations of OpenFF ForceField objects fore equality"""
+    """Compare dict representations of OpenFF ForceField objects fore equality."""
     ff1 = _check_forcefield_dict(ff1)
     ff2 = _check_forcefield_dict(ff2)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ omit =
     # Omit generated versioneer
     openff/interchange/_version.py
 
-[yapf]
-# YAPF, in .style.yapf files this shows up as "[style]" header
-COLUMN_LIMIT = 119
-INDENT_WIDTH = 4
-USE_TABS = False
-
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 119
@@ -31,6 +25,13 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_third_party=numpy,pandas,openff.toolkit,openff.units,pint,pytest,simtk,mdtraj,pydantic,parmed,pmdtest
+
+[pydocstyle]
+match=((?!test|_version).)*\.py
+match-dir = ^(?!test).*$
+# convention=numpy
+ignore=D105,D107,D200,D203,D212
+ignore_decorators=validator
 
 [versioneer]
 # Automatic version numbering scheme


### PR DESCRIPTION
### Description
This PR attempts to add docstrings to all public classes, methods, functions, and modules. Those which shouldn't be public are now largely made private. Most aren't what I would characterize as complete, but they do exist.

Linting is handled by `pydocstyle`, with minimal configuration, in order to at least ensure a baseline level of consistency.

This should improve the results of #255, so I would prefer completing this PR before merging that one.