### PR TITLE
Update positions processing in `Interchange.__add__`

### DIFF
--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -584,8 +584,14 @@ class Interchange(DefaultModel):
                 self_handler.slot_map.update({new_top_key: pot_key})
                 self_handler.potentials.update({pot_key: handler.potentials[pot_key]})
 
-        new_positions = np.vstack([self_copy.positions, other.positions])
-        self_copy.positions = new_positions
+        if self_copy.positions is not None and other.positions is not None:
+            new_positions = np.vstack([self_copy.positions, other.positions])
+            self_copy.positions = new_positions
+        else:
+            warnings.warn(
+                "Setting positions to None because one or both objects added together were missing positions."
+            )
+            self_copy.positions = None
 
         if not np.all(self_copy.box == other.box):
             raise NotImplementedError(

--- a/openff/interchange/unit_tests/components/test_interchange.py
+++ b/openff/interchange/unit_tests/components/test_interchange.py
@@ -123,6 +123,32 @@ class TestInterchangeCombination(_BaseTest):
 
         # TODO: Ensure the de-duplication is maintained after exports
 
+    def test_positions_setting(self):
+        """Test that positions exist on the result if and only if
+        both input objects have positions."""
+
+        ethane = Molecule.from_smiles("CC")
+        ethane.generate_conformers(n_conformers=1)
+        methane = Molecule.from_smiles("C")
+        methane.generate_conformers(n_conformers=1)
+
+        force_field = ForceField("openff_unconstrained-1.3.0.offxml")
+
+        ethane_interchange = Interchange.from_smirnoff(
+            force_field,
+            ethane.to_topology(),
+        )
+        methane_interchange = Interchange.from_smirnoff(
+            force_field,
+            methane.to_topology(),
+        )
+
+        assert not (methane_interchange + ethane_interchange).positions
+        methane_interchange.positions = methane.conformers[0]
+        assert not (methane_interchange + ethane_interchange).positions
+        ethane_interchange.positions = ethane.conformers[0]
+        assert (methane_interchange + ethane_interchange).positions is not None
+
 
 class TestUnimplementedSMIRNOFFCases(_BaseTest):
     def test_bogus_smirnoff_handler(self, parsley):


### PR DESCRIPTION
### Description
This PR updates the behavior of `Interchange.__add__` to set the positions to `None` if either input `Interchange` object is missing positions. Currently, it will error out with no helpful message.

Pesudocode:
```python3
a: Interchange = Interchange.from_x(...)
a.positions = None
b: Interchange = Interchange.from_x(...)
b.positions = None

(a + b).positions
# None

a.positions = some_positions_array

(a + b).positions
# None, with a warning

b.positions = some_positions_array

(a + b).positions
# np.vstack([a, b])
```
### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
