### PR TITLE
Add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
CI logs are clogged with hundreds of lines of warnings about unregistered marks, which I don't see locally because I was using an untracked file. I pretty much copied the configuration from [the docs](https://docs.pytest.org/en/6.2.x/example/markers.html#registering-markers). When I run the entire suite locally, I get only a few warnings:

```
================================================================================= warnings summary ==================================================================================
../../miniconda3/envs/openff-system/lib/python3.8/site-packages/past/builtins/misc.py:45
  /Users/mwt/miniconda3/envs/openff-system/lib/python3.8/site-packages/past/builtins/misc.py:45: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import reload

<frozen importlib._bootstrap>:219
  <frozen importlib._bootstrap>:219: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 88 from PyObject

../../miniconda3/envs/openff-system/lib/python3.8/site-packages/jaxlib/xla_client.py:31
  /Users/mwt/miniconda3/envs/openff-system/lib/python3.8/site-packages/jaxlib/xla_client.py:31: DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.
    from . import xla_extension as _xla

openff/interchange/tests/components/test_interchange.py::TestInterchangeCombination::test_basic_combination
  /Users/mwt/software/openff-system/openff/interchange/components/interchange.py:460: UserWarning: Iterchange object combination is experimental and likely to produce strange results. Use with caution!
    warnings.warn(

openff/interchange/tests/energy_tests/test_energies.py::test_energy_report
openff/interchange/tests/interop/test_openmm.py::test_openmm_roundtrip
  /Users/mwt/miniconda3/envs/openff-system/lib/python3.8/site-packages/pandas/core/dtypes/cast.py:1990: UnitStrippedWarning: The unit of the quantity is stripped when downcasting to ndarray.
    result[:] = values

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================== 92 passed, 95 skipped, 12 xfailed, 2 xpassed, 6 warnings in 952.05s (0:15:52) ===================================================
```