### PR TITLE
 Error out if passed a force field missing required Electrostatics

### DIFF
--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -17,6 +17,7 @@ from openff.interchange.components.smirnoff import (
     SMIRNOFFBondHandler,
     SMIRNOFFConstraintHandler,
 )
+from openff.interchange.components.toolkit import _check_electrostatics_handlers
 from openff.interchange.exceptions import (
     InternalInconsistencyError,
     InvalidBoxError,
@@ -188,6 +189,13 @@ class Interchange(DefaultModel):
         sys_out = Interchange()
 
         cls._check_supported_handlers(force_field)
+
+        if "Electrostatics" not in force_field.registered_parameter_handlers:
+            if _check_electrostatics_handlers(force_field):
+                raise MissingParameterHandlerError(
+                    "Force field contains parameter handler(s) that may assign/modify "
+                    "partial charges, but no ElectrostaticsHandler was found."
+                )
 
         sys_out.topology = topology
 

--- a/openff/interchange/tests/__init__.py
+++ b/openff/interchange/tests/__init__.py
@@ -114,14 +114,53 @@ class _BaseTest:
     def two_peptides(self, mainchain_ala, mainchain_arg):
         return Topology.from_molecules([mainchain_ala, mainchain_arg])
 
+    @pytest.fixture()
+    def tip3p_missing_electrostatics_xml(self):
+        # Stripped from below, follow link for details
+        # https://github.com/openforcefield/openff-toolkit/blob/0.10.2/openff/toolkit/data/test_forcefields/tip3p.offxml
+        return """<?xml version="1.0" encoding='ASCII'?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <vdW
+    version="0.3"
+    potential="Lennard-Jones-12-6"
+    combining_rules="Lorentz-Berthelot"
+    scale12="0.0"
+    scale13="0.0"
+    scale14="0.5"
+    scale15="1"
+    switch_width="1.0*angstroms"
+    cutoff="9.0*angstroms" method="cutoff"
+  >
+    <Atom
+      smirks="[#1]-[#8X2H2+0:1]-[#1]"
+      id="n1"
+      sigma="0.31507524065751241*nanometers"
+      epsilon="0.635968*kilojoules_per_mole"
+    />
+    <Atom
+      smirks="[#1:1]-[#8X2H2+0]-[#1]"
+      id="n2"
+      sigma="1*nanometers"
+      epsilon="0*kilojoules_per_mole" />
+  </vdW>
+  <LibraryCharges version="0.3">
+    <LibraryCharge
+        name="TIP3P"
+        smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
+        charge1="0.417*elementary_charge"
+        charge2="-0.834*elementary_charge"
+        charge3="0.417*elementary_charge"/>
+  </LibraryCharges>
+</SMIRNOFF>"""
+
     xml_ff_bo_bonds = """<?xml version='1.0' encoding='ASCII'?>
     <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
       <Bonds version="0.3" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
         <Bond smirks="[#6:1]~[#8:2]" id="bbo1"
-            k_bondorder1="100.0 * kilocalories_per_mole/angstrom**2"
-            k_bondorder2="1000.0 * kilocalories_per_mole/angstrom**2"
-            length_bondorder1="1.5 * angstrom"
-            length_bondorder2="1.0 * angstrom"/>
+            k_bondorder1="100.0*kilocalories_per_mole/angstrom**2"
+            k_bondorder2="1000.0*kilocalories_per_mole/angstrom**2"
+            length_bondorder1="1.5*angstrom"
+            length_bondorder2="1.0*angstrom"/>
       </Bonds>
     </SMIRNOFF>
     """

--- a/openff/interchange/tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/tests/unit_tests/components/test_interchange.py
@@ -91,7 +91,7 @@ class TestInterchange(_BaseTest):
 
         out = Interchange.from_smirnoff(tip3p, topology)
 
-        assert out.cutoff == 7.89 * unit.angstrom
+        assert out["Electrostatics"].cutoff == 7.89 * unit.angstrom
 
     def test_box_setter(self):
         tmp = Interchange()

--- a/openff/interchange/tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/tests/unit_tests/components/test_interchange.py
@@ -4,7 +4,11 @@ import mdtraj as md
 import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule, Topology
-from openff.toolkit.typing.engines.smirnoff import ParameterHandler
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff.parameters import (
+    ElectrostaticsHandler,
+    ParameterHandler,
+)
 from openff.units import unit
 from openff.utilities.testing import skip_if_missing
 from pydantic import ValidationError
@@ -64,6 +68,30 @@ class TestInterchange(_BaseTest):
 
         with pytest.raises(MissingParametersError, match=r"atoms \(0, 100\)"):
             out._get_parameters("Bonds", (0, 100))
+
+    def test_missing_electrostatics_handler(self, tip3p_missing_electrostatics_xml):
+        """Test that an error is raised when an electrostatics handler is missing"""
+        molecule = Molecule.from_smiles("O")
+        topology = Topology.from_molecules(molecule)
+        topology.box_vectors = unit.Quantity([4, 4, 4], units=unit.nanometer)
+
+        tip3p_missing_electrostatics = ForceField(tip3p_missing_electrostatics_xml)
+
+        with pytest.raises(MissingParameterHandlerError, match="modify partial"):
+            Interchange.from_smirnoff(tip3p_missing_electrostatics, topology)
+
+        tip3p = deepcopy(tip3p_missing_electrostatics)
+
+        dummy_electrostatics_handler = ElectrostaticsHandler(skip_version_check=True)
+        tip3p.register_parameter_handler(dummy_electrostatics_handler)
+
+        Interchange.from_smirnoff(tip3p, topology)
+
+        tip3p["Electrostatics"].cutoff = 7.89 * unit.angstrom
+
+        out = Interchange.from_smirnoff(tip3p, topology)
+
+        assert out.cutoff == 7.89 * unit.angstrom
 
     def test_box_setter(self):
         tmp = Interchange()

--- a/openff/interchange/tests/unit_tests/components/test_toolkit.py
+++ b/openff/interchange/tests/unit_tests/components/test_toolkit.py
@@ -1,13 +1,29 @@
 import pytest
 from openff.toolkit.topology.molecule import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
-from openff.interchange.components.toolkit import _get_14_pairs
-
-
-@pytest.mark.parametrize(
-    ("smiles", "num_pairs"), [("C#C", 1), ("CCO", 12), ("C1=CC=CC=C1", 24)]
+from openff.interchange.components.toolkit import (
+    _check_electrostatics_handlers,
+    _get_14_pairs,
 )
-def test_get_14_pairs(smiles, num_pairs):
-    mol = Molecule.from_smiles(smiles)
-    assert len([*_get_14_pairs(mol)]) == num_pairs
-    assert len([*_get_14_pairs(mol.to_topology())]) == num_pairs
+from openff.interchange.tests import _BaseTest
+
+
+class TestToolkitUtils(_BaseTest):
+    @pytest.mark.parametrize(
+        ("smiles", "num_pairs"), [("C#C", 1), ("CCO", 12), ("C1=CC=CC=C1", 24)]
+    )
+    def test_get_14_pairs(self, smiles, num_pairs):
+        mol = Molecule.from_smiles(smiles)
+        assert len([*_get_14_pairs(mol)]) == num_pairs
+        assert len([*_get_14_pairs(mol.to_topology())]) == num_pairs
+
+    def test_check_electrostatics_handlers(self, tip3p_missing_electrostatics_xml):
+        # https://github.com/openforcefield/openff-toolkit/blob/0.10.2/openff/toolkit/data/test_forcefields/tip3p.offxml
+        tip3p_missing_electrostatics = ForceField(tip3p_missing_electrostatics_xml)
+
+        assert _check_electrostatics_handlers(tip3p_missing_electrostatics)
+
+        tip3p_missing_electrostatics.deregister_parameter_handler("LibraryCharges")
+
+        assert not _check_electrostatics_handlers(tip3p_missing_electrostatics)


### PR DESCRIPTION
### Description
A quick pass at safeguarding against https://github.com/openforcefield/openff-toolkit/issues/716

> The desired behavior would be to raise an exception if the ESHandler doesn't exist, but the system has partial charges that will interact.


### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
