### PR TITLE
Split out examples in CI, trim some heavy/unused test dependencies

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -15,8 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
-        python-version: [3.8, 3.9]
+        os:
+          - macOS-latest
+          - ubuntu-latest
+        python-version:
+          - "3.8"
+          - "3.9"
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
     - name: Run example notebooks
       if: always()
       run: |
-        python -m pytest $COV examples/ --nbval-lax -p no:randomly --ignore=examples/packed_box.ipynb --ignore=examples/foyer-showcase/
+        python -m pytest $COV examples/ --nbval-lax -p no:randomly --ignore=examples/packed_box.ipynb --ignore=examples/foyer-showcase/ --ignore=examples/protein-ligand
 
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -18,8 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.8"
+          - "3.9"
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -15,8 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
-        python-version: [3.8, 3.9]
+        os:
+          - macOS-latest
+          - ubuntu-latest
+        python-version:
+          - "3.8"
+          - "3.9"
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -19,14 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-latest
           - ubuntu-latest
+          - macos-latest
         python-version:
-          - "3.8"
           - "3.9"
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
-      COV: --cov=openff/interchange --cov-report=xml --cov-config=setup.cfg --cov-append
 
     steps:
     - uses: actions/checkout@v3
@@ -34,8 +32,8 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: "${{ matrix.python-version }}"
-        environment-file: devtools/conda-envs/test_env.yaml
-        activate-environment: test
+        environment-file: devtools/conda-envs/examples_env.yaml
+        activate-environment: interchange-examples-env
         auto-activate-base: false
         mamba-version: "*"
         miniforge-version: latest
@@ -64,14 +62,15 @@ jobs:
       env:
         SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
-    - name: Run mypy
+    - name: Run docexamples
       run: |
-        mypy --namespace-packages -p "openff.interchange"
+        # TODO: Add back /interchange.py when `TypedMolecule` is implemented
+        pytest --doctest-modules openff/interchange/ --ignore=openff/interchange/tests --ignore=openff/interchange/components/interchange.py
 
-    - name: Run all tests
+    - name: Run example notebooks
       if: always()
       run: |
-        python -m pytest -r fE -nauto $COV openff/interchange/ -m "slow or not slow"
+        python -m pytest $COV examples/ --nbval-lax -p no:randomly --ignore=examples/packed_box.ipynb --ignore=examples/foyer-showcase/ --ignore=examples/protein-ligand
 
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -70,10 +70,4 @@ jobs:
     - name: Run example notebooks
       if: always()
       run: |
-        python -m pytest $COV examples/ --nbval-lax -p no:randomly --ignore=examples/packed_box.ipynb --ignore=examples/foyer-showcase/ --ignore=examples/protein-ligand
-
-    - name: Codecov
-      uses: codecov/codecov-action@v2.1.0
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
+        python -m pytest examples/ --nbval-lax --ignore=examples/packed_box.ipynb --ignore=examples/foyer-showcase/ --ignore=examples/protein-ligand

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,4 +1,4 @@
-name: full_tests
+name: examples
 
 on:
   push:

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -31,7 +31,6 @@ dependencies:
   - openeye-toolkits
   - pytest
   - pytest-timeout
-  - codecov
   - pytest-cov
   - pytest-xdist
   - nbval

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -1,8 +1,5 @@
 name: openff-interchange-env
 channels:
-  - conda-forge/label/openmm_rc
-  - openeye/label/beta
-  - openeye/label/rc
   - conda-forge
   - bioconda
   - openeye
@@ -18,8 +15,6 @@ dependencies:
   - openff-utilities
   - openff-units >=0.1.5
   # Optional features
-  - jax =0.2.26
-  - jaxlib =0.1.75
   - unyt
   - mbuild
   - foyer >=0.8.1
@@ -27,13 +22,21 @@ dependencies:
   - mdtraj
   - intermol
   - openff-evaluator
+  - openff-recharge
   - openeye-toolkits
   - pytest
   - pytest-timeout
   - pytest-cov
   - pytest-xdist
   - nbval
-  - conda
+  - conda-tree
+  - qcportal
+  - openff-qcsubmit
+  - openff-evaluator
+  - openff-recharge
+  - openeye-toolkits
+  - cached-property
+  - cachetools
   # Drivers
   - gromacs >=2021
   - lammps >=2021
@@ -44,7 +47,19 @@ dependencies:
   - types-setuptools
   - types-pkg_resources
   - pandas-stubs
+  # Development tools
+  - mamba
+  - jupyterlab
+  - ipdb
+  - pre-commit
+  - black
+  - isort
+  - flake8
+  - snakeviz
+  - tuna
+  - rich
   - pip:
     # https://github.com/conda-forge/jaxlib-feedstock/issues/89
     - jax
     - jaxlib
+    - git+https://github.com/openforcefield/openff-toolkit.git@topology-biopolymer-refactor

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -15,16 +15,18 @@ dependencies:
   - openff-toolkit =0.10.3
   - openff-utilities
   - openff-units >=0.1.5
