### PR TITLE
Add actions that automatically check for OpenMM RC builds

### DIFF
--- a/.github/workflows/check-openmm-rc.yaml
+++ b/.github/workflows/check-openmm-rc.yaml
@@ -1,0 +1,32 @@
+# Copied from from below link on 9/22/21
+# https://github.com/openpathsampling/openpathsampling/blob/master/.github/workflows/check-openmm-rc.yml
+# See also https://github.com/openmm/openmm/issues/3232#issuecomment-909478595
+#
+# Workflow to check for a recent OpenMM release candidate.
+#
+# If a recent RC is found, trigger a second workflow to test against it.
+# See also: test-openmm-rc.yml
+name: "Check for OpenMM RC"
+on:
+  schedule:
+    - cron: "0 9 * * *"
+
+jobs:
+  check-rc:
+    if: ${{ github.repository == 'openforcefield/openff-interchange' }}
+    runs-on: ubuntu-latest
+    name: "Check for OpenMM RC"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dwhswenson/conda-rc-check@main
+        id: checkrc
+        with:
+          channel: conda-forge
+          package: openmm
+          ndays: 3
+          labels: openmm_rc
+      - uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Test OpenMM Release Candidate
+          token: ${{ secrets.DISPATCH_TOKEN }}
+        if: ${{ steps.checkrc.outputs.hasrc == 'True' }}

--- a/.github/workflows/test-openmm-rc.yaml
+++ b/.github/workflows/test-openmm-rc.yaml
@@ -1,0 +1,112 @@
+# Adapted from from below link on 9/22/21
+# https://github.com/openpathsampling/openpathsampling/blob/master/.github/workflows/check-openmm-rc.yml
+# See also https://github.com/openmm/openmm/issues/3232#issuecomment-909478595
+#
+# Workflow to test against release candidate of OpenMM.
+# See also: check-openmm-rc.yml
+name: "Test OpenMM Release Candidate"
+on:
+  workflow_dispatch:
+  # use this for debugging
+  #pull_request:
+    #branch: master
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9]
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+      COV: --cov=openff/interchange --cov-report=xml --cov-config=setup.cfg --cov-append
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - uses: conda-incubator/setup-miniconda@v2.1.1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+        activate-environment: test
+        auto-activate-base: false
+        mamba-version: "*"
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
+
+    - name: Install OpenMM RC
+      run: |
+        mamba install -c conda-forge/label/openmm_rc -c conda-forge openmm
+
+    - name: Install package
+      shell: bash -l {0}
+      run: |
+        python setup.py develop --no-deps
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+    - name: Environment Information
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+
+    - name: Clone ParmEd tests
+      shell: bash -l {0}
+      run: |
+        git clone https://github.com/mattwthompson/tests
+        cp -r tests/pmdtest .
+        echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
+
+    - name: License OpenEye
+      shell: bash -l {0}
+      run: |
+        echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
+        python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
+      env:
+        SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
+
+    - name: Run mypy
+      shell: bash -l {0}
+      run: |
+        mypy --show-error-codes --warn-unused-configs --warn-unused-ignores --namespace-packages -p "openff.interchange"
+
+    - name: Run docexamples
+      shell: bash -l {0}
+      run: |
+        pytest -v --doctest-modules openff/interchange/ --ignore=openff/interchange/energy_tests --ignore=openff/interchange/unit_tests --ignore=openff/interchange/data --ignore=openff/interchange/interoperability_tests
+
+    - name: Run all tests
+      if: always()
+      shell: bash -l {0}
+      run: |
+        python -m pytest -v -nauto $COV openff/interchange/
+
+#    - name: Run ParmEd tests
+#      continue-on-error: true
+#      shell: bash -l {0}
+#      run: |
+#        python -m pytest -v $COV openff/interchange/tests/parmed
+
+    - name: Run example notebooks
+      shell: bash -l {0}
+      run: |
+        python -m pytest -v $COV examples/ --nbval-lax
+
+    - name: Codecov
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false


### PR DESCRIPTION
I don't think I can really validate the behavior until another RC is built, which will likely be several months.

Context: https://github.com/openmm/openmm/issues/3232#issuecomment-909478595