### PR TITLE
Add back old charge assignment tests

### DIFF
--- a/openff/interchange/testing/utils.py
+++ b/openff/interchange/testing/utils.py
@@ -24,6 +24,13 @@ kj_nm2_mol = simtk_unit.kilojoule_per_mole / simtk_unit.nanometer ** 2
 kj_rad2_mol = simtk_unit.kilojoule_per_mole / simtk_unit.radian ** 2
 
 
+def _compare_charges_omm_off(omm_sys: openmm.System, off_sys: Interchange) -> None:
+    omm_charges = np.asarray([*_get_charges_from_openmm_system(omm_sys)])
+    off_charges = _get_charges_from_openff_interchange(off_sys)
+
+    np.testing.assert_equal(omm_charges, off_charges)
+
+
 def _top_from_smiles(
     smiles: str,
     n_molecules: int = 1,


### PR DESCRIPTION
### Description
Some unit tests were inadvertently deleted in https://github.com/openforcefield/openff-interchange/commit/36bf5aaf973dfc44c7aee76415b033ee407b41d8. This adds them back, only to learn that at least one is now broken.