+  - cached-property
+  - cachetools
   # Optional features
   - unyt
   - mbuild
   - foyer >=0.8.1
-  # Testing
+  # Examples
+  - intermol
+  - openff-evaluator-base
   - mdtraj
   - nglview
   - openff-amber-ff-ports
-  - cached-property
-  - cachetools
   - openeye-toolkits
   - pytest
   - nbval

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -1,8 +1,6 @@
-name: openff-interchange-env
+name: interchange-examples-env
 channels:
-  - conda-forge/label/openmm_rc
-  - openeye/label/beta
-  - openeye/label/rc
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
   - bioconda
   - openeye
@@ -18,33 +16,26 @@ dependencies:
   - openff-utilities
   - openff-units >=0.1.5
   # Optional features
-  - jax =0.2.26
-  - jaxlib =0.1.75
   - unyt
   - mbuild
   - foyer >=0.8.1
   # Testing
   - mdtraj
-  - intermol
-  - openff-evaluator
+  - nglview
+  - openff-amber-ff-ports
+  - cached-property
+  - cachetools
   - openeye-toolkits
   - pytest
-  - pytest-timeout
-  - pytest-cov
-  - pytest-xdist
   - nbval
-  - conda
+  - nglview
   # Drivers
   - gromacs >=2021
   - lammps >=2021
   - panedr
-  # Typing
-  - mypy
-  - typing-extensions
-  - types-setuptools
-  - types-pkg_resources
-  - pandas-stubs
+  # Temporary
   - pip:
     # https://github.com/conda-forge/jaxlib-feedstock/issues/89
     - jax
     - jaxlib
+    - git+https://github.com/openforcefield/openff-toolkit.git@topology-biopolymer-refactor

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -1,5 +1,6 @@
 name: openff-interchange-minimal-env
 channels:
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
   # Core
@@ -7,7 +8,7 @@ dependencies:
   - pip
   - numpy >=1.21
   - pydantic
-  - openmm =7.6
+  - openmm
   # OpenFF stack
   - openff-toolkit =0.10.3
   - openff-utilities
@@ -15,7 +16,6 @@ dependencies:
   # Testing
   - pytest
   - pytest-xdist
-  - conda
   - cached-property
   - cachetools
   - mdtraj

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,5 +1,6 @@
 name: openff-interchange-env
 channels:
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
   - bioconda
   - openeye
@@ -9,7 +10,7 @@ dependencies:
   - pip
   - numpy >=1.21
   - pydantic
-  - openmm =7.6
+  - openmm
   # OpenFF stack
   - openff-toolkit =0.10.3
   - openff-utilities
@@ -22,7 +23,6 @@ dependencies:
   - mdtraj
   - intermol
   - nglview
-  - openff-evaluator
   - openff-recharge
   - openff-amber-ff-ports
   - cached-property
@@ -34,7 +34,6 @@ dependencies:
   - pytest-randomly
   - pytest-timeout
   - nbval
-  - conda
   - nglview
   # Drivers
   - gromacs >=2021

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,6 @@ dependencies:
   - mdtraj
   - intermol
   - nglview
-  - openff-recharge
   - openff-amber-ff-ports
   - cached-property
   - cachetools
@@ -33,7 +32,6 @@ dependencies:
   - pytest-xdist
   - pytest-randomly
   - pytest-timeout
-  - nbval
   - nglview
   # Drivers
   - gromacs >=2021

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -29,7 +29,6 @@ dependencies:
   - cachetools
   - openeye-toolkits
   - pytest
-  - codecov
   - pytest-cov
   - pytest-xdist
   - pytest-randomly

--- a/examples/protein_ligand/protein_ligand.ipynb
+++ b/examples/protein_ligand/protein_ligand.ipynb
@@ -135,7 +135,7 @@
    "id": "73489c6c-4046-452e-8848-e4d28d2e0732",
    "metadata": {},
    "source": [
-    "From these `Molecule` objects, we can make a `Topology` object. Later, we'll visualize this topology as a subset of the solvated complex."
+    "From these `Molecule` objects, we can make a `Topology` object that represents the protein-ligand complex with no water. Later, we'll visualize this topology as a subset of the solvated complex."
    ]
   },
   {
@@ -147,7 +147,18 @@
    },
    "outputs": [],
    "source": [
-    "docked_topology = Topology.from_molecules([protein, ligand])"
+    "docked_topology = Topology.from_molecules([protein, ligand])\n",
+    "\n",
+    "# TODO: There may be a simpler way to process positions after openff-toolkit #1207\n",
+    "docked_positions = openmm_unit.Quantity(\n",
+    "    np.concatenate([protein_pdb.xyz[0], ligand.conformers[0].m_as(unit.nanometer)]),\n",
+    "    openmm_unit.nanometer,\n",
+    ")\n",
+    "\n",
+    "docked_topology.to_file(\n",
+    "    filename=\"docked.pdb\",\n",
+    "    positions=docked_positions,\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
I _think_ that using https://github.com/codecov/codecov-action removes the need to install the `codecov` conda package.