### PR TITLE
Add GROMACS topology reader and InterMol converter

### DIFF
--- a/openff/interchange/components/base.py
+++ b/openff/interchange/components/base.py
@@ -1,0 +1,78 @@
+"""
+Base models for engine- and force field-agnostic components.
+"""
+from typing import Literal
+
+from openff.units import unit
+from pydantic import Field
+
+from openff.interchange.components.potentials import PotentialHandler
+from openff.interchange.types import FloatQuantity
+
+
+class BaseBondHandler(PotentialHandler):
+    """Base handler for storing generic bond interactions."""
+
+    type: str = "Bonds"
+    expression: str = "k/2*(r-length)**2"
+
+
+class BaseAngleHandler(PotentialHandler):
+    """Base handler for storing generic angle interactions."""
+
+    type: str = "Angle"
+    expression: str = "k/2*(theta-angle)**2"
+
+
+class _BaseNonbondedHandler(PotentialHandler):
+    """Base handler for storing generic nonbonded interactions."""
+
+    type: str = "Nonbonded"
+
+    scale_13: float = Field(
+        0.0, description="The scaling factor applied to 1-3 interactions"
+    )
+    scale_14: float = Field(
+        0.5, description="The scaling factor applied to 1-4 interactions"
+    )
+    scale_15: float = Field(
+        1.0, description="The scaling factor applied to 1-5 interactions"
+    )
+
+    cutoff: FloatQuantity["angstrom"] = Field(  # type: ignore
+        10.0 * unit.angstrom,
+        description="The distance at which pairwise interactions are truncated",
+    )
+
+
+class BasevdWHandler(_BaseNonbondedHandler):
+    """Base handler for storing vdW interactions."""
+
+    type: str = "vdW"
+
+    expression: str = "4*epsilon*((sigma/r)**12-(sigma/r)**6)"
+
+    method: Literal["cutoff", "pme", "no-cutoff"] = Field("cutoff")
+
+    mixing_rule: str = Field(
+        "lorentz-berthelot",
+        description="The mixing rule (combination rule) used in computing pairwise vdW interactions",
+    )
+
+
+class BaseElectrostaticsHandler(_BaseNonbondedHandler):
+    """Base handler for storing vdW interactions."""
+
+    type: str = "Electrostatics"
+
+    expression: str = "coul"
+
+    method: Literal["pme", "cutoff", "reaction-field", "no-cutoff"] = Field("pme")
+
+    @property
+    def charges(self):
+        """Get the total partial charge on each atom, excluding virtual sites."""
+        return {
+            topology_key: self.potentials[potential_key].parameters["charge"]
+            for topology_key, potential_key in self.slot_map.items()
+        }

--- a/openff/interchange/components/base.py
+++ b/openff/interchange/components/base.py
@@ -23,6 +23,13 @@ class BaseAngleHandler(PotentialHandler):
     expression: str = "k/2*(theta-angle)**2"
 
 
+class BaseProperTorsionHandler(PotentialHandler):
+    """Base handler for storing generic proper torsion interactions."""
+
+    type: str = "ProperTorsions"
+    expression: str = "k*(1+cos(periodicity*theta-phase))"
+
+
 class _BaseNonbondedHandler(PotentialHandler):
     """Base handler for storing generic nonbonded interactions."""
 

--- a/openff/interchange/components/base.py
+++ b/openff/interchange/components/base.py
@@ -1,10 +1,9 @@
 """
 Base models for engine- and force field-agnostic components.
 """
-from typing import Literal
-
 from openff.units import unit
 from pydantic import Field
+from typing_extensions import Literal
 
 from openff.interchange.components.potentials import PotentialHandler
 from openff.interchange.types import FloatQuantity

