### PR TITLE
Use mambaforge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,13 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-        activate-environment: test
-        mamba-version: "*"
-        channels: conda-forge,defaults
-        channel-priority: true
         environment-file: devtools/conda-envs/test_env.yaml
+        activate-environment: test
         auto-activate-base: false
+        mamba-version: "*"
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
 
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -20,12 +20,13 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-        activate-environment: test
-        mamba-version: "*"
-        channels: conda-forge,defaults
-        channel-priority: true
         environment-file: devtools/conda-envs/minimal_env.yaml
+        activate-environment: test
         auto-activate-base: false
+        mamba-version: "*"
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
 
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -23,12 +23,13 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-        activate-environment: test
-        mamba-version: "*"
-        channels: conda-forge,defaults
-        channel-priority: true
         environment-file: devtools/conda-envs/test_env.yaml
+        activate-environment: test
         auto-activate-base: false
+        mamba-version: "*"
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
 
     - name: Install development version of OpenFF Recharge
       shell: bash -l {0}


### PR DESCRIPTION
Motivated by https://github.com/openforcefield/openff-toolkit/pull/1043; I thought `mamba-version="*"` was enough to use `mamba` throughout, but that might not the case. I'm not entirely sure which of [these (many) options](https://github.com/conda-incubator/setup-miniconda) are and are not used; I have to say it's not ideal to need to use 8+ options to get fast environment creation.