### PR TITLE
Improve parity of Amber energy driver and exports

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -31,7 +31,6 @@ dependencies:
   - conda
   - mypy
   - unyt
-  - intermol
   - gromacs >=2021
   - lammps
   - mbuild

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,6 @@ Some libraries or tools are only used for development, testing, or optional feat
   - nbval
   - mypy
   - unyt
-  - intermol
   - gromacs >=2020
   - panedr
   - lammps

--- a/openff/interchange/drivers/amber.py
+++ b/openff/interchange/drivers/amber.py
@@ -40,6 +40,12 @@ def get_amber_energies(
         An `EnergyReport` object containing the single-point energies.
 
     """
+    if "Constraints" in off_sys.handlers:
+        if len(off_sys["Constraints"].slot_map) > 0:
+            raise AmberError(
+                "Parsing bond constraints not yet supported in this driver."
+            )
+
     with tempfile.TemporaryDirectory() as tmpdir:
         with temporary_cd(tmpdir):
             struct = off_sys._to_parmed()

--- a/openff/interchange/drivers/amber.py
+++ b/openff/interchange/drivers/amber.py
@@ -4,12 +4,12 @@ import tempfile
 from pathlib import Path
 from typing import Dict, Union
 
-from openff.utilities.utilities import requires_package, temporary_cd
+from openff.utilities.utilities import temporary_cd
 from simtk import unit as omm_unit
 
 from openff.interchange.components.interchange import Interchange
 from openff.interchange.drivers.report import EnergyReport
-from openff.interchange.exceptions import SanderError
+from openff.interchange.exceptions import AmberError, SanderError
 from openff.interchange.utils import get_test_file_path
 
 
@@ -54,7 +54,6 @@ def get_amber_energies(
             return report
 
 
-@requires_package("intermol")
 def _run_sander(
     inpcrd_file: Union[Path, str],
     prmtop_file: Union[Path, str],
@@ -79,8 +78,6 @@ def _run_sander(
         An `EnergyReport` object containing the single-point energies.
 
     """
-    from intermol.amber import _group_energy_terms
-
     in_file = get_test_file_path("min.in")
     sander_cmd = (
         f"sander -i {in_file} -c {inpcrd_file} -p {prmtop_file} -o out.mdout -O"
@@ -112,6 +109,49 @@ def _run_sander(
     )
 
     return energy_report
+
+
+def _group_energy_terms(mdout: str):
+    """
+    Parse AMBER output file and group the energy terms in a dict.
+
+    This code is partially copied from InterMol, see
+    https://github.com/shirtsgroup/InterMol/tree/v0.1/intermol/amber/
+    """
+    with open(mdout) as f:
+        all_lines = f.readlines()
+
+    # Find where the energy information starts.
+    for i, line in enumerate(all_lines):
+        if line[0:8] == "   NSTEP":
+            startline = i
+            break
+    else:
+        raise AmberError(
+            "Unable to detect where energy info starts in AMBER "
+            "output file: {}".format(mdout)
+        )
+
+    # Strange ranges for amber file data.
+    ranges = [[1, 24], [26, 49], [51, 77]]
+
+    e_out = dict()
+    potential = 0 * omm_unit.kilocalories_per_mole
+    for line in all_lines[startline + 3 :]:
+        if "=" in line:
+            for i in range(3):
+                r = ranges[i]
+                term = line[r[0] : r[1]]
+                if "=" in term:
+                    energy_type, energy_value = term.split("=")
+                    energy_value = float(energy_value) * omm_unit.kilocalories_per_mole
+                    potential += energy_value
+                    energy_type = energy_type.rstrip()
+                    e_out[energy_type] = energy_value
+        else:
+            break
+    e_out["ENERGY"] = potential
+    return e_out, mdout
 
 
 def _get_amber_energy_vdw(amber_energies: Dict):

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -177,7 +177,13 @@ class InternalInconsistencyError(BaseException):
     """
 
 
-class SanderError(BaseException):
+class AmberError(BaseException):
+    """
+    Base exception for handling Amber-related errors.
+    """
+
+
+class SanderError(AmberError):
     """
     Exception for when a sander subprocess fails.
     """

--- a/openff/interchange/interoperability_tests/internal/test_amber.py
+++ b/openff/interchange/interoperability_tests/internal/test_amber.py
@@ -32,10 +32,10 @@ def test_amber_energy():
     omm_energies.compare(
         amb_energies,
         custom_tolerances={
-            "Bond": 3.6 * kj_mol,
+            "Bond": 0.03 * kj_mol,
             "Angle": 0.2 * kj_mol,
-            "Torsion": 1.9 * kj_mol,
-            "vdW": 1.5 * kj_mol,
-            "Electrostatics": 36.5 * kj_mol,
+            "Torsion": 0.02 * kj_mol,
+            "vdW": 0.005 * kj_mol,
+            "Electrostatics": 0.01 * kj_mol,
         },
     )

--- a/openff/interchange/interoperability_tests/internal/test_amber.py
+++ b/openff/interchange/interoperability_tests/internal/test_amber.py
@@ -3,7 +3,6 @@ import pytest
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.units import unit
-from openff.utilities.testing import skip_if_missing
 
 from openff.interchange.components.interchange import Interchange
 from openff.interchange.drivers import get_amber_energies, get_gromacs_energies
@@ -12,8 +11,6 @@ from openff.interchange.testing.utils import needs_gmx
 kj_mol = unit.kilojoule / unit.mol
 
 
-@pytest.mark.xfail()
-@skip_if_missing("intermol")
 @needs_gmx
 @pytest.mark.slow()
 def test_amber_energy():

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,9 +86,6 @@ ignore_missing_imports = True
 [mypy-pmdtest.utils]
 ignore_missing_imports = True
 
-[mypy-intermol.*]
-ignore_missing_imports = True
-
 [mypy-pytest]
 ignore_missing_imports = True
 


### PR DESCRIPTION
### Description
There's a ~0.02 kJ/mol/molecule in each term that I'm having a hard time isolating. Could be some rounding in some step, but everything looks to be passed around with 6+ digits of precision ...


### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
