### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       COV: --cov=openff/interchange --cov-report=xml --cov-config=setup.cfg --cov-append

--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -6,7 +6,9 @@ For topics or details not specified, refer to the [development guidelines]( http
 
 ## Supported Python versions
 
-Generally, follow [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). This means that currently Python 3.7-3.9 are supported as of the inception of this document (February 2021). No effort needs to be made to support older versions (Python 2 or 3.6 or earlier) or newer versions that are not well-supported by the [PyData](https://pydata.org) stack.
+Generally, follow [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). This means that currently Python 3.8-3.9 are supported as of the last update of this document (January 2022). No effort needs to be made to support older versions (Python 2 or 3.7 or earlier) or newer versions that are not well-supported by the [PyData](https://pydata.org) stack.
+
+The last release with support for Python 3.7 wass v0.1.3.
 
 ## Style
 


### PR DESCRIPTION
### Description
This PR removes Python 3.7 from CI and updates the developer docs accordingly. The next release will constrain `python >=3.8` at install time.

NumPy removed support for Python 3.7 last month as described in [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
