### PR TITLE
Skip unavailable drivers instead of erroring out

### DIFF
--- a/openff/interchange/drivers/all.py
+++ b/openff/interchange/drivers/all.py
@@ -29,7 +29,7 @@ def get_all_energies(interchange: "Interchange") -> Dict[str, EnergyReport]:
 
     for engine_name, engine_driver, engine_exception in [
         ("Amber", get_amber_energies, AmberError),
-        ("Gromacs", get_gromacs_energies, GMXRunError),
+        ("GROMACS", get_gromacs_energies, GMXRunError),
         ("LAMMPS", get_lammps_energies, LAMMPSRunError),
     ]:
         try:

--- a/openff/interchange/drivers/all.py
+++ b/openff/interchange/drivers/all.py
@@ -33,7 +33,7 @@ def get_all_energies(interchange: "Interchange") -> Dict[str, EnergyReport]:
         ("LAMMPS", get_lammps_energies, LAMMPSRunError),
     ]:
         try:
-            all_energies[engine_name] = engine_driver(interchange)
+            all_energies[engine_name] = engine_driver(interchange)  # type: ignore[operator]
         except engine_exception:
             pass
 

--- a/openff/interchange/drivers/all.py
+++ b/openff/interchange/drivers/all.py
@@ -8,6 +8,7 @@ from openff.interchange.drivers.gromacs import get_gromacs_energies
 from openff.interchange.drivers.lammps import get_lammps_energies
 from openff.interchange.drivers.openmm import get_openmm_energies
 from openff.interchange.drivers.report import EnergyReport
+from openff.interchange.exceptions import AmberError, GMXRunError, LAMMPSRunError
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -22,12 +23,21 @@ def get_all_energies(interchange: "Interchange") -> Dict[str, EnergyReport]:
     # TODO: Return something nan-like if one driver fails, but still return others that succeed
     # TODO: Have each driver return the version of the engine that was used
 
-    return {
+    all_energies = {
         "OpenMM": get_openmm_energies(interchange),
-        "GROMACS": get_gromacs_energies(interchange),
-        "LAMMPS": get_lammps_energies(interchange),
-        "Amber": get_amber_energies(interchange, writer="internal"),
     }
+
+    for engine_name, engine_driver, engine_exception in [
+        ("Amber", get_amber_energies, AmberError),
+        ("Gromacs", get_gromacs_energies, GMXRunError),
+        ("LAMMPS", get_lammps_energies, LAMMPSRunError),
+    ]:
+        try:
+            all_energies[engine_name] = engine_driver(interchange)
+        except engine_exception:
+            pass
+
+    return all_energies
 
 
 @requires_package("pandas")

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -189,6 +189,12 @@ class AmberError(BaseException):
     """
 
 
+class AmberExecutableNotFoundError(AmberError):
+    """
+    Exception for when an Amber-related excutable is not found.
+    """
+
+
 class SanderError(AmberError):
     """
     Exception for when a sander subprocess fails.

--- a/openff/interchange/unit_tests/drivers/test_all.py
+++ b/openff/interchange/unit_tests/drivers/test_all.py
@@ -1,0 +1,38 @@
+"""
+Test the behavior of the drivers.all module
+"""
+from distutils.spawn import find_executable
+
+from openff.interchange.drivers.all import get_all_energies
+from openff.interchange.testing import _BaseTest
+
+
+class TestDriversAll(_BaseTest):
+    def test_skipping_drivers(self, ethanol_top, parsley):
+        from openff.toolkit.topology import Molecule
+
+        from openff.interchange.components.interchange import Interchange
+
+        molecule = Molecule.from_smiles("C")
+        molecule.generate_conformers(n_conformers=1)
+        molecule.name = "MOL"
+        topology = molecule.to_topology()
+
+        out = Interchange.from_smirnoff(parsley, topology)
+        out.positions = molecule.conformers[0]
+        out.box = [4, 4, 4]
+
+        summary = get_all_energies(out)
+
+        assert ("GROMACS" in summary) == (find_executable("gmx") is not None)
+
+        assert ("Amber" in summary) == (find_executable("sander") is not None)
+
+        assert ("LAMMPS" in summary) == (find_executable("lmp_serial") is not None)
+
+        number_expected_drivers = 1 + sum(
+            int(find_executable(exec) is not None)
+            for exec in ["gmx", "lmp_serial", "sander"]
+        )
+
+        assert len(summary) == number_expected_drivers

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ test = pytest
 [mypy]
 mypy_path = stubs/
 plugins = numpy.typing.mypy_plugin
+warn_unused_configs = True
+warn_unused_ignores = True
+show_error_codes = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True


### PR DESCRIPTION
### Description
I implemented `get_all_energies` in a naive and unsafe way, resulting in errors when any driver is not installed. Now, a row is skipped if the driver is uninstalled and/or fails (this could be changed later to be more robust).

In an environment with AmberTools forcefully removed:
```
In [18]: !which antechamber
antechamber not found

In [19]: !which sander
sander not found

In [20]: get_summary_data(out)
Out[20]:
             Bond      Angle    Torsion       vdW  Electrostatics
OpenMM   2.222557  72.962517  15.890858 -0.267811      -27.622730
Gromacs  2.222573  72.962593  15.890857 -0.264045      -27.627102
LAMMPS   2.222439  72.962517  15.890873 -0.271789      -27.611731

```

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
