### PR TITLE
Fix setting byte order while processing bytes to NumPy arrays

### DIFF
--- a/openff/interchange/types.py
+++ b/openff/interchange/types.py
@@ -201,8 +201,7 @@ else:
                         return val * unit_
                 if isinstance(val, bytes):
                     # Define outside loop
-                    dt = np.dtype(int)
-                    dt.newbyteorder("<")
+                    dt = np.dtype(int).newbyteorder("<")
                     return np.frombuffer(val, dtype=dt) * unit_
                 if isinstance(val, str):
                     # could do custom deserialization here?


### PR DESCRIPTION
### Description
Might fix #345, although as discussed there it's not tested in our current infrastructure and may or may not actually be relevant.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
