### PR TITLE
Add native GRO file reader

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - mbuild
   - foyer >=0.8.1
   # Testing
+  - intermol
   - openff-evaluator
   - openff-recharge
   - openeye-toolkits

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -119,7 +119,7 @@ def from_gro(file_path: Union[Path, str]) -> "Interchange":
         path = file_path
 
     # Infer coordinate precision
-    def _infer_coord_precision(file_path: Path) -> int:
+    def _infer_coord_precision(file_path: Union[Path, str]) -> int:
         """
         Infer decimal precision of coordinates by parsing periods in atoms lines.
         """


### PR DESCRIPTION
### Description
This PR adds a function `from_gro` that returns a stripped down `Interchange` object containing only positions and box vectors.

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