--- a/openff/interchange/interop/intermol.py
+++ b/openff/interchange/interop/intermol.py
@@ -1,0 +1,228 @@
+"""Interfaces with InterMol."""
+from typing import List
+
+import mdtraj as md
+from intermol.forces import (
+    HarmonicAngle,
+    HarmonicBond,
+    TrigDihedral,
+    convert_dihedral_from_trig_to_proper,
+)
+from intermol.system import System
+from openff.units.openmm import from_openmm
+
+from openff.interchange.components.base import (
+    BaseAngleHandler,
+    BaseBondHandler,
+    BaseElectrostaticsHandler,
+    BaseProperTorsionHandler,
+    BasevdWHandler,
+)
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.components.mdtraj import _OFFBioTop
+from openff.interchange.components.potentials import Potential
+from openff.interchange.models import PotentialKey, TopologyKey
+
+
+def from_intermol_system(intermol_system: System) -> Interchange:
+    """Convert and Intermol `System` to an `Interchange` object."""
+    interchange = Interchange()
+
+    interchange.box = intermol_system.box_vector
+    interchange.positions = from_openmm([a.position for a in intermol_system.atoms])
+
+    vdw_handler = BasevdWHandler(
+        scale_14=intermol_system.lj_correction,
+        mixing_rule=intermol_system.combination_rule,
+    )
+
+    if vdw_handler.mixing_rule == "Multiply-Sigeps":
+        vdw_handler.mixing_rule = "geometric"
+
+    electrostatics_handler = BaseElectrostaticsHandler(
+        scale_14=intermol_system.coulomb_correction
+    )
+
+    bond_handler = BaseBondHandler()
+    angle_handler = BaseAngleHandler()
+    proper_handler = BaseProperTorsionHandler()
+
+    # TODO: Store atomtypes on a minimal topology, not as a list
+    atomtypes: List = [atom.atomtype[0] for atom in intermol_system.atoms]
+
+    topology = md.Topology()
+    default_chain = topology.add_chain()
+    default_residue = topology.add_residue(name="FOO", chain=default_chain)
+
+    for atom in intermol_system.atoms:
+        topology.add_atom(
+            name=atom.atomtype[0],
+            element=md.element.Element.getByMass(atom.mass[0]._value),  # type: ignore
+            residue=default_residue,
+            serial=atom.index - 1,
+        )
+        topology_key = TopologyKey(atom_indices=(atom.index - 1,))
+        vdw_key = PotentialKey(id=atom.atomtype[0], associated_handler="vdW")
+        electrostatics_key = PotentialKey(
+            id=atom.atomtype[0], associated_handler="Electrostatics"
+        )
+
+        # Intermol has an abstraction layer for multiple states, though only one is implemented
+        charge = from_openmm(atom.charge[0])
+        sigma = atom.sigma[0]
+        epsilon = atom.epsilon[0]
+
+        vdw_handler.slot_map[topology_key] = vdw_key
+        electrostatics_handler.slot_map[topology_key] = electrostatics_key
+
+        vdw_handler.potentials[vdw_key] = Potential(
+            parameters={"sigma": sigma, "epsilon": epsilon}
+        )
+        electrostatics_handler.potentials[electrostatics_key] = Potential(
+            parameters={"charge": charge}
+        )
+
+    for molecule_type in intermol_system.molecule_types.values():
+        for bond_force in molecule_type.bond_forces:
+            if type(bond_force) != HarmonicBond:
+                raise Exception
+
+            topology.add_bond(
+                atom1=topology._atoms[bond_force.atom1 - 1],  # type: ignore[attr-defined]
+                atom2=topology._atoms[bond_force.atom2 - 1],  # type: ignore[attr-defined]
+            )
+
+            topology_key = TopologyKey(
+                atom_indices=tuple(
+                    val - 1 for val in [bond_force.atom1, bond_force.atom2]
+                ),
+            )
+            potential_key = PotentialKey(
+                id=f"{atomtypes[bond_force.atom1-1]}-{atomtypes[bond_force.atom2-1]}",
+                associated_handler="Bonds",
+            )
+
+            bond_handler.slot_map[topology_key] = potential_key
+
+            if potential_key not in bond_handler:
+                potential = Potential(
+                    parameters={
+                        "k": from_openmm(bond_force.k),
+                        "length": from_openmm(bond_force.length),
+                    }
+                )
+
+                bond_handler.potentials[potential_key] = potential
+
+        for angle_force in molecule_type.angle_forces:
+            if type(angle_force) != HarmonicAngle:
+                raise Exception
+
+            topology_key = TopologyKey(
+                atom_indices=(
+                    tuple(
+                        val - 1
+                        for val in [
+                            angle_force.atom1,
+                            angle_force.atom2,
+                            angle_force.atom3,
+                        ]
+                    )
+                ),
+            )
+            potential_key = PotentialKey(
+                id=(
+                    f"{atomtypes[angle_force.atom1-1]}-{atomtypes[angle_force.atom2-1]}-"
+                    f"{atomtypes[angle_force.atom3-1]}"
+                ),
+                associated_handler="Angles",
+            )
+
+            angle_handler.slot_map[topology_key] = potential_key
+
+            if potential_key not in angle_handler.potentials:
+                potential = Potential(
+                    parameters={
+                        "k": from_openmm(angle_force.k),
+                        "angle": from_openmm(angle_force.theta),
+                    }
+                )
+
+                angle_handler.potentials[potential_key] = potential
+
+        for dihedral_force in molecule_type.dihedral_forces:
+
+            if type(dihedral_force) == TrigDihedral:
+                proper_dihedral_parameters = convert_dihedral_from_trig_to_proper(
+                    {
+                        "fc0": dihedral_force.fc0,
+                        "fc1": dihedral_force.fc1,
+                        "fc2": dihedral_force.fc2,
+                        "fc3": dihedral_force.fc3,
+                        "fc4": dihedral_force.fc4,
+                        "fc5": dihedral_force.fc5,
+                        "fc6": dihedral_force.fc6,
+                        "phi": dihedral_force.phi,
+                    }
+                )
+
+                if len(proper_dihedral_parameters) != 1:
+                    raise RuntimeError
+
+                proper_dihedral_parameters = proper_dihedral_parameters[0]
+
+            topology_key = TopologyKey(
+                atom_indices=(
+                    tuple(
+                        val - 1
+                        for val in [
+                            dihedral_force.atom1,
+                            dihedral_force.atom2,
+                            dihedral_force.atom3,
+                            dihedral_force.atom4,
+                        ]
+                    )
+                ),
+                mult=0,
+            )
+
+            def ensure_unique_key(handler: BaseProperTorsionHandler, key: TopologyKey):
+                if key in handler.slot_map:
+                    key.mult += 1  # type: ignore[operator]
+                    ensure_unique_key(handler, key)
+
+            ensure_unique_key(proper_handler, topology_key)
+
+            potential_key = PotentialKey(
+                id=(
+                    f"{atomtypes[dihedral_force.atom1 - 1]}-{atomtypes[dihedral_force.atom2 - 1]}-"
+                    f"{atomtypes[dihedral_force.atom3 - 1]}-{atomtypes[dihedral_force.atom4 - 1]}-"
+                    f"{topology_key.mult}"
+                ),
+                associated_handler="ProperTorsions",
+            )
+
+            proper_handler.slot_map[topology_key] = potential_key
+
+            if potential_key not in proper_handler.potentials:
+
+                potential = Potential(
+                    parameters={
+                        "phase": proper_dihedral_parameters["phi"],
+                        "periodicity": proper_dihedral_parameters["multiplicity"],
+                        "weight": proper_dihedral_parameters["weight"],
+                        "k": proper_dihedral_parameters["k"],
+                    }
+                )
+
+                proper_handler.potentials[potential_key] = potential
+
+    interchange.handlers["vdW"] = vdw_handler
+    interchange.handlers["Electrostatics"] = electrostatics_handler
+    interchange.handlers["Bonds"] = bond_handler
+    interchange.handlers["Angles"] = angle_handler
+    interchange.handlers["ProperTorsions"] = proper_handler
+
+    interchange.topology = _OFFBioTop(mdtop=topology)
+
+    return interchange

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -402,7 +402,7 @@ def from_top(top_file: IO, gro_file: IO):
 
             def ensure_unique_key(handler: BaseProperTorsionHandler, key: TopologyKey):
                 if key in handler.slot_map:
