### PR TITLE
Refactor matrix exports

### DIFF
--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -145,6 +145,25 @@ class PotentialHandler(DefaultModel):
             [[v.m for v in p.parameters.values()] for p in self.potentials.values()]
         )
 
+    def set_force_field_parameters(self, new_p):
+        """Set the force field parameters from a flattened representation."""
+        mapping = self.get_mapping()
+        if new_p.shape[0] != len(mapping):
+            raise RuntimeError
+
+        for potential_key, potential_index in self.get_mapping().items():
+            potential = self.potentials[potential_key]
+            if len(new_p[potential_index, :]) != len(potential.parameters):
+                raise RuntimeError
+
+            for parameter_index, parameter_key in enumerate(potential.parameters):
+                parameter_units = potential.parameters[parameter_key].units
+                modified_parameter = new_p[potential_index, parameter_index]
+
+                self.potentials[potential_key].parameters[parameter_key] = (
+                    modified_parameter * parameter_units
+                )
+
     def get_system_parameters(self, p=None):
         """
         Return a flattened representation of system parameters.

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -18,7 +18,8 @@ from openff.interchange.types import ArrayQuantity, FloatQuantity
 if has_package("jax"):
     from jax import numpy
 else:
-    import numpy
+    # Known mypy bug/limitation: https://github.com/python/mypy/issues/1153
+    import numpy  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
     from openff.interchange.components.mdtraj import _OFFBioTop

--- a/openff/interchange/unit_tests/components/test_smirnoff.py
+++ b/openff/interchange/unit_tests/components/test_smirnoff.py
@@ -545,6 +545,21 @@ class TestMatrixRepresentations(_BaseTest):
                 np.sum(param_matrix, axis=1), np.ones(param_matrix.shape[0])
             )
 
+    def test_set_force_field_parameters(self, parsley, ethanol_top):
+        import jax
+
+        bond_handler = SMIRNOFFBondHandler._from_toolkit(
+            parameter_handler=parsley["Bonds"],
+            topology=ethanol_top,
+        )
+
+        original = bond_handler.get_force_field_parameters()
+        modified = original * jax.numpy.array([1.1, 0.5])
+
+        bond_handler.set_force_field_parameters(modified)
+
+        assert (bond_handler.get_force_field_parameters() == modified).all()
+
 
 class TestSMIRNOFFVirtualSites:
     from openff.toolkit.tests.test_forcefield import (


### PR DESCRIPTION
### Description

- [x] Refactor mapping into saner, potential key-based representation 
- [x] Conditionally fall back to NumPy arrays?
- [x] Ensure JAX training example still works
- [x] Resolve #296 

### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
