### PR TITLE
Allow from_smirnoff to take a list of Molecules instead of a Topology

### DIFF
--- a/openff/interchange/tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/tests/unit_tests/components/test_interchange.py
@@ -229,6 +229,22 @@ class TestInterchange(_BaseTest):
         assert type(out.topology) == Topology
         assert isinstance(out.topology, Topology)
 
+    def test_from_parsley_molecule_list(self, parsley):
+
+        out = Interchange.from_smirnoff(
+            parsley,
+            [Molecule.from_smiles("CCO"), Molecule.from_smiles("CC")],
+        )
+
+        assert "Constraints" in out.handlers.keys()
+        assert "Bonds" in out.handlers.keys()
+        assert "Angles" in out.handlers.keys()
+        assert "ProperTorsions" in out.handlers.keys()
+        assert "vdW" in out.handlers.keys()
+
+        assert type(out.topology) == Topology
+        assert isinstance(out.topology, Topology)
+
     @skip_if_missing("nglview")
     def test_visualize(self, parsley):
         import nglview


### PR DESCRIPTION
### Description
As discussed in #408, this simplifies an important route through the API by removing the need for the user to construct a `Topology` directly. This should allow many users to remove `Topology` from their mental model of the OpenFF ecosystem.

### Checklist
- [x] Add tests
- [x] Lint
- [x] Update docstrings
