### PR TITLE
Update pytest and pre-commit configurations

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Run all tests
       if: always()
       run: |
-        python -m pytest -v $COV openff/interchange/
+        python -m pytest -v $COV openff/interchange/ -m "slow or not slow"
 
     - name: Run example notebooks
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
     - name: Run all tests
       if: always()
       run: |
-        python -m pytest -v -nauto $COV openff/interchange/
+        python -m pytest -v -nauto $COV openff/interchange/ -m "slow or not slow"
 
     - name: Run example notebooks
       run: |

--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -56,4 +56,4 @@ jobs:
     - name: Run unit tests
       if: always()
       run: |
-        python -m pytest -v -nauto -m "not slow" openff/interchange/unit_tests/
+        python -m pytest -v -nauto openff/interchange/unit_tests/

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Run all tests
       if: always()
       run: |
-        python -m pytest -v $COV openff/interchange/
+        python -m pytest -v $COV openff/interchange/ -m "slow or not slow"
 
     - name: Run example notebooks
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+fail_fast: true
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
@@ -12,7 +13,6 @@ repos:
   hooks:
   - id: black
     files: ^openff
-    args: [--check]
   - id: black-jupyter
     files: ^examples
 - repo: https://github.com/PyCQA/isort
@@ -20,7 +20,6 @@ repos:
   hooks:
   - id: isort
     files: ^openff
-    args: [--check]
 - repo: https://github.com/PyCQA/flake8
   rev: 4.0.1
   hooks:

--- a/openff/interchange/energy_tests/test_energies.py
+++ b/openff/interchange/energy_tests/test_energies.py
@@ -185,6 +185,7 @@ def test_liquid_argon():
 
 
 @needs_gmx
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     "toolkit_file_path",
     [

--- a/openff/interchange/interoperability_tests/internal/test_amber.py
+++ b/openff/interchange/interoperability_tests/internal/test_amber.py
@@ -32,6 +32,7 @@ class TestAmber(_BaseTest):
 
         np.testing.assert_equal(coords1, coords2)
 
+    @pytest.mark.slow()
     @pytest.mark.parametrize(
         "smiles",
         [

--- a/openff/interchange/interoperability_tests/internal/test_gromacs.py
+++ b/openff/interchange/interoperability_tests/internal/test_gromacs.py
@@ -81,6 +81,7 @@ class TestGROMACSGROFile(_BaseTest):
 
 @needs_gmx
 class TestGROMACS(_BaseTest):
+    @pytest.mark.slow()
     @pytest.mark.parametrize("reader", ["intermol", "internal"])
     @pytest.mark.parametrize(
         "smiles",

--- a/openff/interchange/interoperability_tests/test_openmm.py
+++ b/openff/interchange/interoperability_tests/test_openmm.py
@@ -247,6 +247,7 @@ def test_combine_nonbonded_forces():
     ).m < 0.001
 
 
+@pytest.mark.slow()
 class TestOpenMMVirtualSites(_BaseTest):
     @pytest.fixture()
     def parsley_with_sigma_hole(self, parsley):

--- a/openff/interchange/unit_tests/drivers/test_all.py
+++ b/openff/interchange/unit_tests/drivers/test_all.py
@@ -3,10 +3,13 @@ Test the behavior of the drivers.all module
 """
 from distutils.spawn import find_executable
 
+import pytest
+
 from openff.interchange.drivers.all import get_all_energies
 from openff.interchange.testing import _BaseTest
 
 
+@pytest.mark.slow()
 class TestDriversAll(_BaseTest):
     def test_skipping_drivers(self, ethanol_top, parsley):
         from openff.toolkit.topology import Molecule

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+addopts = -m "not slow"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,8 @@
-# Helper file to handle all configs
-
 [coverage:run]
-# .coveragerc to control coverage.py and pytest-cov
 omit =
-    # Omit generated versioneer
     openff/interchange/_version.py
 
 [flake8]
-# Flake8, PyFlakes, etc
 max-line-length = 119
 ignore = E203
 per-file-ignores =
@@ -33,15 +28,11 @@ ignore=D105,D107,D200,D203,D212
 ignore_decorators=validator
 
 [versioneer]
-# Automatic version numbering scheme
 VCS = git
 style = pep440
 versionfile_source = openff/interchange/_version.py
 versionfile_build = openff/interchange/_version.py
 tag_prefix = ''
-
-[aliases]
-test = pytest
 
 [mypy]
 mypy_path = stubs/


### PR DESCRIPTION
### Description
Slow tests (hitting a ton of AM1-BCC calculations, running entire liquid boxes, or other energy tests) slow down my development on my poor little hardware, so I am turning them off in the default configuration, but letting them run completely in CI. `pytest -v openff --durations=20 -m slow` now runs in about 40 seconds, down from several minutes.
