### PR TITLE
Add non-OpenEye jobs to CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,12 @@ jobs:
         python-version:
           - "3.8"
           - "3.9"
+        openeye:
+          - true
+          - false
+        exclude:
+          - openeye: true
+            python-version: 3.8
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       COV: --cov=openff/interchange --cov-report=xml --cov-config=setup.cfg --cov-append
@@ -58,6 +64,7 @@ jobs:
         conda list
 
     - name: License OpenEye
+      if: ${{ matrix.openeye == true }}
       run: |
         echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
         python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"

--- a/openff/interchange/tests/interoperability_tests/internal/test_amber.py
+++ b/openff/interchange/tests/interoperability_tests/internal/test_amber.py
@@ -51,16 +51,20 @@ class TestAmber(_BaseTest):
             "C1COC(=O)O1",  # This adds an improper, i2
         ],
     )
-    @pytest.mark.parametrize("constrained", [True, False])
-    def test_amber_energy(self, sage, sage_unconstrained, smiles, constrained):
-        """Basic test to see if the amber energy driver is functional"""
+    def test_amber_energy(self, sage_unconstrained, smiles):
+        """
+        Basic test to see if the amber energy driver is functional.
+
+        Note this test can only use the unconstrained version of Sage because sander applies SHAKE
+        constraints in the single-point energy calculation, i.e. uses geometries with constraints
+        applied, NOT what is in the coordinate file. See issue
+        https://github.com/openforcefield/openff-interchange/issues/323
+        """
         mol = Molecule.from_smiles(smiles)
         mol.generate_conformers(n_conformers=1)
         top = mol.to_topology()
 
-        force_field = sage if constrained else sage_unconstrained
-
-        off_sys = Interchange.from_smirnoff(force_field, top)
+        off_sys = Interchange.from_smirnoff(sage_unconstrained, top)
 
         off_sys.box = [4, 4, 4]
         off_sys.positions = mol.conformers[0]
@@ -68,18 +72,10 @@ class TestAmber(_BaseTest):
         omm_energies = get_openmm_energies(off_sys)
         amb_energies = get_amber_energies(off_sys)
 
-        # MT: I _think_ some of these errors are the result of Amber reporting energies
-        # to 0.001 kcal/mol, which introduces error on the order of ~0.002 kJ/mol
-        # TODO: Figure out why bond and angle energies are reported differently
-        #       in constrained systems
-        #       https://github.com/openforcefield/openff-interchange/issues/323
         omm_energies.compare(
             amb_energies,
             custom_tolerances={
-                "Bond": (0.1 if constrained else 0.001) * kj_mol,
-                "Angle": (0.05 if constrained else 0.001) * kj_mol,
-                "Torsion": (0.005 if constrained else 0.001) * kj_mol,
-                "vdW": 0.02 * kj_mol,
-                "Electrostatics": (0.5 if constrained else 0.05) * kj_mol,
+                "vdW": 0.015 * kj_mol,
+                "Electrostatics": 0.01 * kj_mol,
             },
         )


### PR DESCRIPTION
I realize that for a while now, CI runners _always_ had access to OpenEye toolkits. I'm not interested in exhaustively testing toolkit wrapper behaviors (that's a job for the OpenFF Toolkit) but I do want to ensure a developer without an OpenEye license can run the test suite without major surprises.