### PR TITLE
Fix RTD build and update Sphinx

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -22,6 +22,6 @@ dependencies:
   - myst-parser
   - numpydoc
   - autodoc-pydantic
-  - sphinx=4.2.0
+  - sphinx>=4.4.0,<5
   - pip:
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ autosummary_context = {
         "openff.interchange.tests",
     ],
 }
+autosummary_ignore_module_all = False
 napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
@@ -85,6 +86,7 @@ autodoc_default_options = {
 }
 autodoc_preserve_defaults = True
 autodoc_inherit_docstrings = False
+autodoc_typehints_format = "short"
 
 # autodoc_pydantic settings
 autodoc_pydantic_show_config = False

--- a/openff/interchange/components/foyer.py
+++ b/openff/interchange/components/foyer.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 from copy import copy
 from typing import TYPE_CHECKING, Dict, Type
 
-from foyer.topology_graph import TopologyGraph
 from openff.units import unit
 from openff.utilities.utilities import has_package, requires_package
 from parmed import periodic_table
@@ -26,6 +25,7 @@ POTENTIAL_KEY_SEPARATOR = "-"
 
 
 if has_package("foyer"):
+    from foyer.topology_graph import TopologyGraph
 
     class _TopologyGraph(TopologyGraph):
         """Shim to get TopologyGraph.from_openff_topology working with the Topology refactor."""


### PR DESCRIPTION
### Description
Closes #378, which was due to `openff/interchange/components/foyer.py` having a `foyer` import outside the check that the package exists. This caused imports of this particular module to fail when foyer is unavailable, such as in the RTD environment. Tests that imports are successful on different environments might be worth looking into. 

This PR also updates Sphinx to 4.4.0, which comes with a lot of improvements to the API docs (and has a marginally more informative error message for the above problem)

### Checklist
- [ ] Add tests
- [x] Lint