-                    key.mult += 1
+                    key.mult += 1  # type: ignore[operator]
                     ensure_unique_key(handler, key)
 
             ensure_unique_key(proper_handler, topology_key)

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -351,7 +351,6 @@ def _write_atomtypes_lj(
     for atom_idx, atom_type in typemap.items():
         atom = openff_sys.topology.mdtop.atom(atom_idx)
         mass = atom.element.mass
-        atomic_number = atom.element.atomic_number
         parameters = _get_lj_parameters(openff_sys, atom_idx)
         sigma = parameters["sigma"].to(unit.nanometer).magnitude
         epsilon = parameters["epsilon"].to(unit.Unit("kilojoule / mole")).magnitude

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -264,7 +264,7 @@ def from_top(top_file: IO, gro_file: IO):
     for atom in intermol_system.atoms:
         topology.add_atom(
             name=atom.atomtype[0],
-            element=md.element.Element.getByMass(atom.mass[0]._value),
+            element=md.element.Element.getByMass(atom.mass[0]._value),  # type: ignore
             residue=default_residue,
             serial=atom.index - 1,
         )
@@ -295,8 +295,8 @@ def from_top(top_file: IO, gro_file: IO):
                 raise Exception
 
             topology.add_bond(
-                atom1=topology._atoms[bond_force.atom1 - 1],
-                atom2=topology._atoms[bond_force.atom2 - 1],
+                atom1=topology._atoms[bond_force.atom1 - 1],  # type: ignore[attr-defined]
+                atom2=topology._atoms[bond_force.atom2 - 1],  # type: ignore[attr-defined]
             )
 
             topology_key = TopologyKey(
@@ -339,7 +339,7 @@ def from_top(top_file: IO, gro_file: IO):
 
             angle_handler.slot_map[topology_key] = potential_key
 
-            if potential_key not in angle_handler:
+            if potential_key not in angle_handler.potentials:
                 potential = Potential(
                     parameters={
                         "k": from_openmm(angle_force.k),

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -1,7 +1,7 @@
 """Interfaces with GROMACS."""
 import math
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Dict, List, Set, Tuple, Union
+from typing import IO, TYPE_CHECKING, Dict, Set, Tuple, Union
 
 import numpy as np
 from openff.units import unit
@@ -11,11 +11,10 @@ from openff.interchange.components.mdtraj import (
     _iterate_impropers,
     _iterate_pairs,
     _iterate_propers,
-    _OFFBioTop,
     _store_bond_partners,
 )
 from openff.interchange.exceptions import UnsupportedExportError
-from openff.interchange.models import PotentialKey, TopologyKey, VirtualSiteKey
+from openff.interchange.models import TopologyKey, VirtualSiteKey
 
 if TYPE_CHECKING:
     from openff.interchange.components.interchange import Interchange
@@ -218,228 +217,13 @@ def to_top(openff_sys: "Interchange", file_path: Union[Path, str]):
 
 def from_top(top_file: IO, gro_file: IO):
     """Read the contents of a GROMACS Topology (.top) file."""
-    import mdtraj as md
-    from intermol.forces import (
-        HarmonicAngle,
-        HarmonicBond,
-        TrigDihedral,
-        convert_dihedral_from_trig_to_proper,
-    )
     from intermol.gromacs.gromacs_parser import GromacsParser
-    from openff.units.openmm import from_openmm
 
-    from openff.interchange.components.base import (
-        BaseAngleHandler,
-        BaseBondHandler,
-        BaseElectrostaticsHandler,
-        BaseProperTorsionHandler,
-        BasevdWHandler,
-    )
-    from openff.interchange.components.interchange import Interchange
-    from openff.interchange.components.potentials import Potential
+    from openff.interchange.interop.intermol import from_intermol_system
 
     intermol_system = GromacsParser(top_file, gro_file).read()
 
-    interchange = Interchange()
-
-    interchange.box = intermol_system.box_vector
-    interchange.positions = from_openmm([a.position for a in intermol_system.atoms])
-
-    vdw_handler = BasevdWHandler(
-        scale_14=intermol_system.lj_correction,
-        mixing_rule=intermol_system.combination_rule,
-    )
-
-    if vdw_handler.mixing_rule == "Multiply-Sigeps":
-        vdw_handler.mixing_rule = "geometric"
-
-    electrostatics_handler = BaseElectrostaticsHandler(
-        scale_14=intermol_system.coulomb_correction
-    )
-
-    bond_handler = BaseBondHandler()
-    angle_handler = BaseAngleHandler()
-    proper_handler = BaseProperTorsionHandler()
-
-    # TODO: Store atomtypes on a minimal topology, not as a list
-    atomtypes: List = [atom.atomtype[0] for atom in intermol_system.atoms]
-
-    topology = md.Topology()
-    default_chain = topology.add_chain()
-    default_residue = topology.add_residue(name="FOO", chain=default_chain)
-
-    for atom in intermol_system.atoms:
-        topology.add_atom(
-            name=atom.atomtype[0],
-            element=md.element.Element.getByMass(atom.mass[0]._value),  # type: ignore
-            residue=default_residue,
-            serial=atom.index - 1,
-        )
-        topology_key = TopologyKey(atom_indices=(atom.index - 1,))
-        vdw_key = PotentialKey(id=atom.atomtype[0], associated_handler="vdW")
-        electrostatics_key = PotentialKey(
-            id=atom.atomtype[0], associated_handler="Electrostatics"
-        )
-
-        # Intermol has an abstraction layer for multiple states, though only one is implemented
-        charge = from_openmm(atom.charge[0])
-        sigma = atom.sigma[0]
-        epsilon = atom.epsilon[0]
-
-        vdw_handler.slot_map[topology_key] = vdw_key
-        electrostatics_handler.slot_map[topology_key] = electrostatics_key
-
-        vdw_handler.potentials[vdw_key] = Potential(
-            parameters={"sigma": sigma, "epsilon": epsilon}
-        )
-        electrostatics_handler.potentials[electrostatics_key] = Potential(
-            parameters={"charge": charge}
-        )
-
-    for molecule_type in intermol_system.molecule_types.values():
-        for bond_force in molecule_type.bond_forces:
-            if type(bond_force) != HarmonicBond:
-                raise Exception
-
-            topology.add_bond(
-                atom1=topology._atoms[bond_force.atom1 - 1],  # type: ignore[attr-defined]
-                atom2=topology._atoms[bond_force.atom2 - 1],  # type: ignore[attr-defined]
-            )
-
-            topology_key = TopologyKey(
-                atom_indices=tuple(
-                    val - 1 for val in [bond_force.atom1, bond_force.atom2]
-                ),
-            )
-            potential_key = PotentialKey(
-                id=f"{atomtypes[bond_force.atom1-1]}-{atomtypes[bond_force.atom2-1]}",
-                associated_handler="Bonds",
-            )
-
-            bond_handler.slot_map[topology_key] = potential_key
-
-            if potential_key not in bond_handler:
-                potential = Potential(
-                    parameters={
-                        "k": from_openmm(bond_force.k),
-                        "length": from_openmm(bond_force.length),
-                    }
-                )
-
-                bond_handler.potentials[potential_key] = potential
-
-        for angle_force in molecule_type.angle_forces:
-            if type(angle_force) != HarmonicAngle:
-                raise Exception
-
-            topology_key = TopologyKey(
-                atom_indices=(
-                    tuple(
-                        val - 1
-                        for val in [
-                            angle_force.atom1,
-                            angle_force.atom2,
-                            angle_force.atom3,
-                        ]
-                    )
-                ),
-            )
-            potential_key = PotentialKey(
-                id=(
-                    f"{atomtypes[angle_force.atom1-1]}-{atomtypes[angle_force.atom2-1]}-"
-                    f"{atomtypes[angle_force.atom3-1]}"
-                ),
-                associated_handler="Angles",
-            )
-
-            angle_handler.slot_map[topology_key] = potential_key
-
-            if potential_key not in angle_handler.potentials:
-                potential = Potential(
-                    parameters={
-                        "k": from_openmm(angle_force.k),
-                        "angle": from_openmm(angle_force.theta),
-                    }
-                )
-
-                angle_handler.potentials[potential_key] = potential
-
-        for dihedral_force in molecule_type.dihedral_forces:
-
-            if type(dihedral_force) == TrigDihedral:
-                proper_dihedral_parameters = convert_dihedral_from_trig_to_proper(
-                    {
-                        "fc0": dihedral_force.fc0,
-                        "fc1": dihedral_force.fc1,
-                        "fc2": dihedral_force.fc2,
-                        "fc3": dihedral_force.fc3,
-                        "fc4": dihedral_force.fc4,
-                        "fc5": dihedral_force.fc5,
-                        "fc6": dihedral_force.fc6,
-                        "phi": dihedral_force.phi,
-                    }
-                )
-
-                if len(proper_dihedral_parameters) != 1:
-                    raise RuntimeError
-
-                proper_dihedral_parameters = proper_dihedral_parameters[0]
-
-            topology_key = TopologyKey(
-                atom_indices=(
-                    tuple(
-                        val - 1
-                        for val in [
-                            dihedral_force.atom1,
-                            dihedral_force.atom2,
-                            dihedral_force.atom3,
-                            dihedral_force.atom4,
-                        ]
-                    )
-                ),
-                mult=0,
-            )
-
-            def ensure_unique_key(handler: BaseProperTorsionHandler, key: TopologyKey):
-                if key in handler.slot_map:
-                    key.mult += 1  # type: ignore[operator]
-                    ensure_unique_key(handler, key)
-
-            ensure_unique_key(proper_handler, topology_key)
-
-            potential_key = PotentialKey(
-                id=(
-                    f"{atomtypes[dihedral_force.atom1 - 1]}-{atomtypes[dihedral_force.atom2 - 1]}-"
-                    f"{atomtypes[dihedral_force.atom3 - 1]}-{atomtypes[dihedral_force.atom4 - 1]}-"
-                    f"{topology_key.mult}"
-                ),
-                associated_handler="ProperTorsions",
-            )
-
-            proper_handler.slot_map[topology_key] = potential_key
-
-            if potential_key not in proper_handler.potentials:
-
-                potential = Potential(
-                    parameters={
-                        "phase": proper_dihedral_parameters["phi"],
-                        "periodicity": proper_dihedral_parameters["multiplicity"],
-                        "weight": proper_dihedral_parameters["weight"],
-                        "k": proper_dihedral_parameters["k"],
-                    }
-                )
-
-                proper_handler.potentials[potential_key] = potential
-
-    interchange.handlers["vdW"] = vdw_handler
-    interchange.handlers["Electrostatics"] = electrostatics_handler
-    interchange.handlers["Bonds"] = bond_handler
-    interchange.handlers["Angles"] = angle_handler
-    interchange.handlers["ProperTorsions"] = proper_handler
-
-    interchange.topology = _OFFBioTop(mdtop=topology)
-
-    return interchange
+    return from_intermol_system(intermol_system)
 
 
 def _write_top_defaults(openff_sys: "Interchange", top_file: IO):

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -236,7 +236,7 @@ def from_top(top_file: IO, gro_file: IO):
 
     interchange = Interchange()
 
-    interchange.box_vectors = intermol_system.box_vector
+    interchange.box = intermol_system.box_vector
     interchange.positions = from_openmm([a.position for a in intermol_system.atoms])
 
     vdw_handler = BasevdWHandler(
@@ -380,7 +380,7 @@ def _write_top_defaults(openff_sys: "Interchange", top_file: IO):
             "with GROMACS. Looked for handlers named `vdW` and `Buckingham-6`."
         )
 
-    mixing_rule = openff_sys[handler_key].mixing_rule
+    mixing_rule = openff_sys[handler_key].mixing_rule.lower()
     if mixing_rule == "lorentz-berthelot":
         comb_rule = 2
     elif mixing_rule == "geometric":
@@ -479,9 +479,7 @@ def _write_atomtypes_lj(
 ):
     """Write the [ atomtypes ] section when all atoms use the LJ potential."""
     top_file.write("[ atomtypes ]\n")
-    top_file.write(
-        ";type, bondingtype, atomic_number, mass, charge, ptype, sigma, epsilon\n"
-    )
+    top_file.write(";type, bondingtype, mass, charge, ptype, sigma, epsilon\n")
 
     for atom_idx, atom_type in typemap.items():
         atom = openff_sys.topology.mdtop.atom(atom_idx)
@@ -492,10 +490,9 @@ def _write_atomtypes_lj(
         epsilon = parameters["epsilon"].to(unit.Unit("kilojoule / mole")).magnitude
         # top.write('{0:<11s} {1:5s} {2:6d} {3:18.8f} {4:18.8f} {5:5s}'.format(
         top_file.write(
-            "{:<11s} {:6s} {:6d} {:.16g} {:.16g} {:5s} {:.16g} {:.16g}\n".format(
+            "{:<11s} {:6s} {:.16g} {:.16f} {:5s} {:.16g} {:.16g}\n".format(
                 atom_type,  # atom type
                 "XX",  # atom "bonding type", i.e. bond class
-                atomic_number,
                 mass,
                 0.0,  # charge, overriden later in [ atoms ]
                 "A",  # ptype
@@ -638,10 +635,10 @@ def _write_atoms(
     _store_bond_partners(openff_sys.topology.mdtop)
 
     try:
-        mixing_rule = openff_sys["vdW"].mixing_rule
+        mixing_rule = openff_sys["vdW"].mixing_rule.lower()
         scale_lj = openff_sys["vdW"].scale_14
     except LookupError:
-        mixing_rule = openff_sys["Buckingham-6"].mixing_rule
+        mixing_rule = openff_sys["Buckingham-6"].mixing_rule.lower()
         scale_lj = openff_sys["Buckingham-6"].scale_14
 
     # Use a set to de-duplicate

--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -432,7 +432,10 @@ def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=F
                     f"Electrostatics method {electrostatics_method} not supported"
                 )
 
-        partial_charges = electrostatics_handler.charges_with_virtual_sites
+        try:
+            partial_charges = electrostatics_handler.charges_with_virtual_sites
+        except AttributeError:
+            partial_charges = electrostatics_handler.charges
 
         for top_key, pot_key in vdw_handler.slot_map.items():
             # TODO: Actually process virtual site vdW parameters here

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=numpy,pandas,openff.toolkit,openff.units,pint,pytest,openmm,mdtraj,pydantic,parmed,pmdtest
+known_third_party=numpy,pandas,openff.toolkit,openff.units,pint,pytest,openmm,mdtraj,intermol,pydantic,parmed,pmdtest
 
 [pydocstyle]
 match=((?!test|_version).)*\.py
@@ -49,13 +49,13 @@ plugins = numpy.typing.mypy_plugin
 [mypy-pandas.*]
 ignore_missing_imports = True
 
-[mypy-mdtraj]
-ignore_missing_imports = True
-
 [mypy-openmm]
 ignore_missing_imports = True
 
 [mypy-openmm.unit]
+ignore_missing_imports = True
+
+[mypy-intermol.*]
 ignore_missing_imports = True
 
 [mypy-rdkit]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ per-file-ignores =
     openff/interchange/components/interchange.py:F821
     openff/interchange/components/smirnoff.py:F821
     openff/interchange/components/foyer.py:F821
+    openff/interchange/components/base.py:F821
 
 [isort]
 multi_line_output=3

--- a/stubs/mdtraj/__init__.pyi
+++ b/stubs/mdtraj/__init__.pyi
@@ -1,5 +1,17 @@
-from typing import Any
+from typing import Any, Optional, NoReturn
 
 class Topology(object):
     @classmethod
     def from_openmm(cls, value: Any) -> Topology: ...
+    def add_chain(self) -> Any: ...
+    def add_residue(self, name: str, chain: Any) -> Any: ...
+    def add_atom(
+        self, name: str, element: Any, residue: Any, serial: int
+    ) -> NoReturn: ...
+    def add_bond(
+        self,
+        atom1: Any,
+        atom2: Any,
+        type: Optional[Any] = None,
+        order: Optional[int] = None,
+    ) -> NoReturn: ...


### PR DESCRIPTION
### Description
This PR adds a not-fully-scoped GROMACS topology reader. As of today I can round-trip a test file into something that looks decent for the sections that are implemented; I have not yet tested if they will run.

It currently is little more than a converted from an InterMol object, which is responsible for the heavy lifting. I may continue to build out that conversion layer, but I will also start to refactor it out in favor of internal parsers. I have found InterMol's object models to be more straightforward so far, and I hope they are a more feasible starting point for refactoring than ParmEd.

Part of this necessarily chips away at #301, especially while upstream functionality in the toolkit is not yet being worked on.

Note that full - or even just generally useful - GROMACS parsers are blocked by the topology refactor.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
