### PR TITLE
Add nbstripout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     exclude: '\.(pdb|gro|top|sdf)$'
   - id: debug-statements
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     files: ^openff
@@ -62,4 +62,9 @@ repos:
       args:
         - --py37-plus
     - id: nbqa-isort
+      files: ^examples
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.5.0
+  hooks:
+    - id: nbstripout
       files: ^examples

--- a/examples/SMIRNOFF_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation.ipynb
@@ -13,24 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:01:08.823239Z",
-     "iopub.status.busy": "2021-12-23T15:01:08.819204Z",
-     "iopub.status.idle": "2021-12-23T15:01:21.466415Z",
-     "shell.execute_reply": "2021-12-23T15:01:21.466867Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from openff.toolkit.topology import Molecule, Topology\n",
     "from openff.toolkit.typing.engines.smirnoff import ForceField\n",
@@ -58,15 +43,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:01:21.490448Z",
-     "iopub.status.busy": "2021-12-23T15:01:21.489798Z",
-     "iopub.status.idle": "2021-12-23T15:01:27.681810Z",
-     "shell.execute_reply": "2021-12-23T15:01:27.683016Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an Interchange object from the force field and topology objects\n",
@@ -75,15 +53,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:01:27.726581Z",
-     "iopub.status.busy": "2021-12-23T15:01:27.716744Z",
-     "iopub.status.idle": "2021-12-23T15:01:28.874459Z",
-     "shell.execute_reply": "2021-12-23T15:01:28.874991Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert the OpenFF Interchange object to an OpenMM System\n",
@@ -102,15 +73,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:01:30.082428Z",
-     "iopub.status.busy": "2021-12-23T15:01:30.081733Z",
-     "iopub.status.idle": "2021-12-23T15:01:30.089373Z",
-     "shell.execute_reply": "2021-12-23T15:01:30.090202Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from simtk import openmm, unit\n",
@@ -154,26 +118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:01:30.095412Z",
-     "iopub.status.busy": "2021-12-23T15:01:30.094712Z",
-     "iopub.status.idle": "2021-12-23T15:02:51.538970Z",
-     "shell.execute_reply": "2021-12-23T15:02:51.540370Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting simulation\n",
-      "Elapsed time 5.63 seconds\n",
-      "Done!\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import time\n",
     "\n",

--- a/examples/conformer_energies.ipynb
+++ b/examples/conformer_energies.ipynb
@@ -2,14 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:02:57.059663Z",
-     "iopub.status.busy": "2021-12-23T15:02:57.056392Z",
-     "iopub.status.idle": "2021-12-23T15:03:03.975197Z",
-     "shell.execute_reply": "2021-12-23T15:03:03.975647Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -26,15 +20,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:03.980619Z",
-     "iopub.status.busy": "2021-12-23T15:03:03.979095Z",
-     "iopub.status.idle": "2021-12-23T15:03:03.983161Z",
-     "shell.execute_reply": "2021-12-23T15:03:03.983557Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "SMILES = \"c1n(CCO)c(C(F)(F)(F))cc1CNCCl\""
@@ -42,15 +29,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:04.004922Z",
-     "iopub.status.busy": "2021-12-23T15:03:04.004120Z",
-     "iopub.status.idle": "2021-12-23T15:03:05.682870Z",
-     "shell.execute_reply": "2021-12-23T15:03:05.683410Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "molecule = Molecule.from_smiles(SMILES)\n",
@@ -60,15 +40,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:05.687723Z",
-     "iopub.status.busy": "2021-12-23T15:03:05.686848Z",
-     "iopub.status.idle": "2021-12-23T15:03:06.460745Z",
-     "shell.execute_reply": "2021-12-23T15:03:06.461224Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "parsley = ForceField(\"openff-1.1.0.offxml\")"
@@ -76,15 +49,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:06.493192Z",
-     "iopub.status.busy": "2021-12-23T15:03:06.492590Z",
-     "iopub.status.idle": "2021-12-23T15:03:15.211887Z",
-     "shell.execute_reply": "2021-12-23T15:03:15.212988Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "openff_sys = Interchange.from_smirnoff(force_field=parsley, topology=topology)\n",
@@ -93,15 +59,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:15.219281Z",
-     "iopub.status.busy": "2021-12-23T15:03:15.218538Z",
-     "iopub.status.idle": "2021-12-23T15:03:15.221365Z",
-     "shell.execute_reply": "2021-12-23T15:03:15.221781Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "openff_sys.positions = molecule.conformers[0]\n",
@@ -110,24 +69,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:03:15.509835Z",
-     "iopub.status.busy": "2021-12-23T15:03:15.224236Z",
-     "iopub.status.idle": "2021-12-23T15:08:17.054045Z",
-     "shell.execute_reply": "2021-12-23T15:08:17.054726Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "df = pd.DataFrame()\n",
     "\n",
@@ -166,171 +110,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:17.066170Z",
-     "iopub.status.busy": "2021-12-23T15:08:17.058345Z",
-     "iopub.status.idle": "2021-12-23T15:08:19.252729Z",
-     "shell.execute_reply": "2021-12-23T15:08:19.250104Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/2w/dfnzsrm57_730c_n_h0f3psc0000gn/T/ipykernel_7922/496160328.py:1: FutureWarning: this method is deprecated in favour of `Styler.hide(axis='index')`\n",
-      "  df.style.hide_index()\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style type=\"text/css\">\n",
-       "</style>\n",
-       "<table id=\"T_7e276\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th id=\"T_7e276_level0_col0\" class=\"col_heading level0 col0\" >Conformer No.</th>\n",
-       "      <th id=\"T_7e276_level0_col1\" class=\"col_heading level0 col1\" >Toolkit (kJ/mol)</th>\n",
-       "      <th id=\"T_7e276_level0_col2\" class=\"col_heading level0 col2\" >Interchange -> OpenMM (kJ/mol)</th>\n",
-       "      <th id=\"T_7e276_level0_col3\" class=\"col_heading level0 col3\" >Interchange -> GROMACS</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row0_col0\" class=\"data row0 col0\" >0</td>\n",
-       "      <td id=\"T_7e276_row0_col1\" class=\"data row0 col1\" >382.076000</td>\n",
-       "      <td id=\"T_7e276_row0_col2\" class=\"data row0 col2\" >382.000000</td>\n",
-       "      <td id=\"T_7e276_row0_col3\" class=\"data row0 col3\" >381.922000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row1_col0\" class=\"data row1 col0\" >1</td>\n",
-       "      <td id=\"T_7e276_row1_col1\" class=\"data row1 col1\" >380.791000</td>\n",
-       "      <td id=\"T_7e276_row1_col2\" class=\"data row1 col2\" >380.758000</td>\n",
-       "      <td id=\"T_7e276_row1_col3\" class=\"data row1 col3\" >380.690000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row2_col0\" class=\"data row2 col0\" >2</td>\n",
-       "      <td id=\"T_7e276_row2_col1\" class=\"data row2 col1\" >395.580000</td>\n",
-       "      <td id=\"T_7e276_row2_col2\" class=\"data row2 col2\" >395.449000</td>\n",
-       "      <td id=\"T_7e276_row2_col3\" class=\"data row2 col3\" >395.381000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row3_col0\" class=\"data row3 col0\" >3</td>\n",
-       "      <td id=\"T_7e276_row3_col1\" class=\"data row3 col1\" >390.744000</td>\n",
-       "      <td id=\"T_7e276_row3_col2\" class=\"data row3 col2\" >390.726000</td>\n",
-       "      <td id=\"T_7e276_row3_col3\" class=\"data row3 col3\" >390.664000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row4_col0\" class=\"data row4 col0\" >4</td>\n",
-       "      <td id=\"T_7e276_row4_col1\" class=\"data row4 col1\" >390.629000</td>\n",
-       "      <td id=\"T_7e276_row4_col2\" class=\"data row4 col2\" >390.596000</td>\n",
-       "      <td id=\"T_7e276_row4_col3\" class=\"data row4 col3\" >390.539000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row5_col0\" class=\"data row5 col0\" >5</td>\n",
-       "      <td id=\"T_7e276_row5_col1\" class=\"data row5 col1\" >389.857000</td>\n",
-       "      <td id=\"T_7e276_row5_col2\" class=\"data row5 col2\" >389.782000</td>\n",
-       "      <td id=\"T_7e276_row5_col3\" class=\"data row5 col3\" >389.709000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row6_col0\" class=\"data row6 col0\" >6</td>\n",
-       "      <td id=\"T_7e276_row6_col1\" class=\"data row6 col1\" >377.463000</td>\n",
-       "      <td id=\"T_7e276_row6_col2\" class=\"data row6 col2\" >377.401000</td>\n",
-       "      <td id=\"T_7e276_row6_col3\" class=\"data row6 col3\" >377.343000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row7_col0\" class=\"data row7 col0\" >7</td>\n",
-       "      <td id=\"T_7e276_row7_col1\" class=\"data row7 col1\" >375.871000</td>\n",
-       "      <td id=\"T_7e276_row7_col2\" class=\"data row7 col2\" >375.822000</td>\n",
-       "      <td id=\"T_7e276_row7_col3\" class=\"data row7 col3\" >375.774000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row8_col0\" class=\"data row8 col0\" >8</td>\n",
-       "      <td id=\"T_7e276_row8_col1\" class=\"data row8 col1\" >401.992000</td>\n",
-       "      <td id=\"T_7e276_row8_col2\" class=\"data row8 col2\" >401.917000</td>\n",
-       "      <td id=\"T_7e276_row8_col3\" class=\"data row8 col3\" >401.859000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row9_col0\" class=\"data row9 col0\" >9</td>\n",
-       "      <td id=\"T_7e276_row9_col1\" class=\"data row9 col1\" >401.884000</td>\n",
-       "      <td id=\"T_7e276_row9_col2\" class=\"data row9 col2\" >401.812000</td>\n",
-       "      <td id=\"T_7e276_row9_col3\" class=\"data row9 col3\" >401.738000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row10_col0\" class=\"data row10 col0\" >10</td>\n",
-       "      <td id=\"T_7e276_row10_col1\" class=\"data row10 col1\" >379.166000</td>\n",
-       "      <td id=\"T_7e276_row10_col2\" class=\"data row10 col2\" >379.107000</td>\n",
-       "      <td id=\"T_7e276_row10_col3\" class=\"data row10 col3\" >379.028000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row11_col0\" class=\"data row11 col0\" >11</td>\n",
-       "      <td id=\"T_7e276_row11_col1\" class=\"data row11 col1\" >376.869000</td>\n",
-       "      <td id=\"T_7e276_row11_col2\" class=\"data row11 col2\" >376.852000</td>\n",
-       "      <td id=\"T_7e276_row11_col3\" class=\"data row11 col3\" >376.783000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row12_col0\" class=\"data row12 col0\" >12</td>\n",
-       "      <td id=\"T_7e276_row12_col1\" class=\"data row12 col1\" >387.650000</td>\n",
-       "      <td id=\"T_7e276_row12_col2\" class=\"data row12 col2\" >387.531000</td>\n",
-       "      <td id=\"T_7e276_row12_col3\" class=\"data row12 col3\" >387.453000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row13_col0\" class=\"data row13 col0\" >13</td>\n",
-       "      <td id=\"T_7e276_row13_col1\" class=\"data row13 col1\" >384.113000</td>\n",
-       "      <td id=\"T_7e276_row13_col2\" class=\"data row13 col2\" >384.078000</td>\n",
-       "      <td id=\"T_7e276_row13_col3\" class=\"data row13 col3\" >384.008000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row14_col0\" class=\"data row14 col0\" >14</td>\n",
-       "      <td id=\"T_7e276_row14_col1\" class=\"data row14 col1\" >374.496000</td>\n",
-       "      <td id=\"T_7e276_row14_col2\" class=\"data row14 col2\" >374.406000</td>\n",
-       "      <td id=\"T_7e276_row14_col3\" class=\"data row14 col3\" >374.356000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row15_col0\" class=\"data row15 col0\" >15</td>\n",
-       "      <td id=\"T_7e276_row15_col1\" class=\"data row15 col1\" >378.205000</td>\n",
-       "      <td id=\"T_7e276_row15_col2\" class=\"data row15 col2\" >378.192000</td>\n",
-       "      <td id=\"T_7e276_row15_col3\" class=\"data row15 col3\" >378.108000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row16_col0\" class=\"data row16 col0\" >16</td>\n",
-       "      <td id=\"T_7e276_row16_col1\" class=\"data row16 col1\" >387.122000</td>\n",
-       "      <td id=\"T_7e276_row16_col2\" class=\"data row16 col2\" >386.987000</td>\n",
-       "      <td id=\"T_7e276_row16_col3\" class=\"data row16 col3\" >386.946000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row17_col0\" class=\"data row17 col0\" >17</td>\n",
-       "      <td id=\"T_7e276_row17_col1\" class=\"data row17 col1\" >388.525000</td>\n",
-       "      <td id=\"T_7e276_row17_col2\" class=\"data row17 col2\" >388.455000</td>\n",
-       "      <td id=\"T_7e276_row17_col3\" class=\"data row17 col3\" >388.383000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row18_col0\" class=\"data row18 col0\" >18</td>\n",
-       "      <td id=\"T_7e276_row18_col1\" class=\"data row18 col1\" >386.834000</td>\n",
-       "      <td id=\"T_7e276_row18_col2\" class=\"data row18 col2\" >386.797000</td>\n",
-       "      <td id=\"T_7e276_row18_col3\" class=\"data row18 col3\" >386.731000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td id=\"T_7e276_row19_col0\" class=\"data row19 col0\" >19</td>\n",
-       "      <td id=\"T_7e276_row19_col1\" class=\"data row19 col1\" >387.086000</td>\n",
-       "      <td id=\"T_7e276_row19_col2\" class=\"data row19 col2\" >387.081000</td>\n",
-       "      <td id=\"T_7e276_row19_col3\" class=\"data row19 col3\" >387.005000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7f84ffc06c10>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "df.style.hide_index()"
    ]

--- a/examples/conformer_energies.ipynb
+++ b/examples/conformer_energies.ipynb
@@ -33,6 +33,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "molecule = Molecule.from_smiles(SMILES)\n",
+    "molecule.generate_conformers(n_conformers=20, rms_cutoff=0.1 * unit.angstrom),\n",
+    "topology = molecule.to_topology()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "parsley = ForceField(\"openff-1.1.0.offxml\")"
    ]
   },

--- a/examples/foyer-showcase/solvated-nanoparticle.ipynb
+++ b/examples/foyer-showcase/solvated-nanoparticle.ipynb
@@ -2,30 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "7c15df9e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ce3dd8cbf1724d738cbbb819aafef43c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import mbuild as mb\n",
     "import mdtraj as md\n",
@@ -43,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d80b16a1",
    "metadata": {},
    "outputs": [],
@@ -53,34 +33,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "271d536f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.9/site-packages/foyer/forcefield.py:656: UserWarning: Non-atomistic element type detected. Creating custom element for _EP\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.9/site-packages/foyer/forcefield.py:620: UserWarning: No force field version number found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.9/site-packages/foyer/forcefield.py:632: UserWarning: No force field name found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.9/site-packages/foyer/forcefield.py:644: UserWarning: No combining rule found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.9/site-packages/foyer/validator.py:165: ValidationWarning: You have empty smart definition(s)\n",
-      "  warn(\"You have empty smart definition(s)\", ValidationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "oplsaa_silica = FoyerForcefield(\"oplsaa_switchable.xml\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "0c6b86b4",
    "metadata": {},
    "outputs": [],
@@ -90,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "8ed54033",
    "metadata": {},
    "outputs": [],
@@ -103,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "a927de8a",
    "metadata": {},
    "outputs": [],
@@ -116,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b5ee185c",
    "metadata": {},
    "outputs": [],
@@ -126,11 +89,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "1ba9dec8",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "solvent_interchange = Interchange.from_smirnoff(\n",
@@ -145,34 +106,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "290653cc",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mwt/software/openff-system/openff/interchange/components/interchange.py:617: UserWarning: Interchange object combination is experimental and likely to produce strange results. Any workflow using this method is not guaranteed to be suitable for production. Use with extreme caution and thoroughly validate results!\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/software/openff-system/openff/interchange/components/interchange.py:649: UserWarning: 'other' Interchange object has handler with name RBTorsions not found in 'self,' but it has now been added.\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/software/openff-system/openff/interchange/components/interchange.py:649: UserWarning: 'other' Interchange object has handler with name RBImpropers not found in 'self,' but it has now been added.\n",
-      "  warnings.warn(\n",
-      "/Users/mwt/software/openff-system/openff/interchange/components/interchange.py:672: UserWarning: Setting positions to None because one or both objects added together were missing positions.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "combined = solvent_interchange + nanoparticle_interchange"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "a96df17a",
    "metadata": {},
    "outputs": [],
@@ -182,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "97ab9307",
    "metadata": {},
    "outputs": [],
@@ -194,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "3da5e45d",
    "metadata": {},
    "outputs": [],
@@ -209,27 +153,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "9e1f1ddf",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7bf9a73fbdfa4e00821b9abe3ee39ca9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NGLWidget()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "combined.to_pdb(\"out.pdb\")\n",
     "view = nglview.show_mdtraj(md.load(\"out.pdb\"))\n",
@@ -242,23 +169,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "f9cfc042",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "EnergyReport(energies={'Bond': <Quantity(9.71710874e+09, 'kilojoule / mole')>, 'Angle': <Quantity(1303887.88, 'kilojoule / mole')>, 'Torsion': <Quantity(0.0, 'kilojoule / mole')>, 'Nonbonded': <Quantity(0.0, 'kilojoule / mole')>})"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "get_openmm_energies(combined, combine_nonbonded_forces=True)"
    ]

--- a/examples/optimize-with-jax.ipynb
+++ b/examples/optimize-with-jax.ipynb
@@ -2,15 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:25.923096Z",
-     "iopub.status.busy": "2021-12-23T15:08:25.922182Z",
-     "iopub.status.idle": "2021-12-23T15:08:42.836426Z",
-     "shell.execute_reply": "2021-12-23T15:08:42.837301Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
@@ -25,15 +18,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:42.868432Z",
-     "iopub.status.busy": "2021-12-23T15:08:42.860311Z",
-     "iopub.status.idle": "2021-12-23T15:08:50.056431Z",
-     "shell.execute_reply": "2021-12-23T15:08:50.068590Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Construct a single-molecule system from toolkit classes\n",
@@ -47,24 +33,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:50.110802Z",
-     "iopub.status.busy": "2021-12-23T15:08:50.102811Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.352843Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.353442Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "bonds = off_sys.handlers[\"Bonds\"]\n",
     "\n",
@@ -77,30 +48,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.370284Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.362494Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.385468Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.384750Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[5.3113739e+02, 1.5203758e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [6.6914154e+02, 1.4142879e+00],\n",
-       "             [1.1205833e+03, 9.7076875e-01]], dtype=float32)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# force field parameters, each row is something like [k (kcal/mol/A), length (A)]\n",
     "p"
@@ -108,34 +58,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.399368Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.396247Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.404133Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.405233Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[5.3113739e+02, 1.5203758e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [6.6914154e+02, 1.4142879e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [7.5809320e+02, 1.0928884e+00],\n",
-       "             [1.1205833e+03, 9.7076875e-01]], dtype=float32)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# system parameters, a.k.a. force field parameters as they exist in a parametrized system\n",
     "q"
@@ -143,42 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.421509Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.420437Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.563034Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.565299Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[1., 0., 0., 0., 0., 0., 0., 0.],\n",
-       "             [0., 1., 0., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 1., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 1., 0., 0., 0., 0.],\n",
-       "             [0., 0., 1., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 1., 0., 0., 0., 0.],\n",
-       "             [0., 0., 1., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 1., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 0., 1., 0., 0., 0.],\n",
-       "             [0., 0., 0., 0., 0., 1., 0., 0.],\n",
-       "             [0., 0., 1., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 1., 0., 0., 0., 0.],\n",
-       "             [0., 0., 1., 0., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 1., 0., 0., 0., 0.],\n",
-       "             [0., 0., 0., 0., 0., 0., 1., 0.],\n",
-       "             [0., 0., 0., 0., 0., 0., 0., 1.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# m is the parametrization matrix, which can be dotted with p to get out q\n",
     "assert np.allclose(m.dot(p.flatten()).reshape((-1, 2)), q)\n",
@@ -188,15 +80,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.576312Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.574446Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.582790Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.584570Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# save and set initial values\n",
@@ -209,15 +94,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.596593Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.591759Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.602187Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.605985Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from copy import deepcopy"
@@ -225,15 +103,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.623676Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.616587Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.832935Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.838067Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# let jax run with autodiff\n",
@@ -244,15 +115,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:52.856317Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.855059Z",
-     "iopub.status.idle": "2021-12-23T15:08:52.898447Z",
-     "shell.execute_reply": "2021-12-23T15:08:52.924601Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "q_target = deepcopy(q0)\n",
@@ -275,15 +139,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:53.021226Z",
-     "iopub.status.busy": "2021-12-23T15:08:52.955894Z",
-     "iopub.status.idle": "2021-12-23T15:08:53.449250Z",
-     "shell.execute_reply": "2021-12-23T15:08:53.451705Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "out, f_vjp_bonds = jax.vjp(loss, p0)  # composes a jax.grad"
@@ -291,27 +148,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:53.464687Z",
-     "iopub.status.busy": "2021-12-23T15:08:53.457084Z",
-     "iopub.status.idle": "2021-12-23T15:08:53.868898Z",
-     "shell.execute_reply": "2021-12-23T15:08:53.870143Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray(True, dtype=bool)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# This also returns loss(p0), which we do not need to store\n",
     "out == loss(p0)"
@@ -319,60 +158,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:53.878288Z",
-     "iopub.status.busy": "2021-12-23T15:08:53.877104Z",
-     "iopub.status.idle": "2021-12-23T15:08:55.268187Z",
-     "shell.execute_reply": "2021-12-23T15:08:55.269662Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(DeviceArray([[ 0.        ,  0.03217361],\n",
-       "              [ 0.        , -1.2721817 ],\n",
-       "              [ 0.        ,  0.5845848 ],\n",
-       "              [ 0.        ,  0.577526  ]], dtype=float32),)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "f_vjp_bonds(1.0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:55.283717Z",
-     "iopub.status.busy": "2021-12-23T15:08:55.274801Z",
-     "iopub.status.idle": "2021-12-23T15:08:55.787242Z",
-     "shell.execute_reply": "2021-12-23T15:08:55.787967Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[ 0.        ,  0.03217361],\n",
-       "             [ 0.        , -1.2721817 ],\n",
-       "             [ 0.        ,  0.5845848 ],\n",
-       "             [ 0.        ,  0.577526  ]], dtype=float32)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# this does the same as the jax.vjp above\n",
     "jax_loss = jax.grad(loss)\n",
@@ -382,60 +179,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:55.808202Z",
-     "iopub.status.busy": "2021-12-23T15:08:55.806826Z",
-     "iopub.status.idle": "2021-12-23T15:08:56.330971Z",
-     "shell.execute_reply": "2021-12-23T15:08:56.332157Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[ True,  True],\n",
-       "             [ True,  True],\n",
-       "             [ True,  True],\n",
-       "             [ True,  True]], dtype=bool)"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "f_vjp_bonds(1.0)[0] == jax_loss(p0)  # dL/dp"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:56.345467Z",
-     "iopub.status.busy": "2021-12-23T15:08:56.344493Z",
-     "iopub.status.idle": "2021-12-23T15:08:56.657845Z",
-     "shell.execute_reply": "2021-12-23T15:08:56.658789Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(DeviceArray([[   0.      ,   12.008647],\n",
-       "              [   0.      , -474.8358  ],\n",
-       "              [   0.      ,  218.19348 ],\n",
-       "              [   0.      ,  215.55882 ]], dtype=float32),)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# derivative of loss function evaluated at the original system parameters;\n",
     "# note that column 0 mathces target values, so the derivate is flat\n",
@@ -444,55 +199,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:08:56.666179Z",
-     "iopub.status.busy": "2021-12-23T15:08:56.665210Z",
-     "iopub.status.idle": "2021-12-23T15:09:48.283685Z",
-     "shell.execute_reply": "2021-12-23T15:09:48.285163Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "step 0\tloss: 0.8032218813896179\n",
-      "step 10\tloss: 0.26887309551239014\n",
-      "step 20\tloss: 0.26887327432632446\n",
-      "step 30\tloss: 0.26887327432632446\n",
-      "step 40\tloss: 0.26887327432632446\n",
-      "step 50\tloss: 0.26887327432632446\n",
-      "step 60\tloss: 0.26887327432632446\n",
-      "step 70\tloss: 0.26887327432632446\n",
-      "step 80\tloss: 0.26887327432632446\n",
-      "step 90\tloss: 0.26887327432632446\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(0.0, 1.5)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABL70lEQVR4nO2deXxU1fn/309YBKQIgqgYFERA2RLFDaoWi62KaxVF60bVurc/vhWt8lVrXb8tttJWcbcorri0dQG1LuACLoCBSAyESAwJkRAJhJiQZDLP749Z7kwmy00yyb0hz/v1uq+ZOefec5/7mTP3zDn3nOcRVcUwDMMw3JLitQGGYRhGx8IaDsMwDKNZWMNhGIZhNAtrOAzDMIxmYQ2HYRiG0Sy6em1Aa+jWrZv26NEjLm3PPfdkr732IhgMkpOTk3DMgAED6N+/P4FAgNzc3IT8gQMH0q9fP6qrq9mwYUNC/j777MMee+zBzp07+eabb6isrIzm9ezZk9TUVPr06UNFRQUbN25MOH6//fajd+/elJeXU1hYmJA/ePBgevXqRVlZGUVFRQn5BxxwAD169GD79u1899131NbWxtkwbNgw+vbtS2lpKcXFxQnHDxs2jK5du/L9999TUlKSkD98+HBSUlLYsmULW7duTcgfOXIkAJs3b2bbtm3R9Fg7RIT+/fuzc+fOuGO7du3KsGHDACgsLKS8vDwuv3v37gwdOhSAjRs3UlFREZffo0cPDjjgAAC+/fbbhPK7devGtm3biMwU7NmzJ126dInm9+7dm/322w+A3NxcAoFA3PF9+vRh3333BSAnJ4dgMBiX37dvX/bee28A1q5dm6BNpO7t2LGDdevWRdMjdiSz7n377bcJ+fvuu2+07uXl5SXUzf333z+pda8uQ4cOpXv37nF1r269GDlyJDt37kxq3QNISUlh+PDhABQVFVFWVhbNq2tDRONYWlv3evXqxeDBgwHYsGFDQvm9e/emb9++rF27tt76may65/a+V15eXqKqeyXs6JIO3XB0796d8ePHx6Wde+65XHPNNVRUVDBlypSEY6ZPn8706dMpKSlh6tSpCflXX30106ZNY+PGjVx00UUJ+ddffz2nnXYaa9eu5eSTT477ge+zzz7MnTuXE044gYyMDGbMmJFw/D333MPEiRNZunQps2bNSsifM2cO6enpvPvuu9x1110J+Y888ggjR47k9ddf5y9/+Qv5+flxNpx99tn86U9/4sUXX+Shhx5KOP7ll19mwIABzJs3j3nz5iXkL1y4kF69ejF37lwWLFiQkL948WIA7rvvPt54441oeqwdKSkppKenU1NTE3ds//79eeWVVwC4+eabWbZsWVx+amoqzzzzDAAzZswgIyMjLn/EiBE8+uijAFxxxRVxN2eAmpoaPvvsM2praxER9tlnH/bff/9o/oQJE7j33nujOn3//fdxx0+ePJlbb70VgJNPPjnuxgtw6qmnMnPmTAAmTZqUoE2k7v3xj3/k9ttvj6ZH7Ehm3bvyyisT8m+55ZZo3TvrrLMS6uaTTz6Z1LpXl/nz5zN48OC4ule3Xlx88cXsu+++Sa17ELoJL1q0CIA777yT9957L5pX14axY8cmlN3aupeens6cOXMAuPDCCykoKIjLnzBhAn369OHWW2+ltrYWIK5+Jqvuub3vLVmyJPGfR3NQ1Q67paenq5csXbpUe/bsqV26dNGePXvq0qVLO6UNfrHDDzb4xQ4/2OAXO/xgg5/sUFUFlmsr7r2iHXgBYFpamq5atcpTG5YtW8bixYuZNGkSEyZM8MyG1157jdNPP90zGyJ2mBaOHaaFY4dp4djhtRYAIrJCVQ9v8fHWcOwaFBUVRcdIOzumhYNp4WBaOLS24ejQs6pExGsTfEO3bt28NsE3mBYOpoWDaZE8OnTDUXfmQWem7gylzoxp4WBaOJgWyaNDNxxdu3boSWFJZcCAAV6b4BtMCwfTwsG0SB6NNhwiMkBEfici74lIiYjUhF/fE5GZItLiecDJoO5c6c5M3el/nRnTwsG0cDAtkkeDDYeI3At8CYwEngB+BhwSfn0CGA6sFJH/awc762W33Xbz6tS+46CDDvLaBN9gWjiYFg6mRfJorMexCThIVa9U1edU9UtVXR9+fU5VryTUeHjWjNddvdmZWbNmjdcm+AbTwsG0cDAtkkeHno6benCqvvTfl5gw2Lv50IZhGB2NdpuOKyIjReRcEbk0dnN57JMiUiwiXzWx3xEiUisiif4Y6qGwrJDJT09m2cZlTe+8i7NixQqvTfANpoWDaeFgWiQPVz0OEZkF3AasAmK9f6mq/tTF8ccB5cDTqjqmgX26AP8FdgJPqurLTZY7SLTLVV248/g7ufnYm5u8DsMwDKP9ehwzgCNV9ShVPT5ma7LRAFDVD4FEd5fx/AZ4BUh06doI3bt0Z9KQSc05ZJfE/k05mBYOpoWDaZE83DYclUB2WxkhIvsBvwAedrHvFSKyXESW95E+vHLGKwzpOoTCwkJKS0vJzc2lsrKSrKwsgsEgK1euBJxKs3LlSoLBIFlZWVRWVpKbm0tpaSmFhYUUFRVRUlJCXl4e5eXlZGdnEwgEiLg1iZQRec3MzKSqqoqcnBzKysrIz8+nuLiY4uJi8vPzKSsrIycnh6qqKjIzM+stY9WqVQQCAbKzsykvLycvL4+SkhKKioqadU2HHnroLndNLf2eIuxK19TS72nMmDG73DW19HvaZ599drlraun31FoaHKoSkdhG5ULgx8DtwObY/VTV1fJtERkCvFHfUJWIvAT8RVU/FZF54f2aHKoaPXq02kyJEJmZmfW6i+6MmBYOpoWDaeHQ2qGqxpZeB4BIqxJxCnV57LnD+V1oPYcDL4R9Tw0ApohIQFX/3dhBdYM4dWZGjBjhtQm+wbRwMC0cTIvk0dhQ1VDgwPA2tM7nA2M+txpVHaqqQ1R1CPAycE1TjQbYyvFY8vPzvTbBN5gWDqaFg2mRPBrscahqgxGiRKQnUKuqru7cIvI8MAkYICIFwB+AbuHzNPlcoyHMV5VDJKykYVrEYlo4mBbJw9WdV0TuAxao6ucicgqhXoGKyDRVfb2p41X1fLcGqep0t/tGQjAasG3bNvr06eO1Gb7AtHAwLRxMi+ThdlbVBUBk8d5thB6Wnw7c0xZGuSUlpUM7900q9rzHwbRwMC0cTIvk4Xasp5eqVohIf+BAVX0FQEQOaDvTDMMwDD/ituFYJyIXAAcRWt2NiAwgtL7DMyyQk4M5fHQwLRxMCwfTInm4bTiuAf4GVAOXhdNOBN5pC6Pc0qVLMmYC7xr07dvXaxN8g2nhYFo4mBbJw9VDAlX9QlUnquokVc0Npz2rqhe1rXmNEwgEvDy9r9i8eXPTO3USTAsH08LBtEgeDfY4ROS4sI8pRKRBn1Sq+n5bGOaG7t27e3Vq37H//vt7bYJvMC0cTAsH0yJ5NNbjmBvz/okGtsfbzrSmsTFLh3Xr1nltgm8wLRxMCwfTInl06EBOhx9+uC5fvtxrMwzDMDoUbemrqqETnq+qz7f0hMkk+PXXMGlSfOK558I110BFBUyZknjQ9OmhraQEptYTL+rqq2HaNNi4ES6q5xHO9dfDaafB2rVw5ZWJ+bfcAiecABkZMGNGYv4998DEibB0KcyalZg/Zw6kp8O778JddyXmP/IIjBwJr78Of/lLNHnHjh386Ec/gvnzYfBgePFFeOihxONffhkGDIB580JbXRYuhF69YO5cWLAgMX/x4tDrfffBG2/E5/XsCYsWhd7feSe89158fv/+8Morofc33wzL6gTgSk2FZ54JvZ8xI6RhLCNGwKOPht5fcQXU/QeZng5z5rBixQrG338/FNSJajxhAtx7b+j92WfD99/H50+eDLfeGnp/8slQ14voqafCzJmh93XrHfiy7kXrBbRZ3Yvi87q3YtYsxo8f36Z1D4ALL+x4da+ZtGQF3SOtPmuSsAWADtGbgxG6ORiA1YtYrF4kj2YPVYnIDlX1RW0cNWqUZmVleW2GL1ixYoX9MMKYFg6mhYNp4dDaoaqWNBwLVbWevlD7Y884DMMwmk97hY6N4pdGA0hKJKtdhbrR7zozpoWDaeFgWiQPVz0OEekOTAfSgd6xeap6cVsY5obx48erxREOEQgEzM18GNPCwbRwMC0c2qvH8RQwA9gB5NbZPKOqqsrL0/uK9evXe22CbzAtHEwLB9Miebhtfk8Chqrqtja0pdnYynGH1NRUr03wDaaFg2nhYFokD7c9jnxgt7Y0pCWYryqHkpISr03wDaaFg2nhYFokj8Z8VcX6p3oa+I+I/A2I8xTmpa8qW8fh0Lt376Z36iSYFg6mhYNpkTwaG6p6op60uhH/FDgweeY0j47sLiXZ1NTUeG2CbzAtHEwLB9MieTTYcKjq0PY0xGgdFtTKwbRwMC0cTIvk4WqsR0T+00D6qy6Pf1JEikXkqwbyLxCR1eFtqYikuSnXhqocevXq5bUJvsG0cDAtHEyL5OH2znt8A+mTXB4/j9DMrIbYAPxEVccBdwKPuinUHo47bN261WsTfINp4WBaOJgWyaPR6bgickf4bfeY9xEOBL51cxJV/VBEhjSSvzTm46eAq3lz3bp1c7Nbp2DQoEFem+AbTAsH08LBtEgeTfU4Boe3lJj3gwnd2DcC57SBTZcBixrKFJErRGS5iCzftGkTJSUlFBUVUVhYSGlpKbm5uVRWVpKVlUUwGGTlypVAyMEZwMqVKwkGg2RlZVFZWUlubi6lpaUUFhZSVFRESUkJeXl5lJeXk52dTSAQiLoqiJQRec3MzKSqqoqcnBzKysrIz8+nuLiY4uJi8vPzKSsrIycnh6qqKjIzM+stY9WqVQQCAbKzsykvLycvL69F1/TNN9/sctfU0u9pWdhl9q50TS39nnJycna5a2rp97R69epd7ppa+j21FrcuR36tqo+16kShHscbqjqmkX2OJxR58BhV/b6h/SL4wsnhsmWhOAGTJoV87ntkQ/CDD0g5/njvbAjbYVo4dpgWjh2mhWOH51rQepcjqGqTG6Fhqfq2/YAUl2UMAb5qJH8cIRcmI9yUp6occsgh6ilLl6r27KnapUvodelSz2wIpqR4Z0OMHaaFmhb12GFaqD+0CAMsV5f32fo2tw/H1wM54S32fT5QJSKviMjeLW28RGR/4FXgIlV1HRjY81kSixdDdTXU1oZeIxHKPLBBgkHvbIixw7TAtKjHDtMCf2iRJNw2HL8GngVGAD2AkcAzwDXAWEIP2R9s6GAReR5YBowUkQIRuUxErhKRq8K73Ab0B+aKSIaIuBp/qqiocGl+GzFpEnTvDl26hF7rC+nYTjaolzbE2GFaYFrUY4dpgT+0SBJun3EUAAep6s6YtF7AOlVNFZF+QI6qDmg7UxOxZxw+ssEvdvjBBr/Y4Qcb/GKHH2zwkR3tEgFQRDYBP1XV7Ji0g4EPVHVfEekGbFHVvi01pCVY6FiHlStXcthhh3lthi8wLRxMCwfTwqG1DYdbt+pzgPdF5J+EpuGmAr8KpwOcQmgoql3x/BmHj0hPT/faBN9gWjiYFg6mRfJw9YxDVf8MXArsA5wBDAIuU9U/hfP/raont5mVDbBz586md+okZGdnN71TJ8G0cDAtHEyL5OE6jqKqvgW81Ya2NBsL5OQwdKj5pIxgWjiYFg6mRfJw6+Swe3jF9lwReTp2a2sDG8PcJDts2rTJaxN8g2nhYFo4mBbJw22P4ykgDXidOoGcvMQCzzvsueeeXpvgG0wLB9PCwbRIHh065rj513eoqKigX79+XpvhC0wLB9PCwbRIHh065nhKcXFoXrRhsUliMC0cTAsH0yJ5uO1x+DLmeJfvvoPJk+G997xd1OMDzMW8g2nhYFo4mBbJw23DcV341VcxxwHH50snbzjKy8sZMKBdF+77FtPCwbRwMC2Sh6uGQ/0cf7yD+3xJFvaDcDAtHEwLB9Miebge9BORbiJyrIhMC3/eXUR2bzvTmiYwcKANU4UpKCjw2gTfYFo4mBYOpkXycOuraizwGlAFpKpqbxGZAlyiqtPa2MYGGT9+vEYiXHV2AoGATU8OY1o4mBYOpoVDa31Vue1xPATcpqoHA5FVd0uAY1p64mRgLkcc1qxZ47UJvsG0cDAtHEyL5OG2x1EK7KmqKiJbVXXPcHr0vRf4wq26YRhGB6O9ehx5wPg6Jz6SUDRAz/A8kJOPsCE7B9PCwbRwMC2Sh9sex6nAE8DDwPXA3cBVwK9V9Z02tbARrMdhGIbRfNqlx6GqbwAnA3sRerZxAHCWl40GWI8jFvs35WBaOJgWDqZF8nDV4/Ar1uMwDMNoPm0WAVBE7nBTgKre1tKTt5bKykqvTu07MjMzGTt2rNdm+ALTwsG0cDAtkkdjk5oHuzjeVXdFRJ4ETgWKVXVMPfkC/A2YAlQA01V1ZVPl9ujRw83pOwUjRozw2gTfYFo4mBYOpkXyaLDhUNVfJfE884AHCDlLrI+TgeHh7ShC60aOaqrQ6urqJJnX8cnPz2f48OFem+ELTAsH08LBtEge7eJnWFU/BLY2sssZwNMa4lOgr4js21S5tgrUYe+99/baBN9gWjiYFg6mRfLwi4P6/YCNMZ8LwmkJhEPYLheR5d999x0lJSUUFRVRWFhIaWkpubm5VFZWkpWVRTAYZOXK0IhXZEbFypUrCQaDZGVlUVlZSW5uLqWlpRQWFlJUVERJSQl5eXmUl5eTnZ1NIBBg1apVcWVEXjMzM6mqqiInJ4eysjLy8/MpLi6muLiY/Px8ysrKyMnJoaqqiszMzHrLWLVqFYFAgOzsbMrLy8nLy2vRNZWWlu5y19TS7ykjI2OXu6aWfk9btmzZ5a6ppd/Thg0bdrlraun31FrabVaViAwB3mjgGcebwL2q+nH483vAjara6Py59PR0jdwkOjvFxcUMHDjQazN8gWnhYFo4mBYO7bVyvK0pIP5hfCrQZGT5zZtTLACgYRhGO9PYdNyfuikgSREAXwOuE5EXCD0U366qRU0d9N13KRYAMIw5fHQwLRxMCwfTInk09nT5iTqf9yM0/fZ7oD8ghHoKTUYAFJHngUnAABEpAP4AdANQ1YeBhYSm4q4nNB3X9YwuCwAYom/fvl6b4BtMCwfTwsG0SB6NTceNRv0TkVmEGotbVbVCRHoBdxBqRJpEVc9vIl+Ba11ZXAcLABhi8+bN9OnTx2szfIFp4WBaOJgWycPtM47/AW5S1QqA8OvNwO/ayjA3DBqkng9TLdu4jHs/updlG7172LJs4zJeKHzBUxsidpgWjh2mhWOHaeHY4bUWycCtd9w84AJV/SQmbSLwvKoe0HbmNc7u+++uR9xxRFzauaPP5ZojrqGipoIpz05JOGZ6+nSmp0+npKKEqQumJuRfffjVTBszjY3bN3LRvy5KyL9+wvWcNvI01pas5bxXzmP15tUENUiKpDBu73HM/tlsTjjwBDK+y2DGWzMSjr9n8j1MHDyRpRuXMuu9WQn5c06aQ/o+6bz7zbvc9eFdCfmPnPoIIweM5PW1r/OXZX9he9X2OBteOecVzjzkTF786kUeWv5QwvEvn/syA3oNYF7GPOZlzEvIX3jBQnp168XcL+ayYM2ChPzF0xcDcN/S+3hj3RvR9IgdgtC9S3cuGHsBOVtz4o7t36s/r5z7CgA3v3szywrifzypfVJ55qxnAJjx1gwyvsuIyx/RfwSPnvYoAFe8fgXrvl8Xl7/37nvz+rrXqQpUISKM3Xsse+y2RzR/QuoE7j3hXgDOXnA231fEd5gnD53MrT+5FYCTnz2Zypr4aYunjjiVmRNnAjBp3qQEbSJ174MNH3DC/BPi6sUeu+2R1Lp35RtXJuTfctwt0br3q//8KqFuPjjlwaTWvbrM/8V8Bu8xOK7uxdbPHl178P7F77P2+7VJrXsAPbv1ZNEFiwC4c8mdvLfhvWje9qrtZG7ORFXZretuTD1kKvll+XHHt7bupe+TzpyT5gBw4asXUlAWH6Z2QuoETh95OpOfnkxloDKuXkDy6p7b+96SXy1pl1lVtwJvichzIvInEXkOeAu4paUnTgYpXbydFLZ953aCGgQgqEG279zuuQ11b8btbUet1lJdW03etrx2t6GgrIDq2mqCBD37PgA+zP/Qd/XCKy1i7aiprWFx3mJPbKjVWoIEqa6tTmg02ovFeYuprg15u/DyO0kGrtdxiMgo4GxgEFAEvKyqWW1oW5OMGjVKs7K8M2HZxmVMfnoy1bXVdO/Snfcufo8Jg9t33CxqQ6Ca7l29sSHODtPCtKjPDtPCF1pEaO06DnOr3kqWbVzG4rzFTBoyybNK4Acb/GKHH2zwix1+sMEvdvjBBj/Z0S4Nh4jsCcwE0oHesXmqelxLT95avO5x+IkVK1Ywfvz4pnfsBJgWDqaFg2nh0F4Nx1vAbsACQussoqjqUy09eWvxQ4/DMAyjo9FeLkcmAiep6kOq+lTs1tITJwML5OQQcbJmmBaxmBYOpkXycNtwrCbkP8pXWCAnh9GjR3ttgm8wLRxMCwfTInm4bTjeJzQdd5aIXBq7taVxTVFVVeXl6X3F+vXrvTbBN5gWDqaFg2mRPNxGQjqWkF+qn9VJV+DJpFrUDLp37+7VqX1HaqrvOoSeYVo4mBYOpkXycNVwqOrxbW1ISwgEAl6b4BtKSkro3bt30zt2AkwLB9PCwbRIHq5jr4pIP+A0Ql5yC4HXVbW0rQxzQ0qKX8KJeI/9IBxMCwfTwsG0SB6u7rwiMgHIBa4CxgFXArnhdM/oyIsXk01NTY3XJvgG08LBtHAwLZKH2x7HHOAaVX0hkiAi04C/A0c0dJDRfgSDQa9N8A2mhYNp4WBaJA+3Yz0jCC3+i+Vl4KDkmtM8bKjKoVevXl6b4BtMCwfTwsG0SB5u77w5wHl10s4hNHzlGfZw3GHr1q1em+AbTAsH08LBtEgeboeqZgBviMhvgW+BIcBw4NS2Mcsd3bp18/L0vmLQoEFem+AbTAsH08LBtEgernocqroUGAY8AKwA/gEcFE73jOrqai9P7ys2bNjgtQm+wbRwMC0cTIvk0Sy36iKyH6F4HJtUtbDNrHKJOTl0CAaD9swnjGnhYFo4mBYO7eLkUET2F5GPgDzgTSBPRD4WEddhY0XkJBFZKyLrReSmevL3EJHXRWSViKwRkV81VWZFRUVTu3QaMjIyvDbBN5gWDqaFg2mRPNy6Vf8AWAX8r6r+ICK9gTuBQ1V1kovjuwDrCLksKQC+AM6PjSAoIrOAPVT19yKyF7AW2EdVGxyPsh6HYRhG82kvt+rjgRtU9QcAVS0Hfh9Od8ORwHpV/SbcELwAnFFnHwV+JCJCKFjUVqDRaVPW43BYsWKF1yb4BtPCwbRwMC2Sh9uG41NCN/9YDgeWuTx+P2BjzOeCcFosDwCHAJuATOD/qWrCih0RuUJElovI8u3bt1NSUkJRURGFhYWUlpaSm5tLZWUlWVlZBINBVq5cCTiVZuXKlQSDQbKysqisrCQ3N5fS0lIKCwspKiqipKSEvLw8ysvLyc7OJhAIRP34R8qIvGZmZlJVVUVOTg5lZWXk5+dTXFxMcXEx+fn5lJWVkZOTQ1VVFZmZmfWWsWrVKgKBANnZ2ZSXl5OXl9eiazr00EN3uWtq6fcUYVe6ppZ+T2PGjNnlrqml39M+++yzy11TS7+n1tLgUJWI3BHzcS/gl4Seb2wEBgNTgOdU9ZomTyJyDnCiql4e/nwRcKSq/iZmn6nAj4HfEZrB9V8gTVXLGirXQsc6rFy5ksMOO8xrM3yBaeFgWjiYFg5tOVQ1OGbrAbwKVAEDw6//Cqe7oSBcToRUQj2LWH4FvKoh1gMbgIMbK9RWgjqkp6d7bYJvMC0cTAsH0yJ5NLgAUFWbnNXUDL4AhovIUEKedc8j1IOJJR+YDHwkInsDI4FvGit0586dSTSxY5Odnc2oUaO8NsMXmBYOpoWDaZE8GuxxiMhANwWEb/KNoqoB4DrgbeBrYIGqrhGRq0TkqvBudwITRSQTeA/4vaqWNFauBXJyGDp0qNcm+AbTwsG0cDAtkkdjQ1UfiMhcEZkgInH7iUiKiBwtInMJ3eSbRFUXquoIVR2mqneH0x5W1YfD7zep6s9VdayqjlHVZ5oq09wkO2zaVHfkr/NiWjiYFg6mRfJorOE4FMgCHgV2iEimiCwN9wh2AA8Tmv3k2dOmrl1dx6Ha5dlzzz29NsE3mBYOpoWDaZE8GnvGUU1oiuwDIjIYGAv0BUqB1X5wOWL+9R0qKiro16+f12b4AtPCwbRwMC2Sh9uY4xuJX4dh+AzzweNgWjiYFg6mRfLo0EqGFpkbYC7mYzEtHEwLB9MieXTohsOGqhzKy8u9NsE3mBYOpoWDaZE8OnTDYQ/HHQYMGOC1Cb7BtHAwLRxMi+TRrIYjPA1337YyprlYICeHgoICr03wDaaFg2nhYFokD7fxOPqKyHPATmB9OO10EbmrLY1rit12283L0/uKgw46yGsTfINp4WBaOJgWycNtj+NhYDtwABD5m78MmNYWRrnFXI44rFmzxmsTfINp4WBaOJgWycNtIKctwCBVrRGRraq6Zzh9u6ru0dZGNoQFcjIMw2g+7RXIaTsQ92RJRPYHilp64mRggZwcLEiNg2nhYFo4mBbJw23D8TjwiogcD6SIyATgKUJDWJ5hbtUdxo93G4xx18e0cDAtHEyL5OG24fgTsAB4EOgGPAn8B/hbG9nlCutxONi/KQfTwsG0cDAtkoerZxx+xZ5xGIZhNJ92ecYhIj9taGvpiZNBMmLn7ipE4hUbpkUspoWDaZE83C69fqLO572A7oRCwh6YVIuaQY8ebiPX7vqMGDHCaxN8g2nhYFo4mBbJw1WPQ1WHxm7AHsDdhNyue4atHHfIz8/32gTfYFo4mBYOpkXyaJGvKlWtJdRw3Jhcc5qH+apy2HvvJiP4dhpMCwfTwsG0SB6tcXL4M8BT97S1tbVent5XbNu2zWsTfINp4WBaOJgWycPVX3YR2QjETr/qBfQArmkLo9xigVkc7HmPg2nhYFo4mBbJw+1Yz4V1Pv8ArFPVMrcnEpGTCK376AI8rqr/V88+k4A5hNaKlKjqT9yWbxiGYbQPbkPHLmnNSUSkC6HFgz8jNBPrCxF5TVWzYvbpC8wFTlLVfBEZ2FS5FsjJwRw+OpgWDqaFg2mRPBpsOERkPvHDU/Wiqhe7OM+RwHpV/SZc9gvAGUBWzD6/BF5V1fxwucVNFdqlSxcXp+4c9O3b12sTfINp4WBaOJgWyaOxhwTrgVwXmxv2AzbGfC4Ip8UyAugnIotFZIWI1NsgicgVIrJcRJZ/9913lJSUUFRURGFhIaWlpeTm5lJZWUlWVhbBYJCVK1cCjruBlStXEgwGycrKorKyktzcXEpLSyksLKSoqIiSkhLy8vIoLy8nOzubQCDAqlWr4sqIvGZmZlJVVUVOTg5lZWXk5+dTXFxMcXEx+fn5lJWVkZOTQ1VVVXTxUd0yVq1aRSAQIDs7m/LycvLy8lp0Td99990ud00t/Z7qlrUrXFNLv6fCwsJd7ppa+j2tW7dul7umln5PraVdXI6IyDnAiap6efjzRcCRqvqbmH0eAA4HJgM9CcX7OEVV1zVU7vjx49X8z4SoqqqywFZhTAsH08LBtHBoL7fqiEh3ERkrIse3wOVIATA45nMqsKmefd5S1R9UtQT4EEhrrFAbs3RYt67B9rXTYVo4mBYOpkXycBvI6RjgJWA3oA9QBvwI2KiqTbocEZGuwDpCvYlC4Avgl6q6JmafQwitRD+RkDuTz4HzVPWrhso1J4eGYRjNp716HPcDfw5H/tsRfr2T0CyoJlHVAHAd8DbwNbBAVdeIyFUiclV4n6+Bt4DVhBqNxxtrNMDcqsdiQ3YOpoWDaeFgWiQPtz2O7UA/VQ2KSKmq9hOR7sAGVa37kLvdsB6HYRhG82nP0LF9wu+LRGQU0A/o3dITJwPrcTjYvykH08LBtHAwLZKH24bjVWBK+P0TwAfACkLPPTzDQsc6WFhMB9PCwbRwMC2Sh1u36jNU9bnw+78AZwO/Bq5oQ9uaxAI5OUTmkRumRSymhYNpkTzcPuM4E3hTVWva3KJmYOs4HAKBgLmZD2NaOJgWDqaFQ3s947gd2Cwij4vI8S09WbKpqqry2gTfsH79eq9N8A2mhYNp4WBaJA+3Q1XpwDHAd8BjIlIgIn8REU8HDbt37+7l6QFYtgzuvTf06qUNL7ww1FMbInaYFo4dpoVjh2nh2OG1FsmgRS5HRORo4A5gsqp65mmwd+/xevjh8UNV554L11wDFRUwZUriMdOnh7aSEpg6NTH/6qth2jTYuBEuuigx//rr4bTTYO1aOO88WL0agkFISYFx42D2bDjhBMjIgBkzEo+/5x6YOBGWLoVZsxLz58yB9HR49124667E/EcegZEj4fXX4S9/ge3bIzYoKSnCK6/AmWfCiy/CQw8lHv/yyzBgAMybF9rqsnAh9OoFc+fCggWJ+YsXh17vuw/eeMNJj9ghAt27wwUXQE5O/LH9+8Mrr4Te33xz4o8nNRWeeSb0fsaMkIaxjBgBjz4aen/FFVB3IfDee4d0qapSRISxY2GPPZz8CRNCP1qAs8+G77+PP37yZLj11tD7k0+Guo/QTj0VZs4MvZ80iQQide+DD0J1ILZe7LFHcuvelVcm5t9yi1P3fvWr+Hoxbhw8+GBy615d5s+HwYPj655TP6FHD3j//ZD9yax7AD17wqJFofd33gnvvefkbd8OmZmgquy2mzB1KtSNItvaupeeHtIP4MILoaAgPn/CBDj99FAdq6yMrxeQvLrn9r63ZEk7uRwBEJHBInID8BAhv1L/bOmJdwW2bw/9ICD0un27lzYIwaB3/2QidtTWQnU15OW1vw0FBaFzB4Pi2fcB8OGH/qsXXmkR+xupqXFu/u1tQ21tqF5UVyc2Gu3F4sWh+gne1YukoapNboQi/X0M7ABeBM4Eurs5ti23cePGqZcsXaras6dqly6h16VLvbQh6JkN8XaYFqZFfXaYFn7QIgKwXFtx73U7q2oR8BzwL1Utb6tGrLmkpaWp11Psli0L/ZOYNCnUHfXKhtde287pp+/hmQ0RO0wLxw7TwrHDtHDs8FoLaP2sqnZxq95WHHroofrll196bYYvKC0tpV+/fl6b4QtMCwfTwsG0cGg3t+p+JBAIeG2Cb9i6davXJvgG08LBtHAwLZJHh244unXr5rUJvmHQoEFem+AbTAsH08LBtEgeHXoZZXVkikIMxcXFzJw5k+zsbIKR6RydgJqaGmtIw9TW1jJ27Fjuu+8+Bg4c6LU5nrJhwwZGjRrltRm+wLRIHk0+4xCRLoSCMI1SVV8t1a7PrfrFF1/M8ccfz4UXXtipbqSqobULRugPxTPPPMPixYt5+umnvTbHU4LBICkpHXpgIWmYFg5t/oxDVWuBWqBHS0/SVtTnVj07O7vTNRpgLuZjqamp4aKLLiI7O9trUzwno+5Ktk6MaZE83A5VzQEWiMg9hGKDR7spqvpNG9jlivrcqgeDwU7XaADsvvvuXpvgGyJadKahyoY47LDDvDbBN5gWycNtv+0B4GeE4nDkAOvDW05jB7U19i/b4YcffvDaBN9gWjiY92gH0yJ5uOpxqKovBwYtkJOD9TgcTAsHC17kYFokj5b4qjq6rYxpLn7tceTl5dGzZ0/S09Pj0m+++WYWL17Mv//9b/7v//4vLu8f//gHI0eOZPTo0dx4440AvPrqq0yePDm6z8cff0x6enrc+pUvvviCLl268EzEQ1sdHnjgAQ466CBEhJKSkmj6iy++yEEHHcSpp55a73FdunQhPT2dTZs2xaU/8sgjzJs3j4yMDK666qq4vAULFjBq1ChGjx7NL3/5SwCWL1/OmDFjojPgcnNzOfDAAykrK4sel5+fT+/evbnvvvvqteWGG27g4IMPZty4cfziF79g27ZtAHz00UeMGjWKMWPGxO1vPQ6HlStXem2CbzAtkogbvyTA/sAnwA9AeThtKvC4W98mwEnAWkJDXDc1st8RhB7GT22qzPHjxyf4YKmb9pOf/CRhe/DBB1VV9Ycffqg3/5///Keqqm7ZsiUhzw0bNmzQ0aNHJ6Qff/zxWlFRoTNmzNCPP/44mv7+++/r5MmTdefOnaqqunnz5mjelClT9Nlnn9WamhodO3asfvLJJ9G8QCCgxx9/vJ588sm6YMGCem1ZuXKlbtiwQQ844ADdsmVLXN4HH3ygp5xySr3H7b777vWmX3DBBbp+/XqdM2eOPvPMM9H0devWaXp6um7dujXhGq6++mq9++67VVX1xBNP1Oeeey6uzLPOOkunTp2qs2fPrvecb7/9ttbU1Kiq6o033qg33nhjNK8+rYPBoKom1oXOSG1trdcm+AbTwoFW+qpy+3D8EeBN4Fgg4oz6v0A9zpUTCU/pfZDQc5IC4AsReU1Vs+rZ70/A227K3blzpyvjveaGG27g7bffZsOGDUyYMIHc3Fzee+89pk6dym233cZDDz3ETTfdxG677QYQt/bgH//4ByeccAJr1qzhiCOOYOLEiXF5Z599Nl988QU1NfUHZzz00EOTcg33338/Tz31FDk5OXz11Vfk5eUxaNAgPvroIx5++GEee+wxrr322qhLh9hruOeeezjssMPo2rUrNTU1nH/++dG8f//73xx44IGNDi/9/Oc/j74/+uijefnllxu1defOnfTs2bOll7pLkZ2dbWsXwpgWScRN60KosUgJv98ak77N5fETgLdjPt8M3FzPfjOAa4F5uOhxHHrooQktqR/+Zdb3L/izzz7T6667Tqurq3XixIlxeWlpaXrbbbfpkUceqccdd5x+/vnncfk33XST9unTJ67HUFBQoMcdd5wGAgG95JJL9MUXX4zmnXzyyVpYWBhXRjJ6HMXFxXraaaepqurhhx8el3fGGWfoDTfcoBMnTtSjjjpKFy1aFJf/8MMPa0pKimZnZ0fTysvL9eijj9YdO3boH/7wh7gex2WXXaZffPFFgg2nnnqqzp8/P/q5Pq0j/yz9UBe8pqKiwmsTfINp4UArexxun3FsBg6KTRCRUYBbz/b7ARtjPheE02LL2w/4BfBwYwWJyBUislxElhcVFVFSUkJRURGFhYWUlpYSCAQIBoNUVlaiqtHx7thXVaWyspJgMMjOnTsJBAJUV1dTXV1NTU0NVVVV1NbWRsuIPEupW1ZFRUW0jNraWqqqqqipqaGmpgZVpba2lp07dxIMBvnss89IT09n5cqVjBo1Kq6MQCDAli1b+OSTT7j77rs599xzqaqqitr0zjvv0Lt3b9auXRu9phkzZnD77bfTpUsXAoEAgUAgek2vvvoqAwcOjLumiD11r6m2trbea4rkxV7TZ599xtixY9myZQt9+/aN0yUQCPD111+zePFinnzySS6//HKKioqiZbz55pvsvfferF69mkAgwM6dO7ntttu49tpr2X333aPPQCJ2/O1vf2P8+PFx39Odd95JSkoK55xzTtz3FKnMdb+nSJmZmZlUVVWRk5NDWVkZ+fn5FBcXU1xcTH5+PmVlZeTk5FBVVUVmZibgzMCJvK5atYpAIEB2djbl5eXk5eUl1L3c3FwqKyvJysoiGAxGx9QjZaxcuZJgMEhWVhaVlZXk5uZSWlpKYWEhkbqcl5dHeXk52dnZBAIBIt6f69rj9pry8/N3uWtq6ff09ddf73LX1NLvqdW4aV2ASwmtHv8VUAacD2QCF7g8/hxinocAFwH/qLPPS8DR4ffzcNHjSE9PT2hJ/fAvM/Zf8JdffqlpaWnav39/HTlypA4ePFhTU1M1LS0t+g/oxBNP1A8++CB6/IEHHqjFxcWqqvr3v/9dp0+frosWLdKjjjoqOn4/ZMgQPeCAA/SAAw7Q3XffXffaay/917/+1aBNjfU4AoGApqWlaVpamt56662qGt/j2Lx5s6alpem+++6rQ4cO1WHDhunAgQM1LS1N169fr6qqV155ZfTZkKrqT3/602jP6fXXX9dJkybp6tWrddiwYfrDDz+oquoxxxwTvYY99thD+/Xrp//4xz/qtX/evHl69NFHR4+tT+sIkechfqgLXhN55mSYFrHQyh6H+x1DwZsWAmuARcCZzTi2yaEqYAOQF97KgeKmzlFfICc/3Czqu5lNmDBBa2tr9ZJLLtE1a9bE5T300EPRG/batWs1NTVVg8GgFhUV6ZAhQ6KNyFlnnaWPPvpowvkuueQSff755xu1KRlDVaeccopu2bJF//CHP+ibb74Zl7do0SK9+OKLVTU0qSA1NVVLSkq0oqJCR4wYEb3m3/3udzpr1qyEsusOVdUt+5BDDonqEEt9WldVVamqP+qC1xQUFHhtgm8wLRxa23C4GqoSkaNU9d+qOkVVR6vqyar6bxE50mXH5gtguIgMFZHuwHnAa7E7qOpQVR2iqkOAl4FrVPXfLsv3NVu2bKFfv36kpKTU+4Du0ksv5ZtvvmHMmDGcd955PPXUU4gIv/vd77jxxhvZa6+9AJgzZw533313k+6hp0yZEp1G+/e//53U1FQKCgoYN24cl19+eYuuoba2lu+//54BAwawdOlSjjnmmLj8E088kf79+zNq1CiOP/54Zs+eTf/+/bnzzjs588wzo9d8++2388ILL5BTNyB5HS6//HIifsiuu+46duzYwc9+9jPS09MTpgEbDWO+mRxMiyTipnUByhpI3+rm+PC+UwgNd+UC/xtOuwq4qp595+FiqCotLS2hJfXDv8yGpuO2JdXV1c0+piXTcf1GfVpHtPBDXfCaur3Mzoxp4UBb9jhEJCU8RVbCpMRswwHXkZRUdaGqjlDVYap6dzjtYVVNeBiuqtNVtfE5l/jXF1GXLl3Yvn17wgLAtqS5Wrz44otcc801DUZE69OnT70LAP3ERx99xGmnncaAAQPi0v1aL7ygvNw3kZ49x7RIHk2t4wjgODSs20gEgbuTblEz6NrVn+FEBg8ezMaNG5veMYk0V4tp06Yxbdq0BvP93GBEOPbYY6MzUWLxa73wgrqNamfGtEgeTQ36DQWGEZo+e2D4/YHh9D6qenubWtcE9QVy6qyYFg6mhUNBQYHXJvgG0yJ5NPrXTFW/Db89AEJDV8DeqlrU1oa5IbLS2oAePXwXLsUzTAuHgw46qOmdOgmmRfJwO6uqr4g8B+wk5GsKETldRO5qS+OaoqO4HGkPkrKoZxfBtHBYs2aN1yb4BtMiebidn/YwsJ1QzyMyDrAMaHiQvB0wf0QO5mLewbRwSEtL89oE32BaJA+3Dcdk4LfhISoFUNUtwMBGj2pjzK26f9yqf/jhh1FHhg05IayoqOCUU07h4IMPZvTo0dx0003RvPvvv5/999+f6667rt5jm4O5VXew4EUOpkXycNtwbAfipiSIyP6Ap886XP2znDQpcZs7N5RXUVF//rx5ofySksQ8lwwbNiwhxvFnn33GUUcdxZIlSzj22GOj6R988AH/+c9/WL16NWvWrGHmzJkAnHXWWfTo0YPnnnuOQCDANddcw9y5c6Ozhmpra/n973/PiSee2OC4/o9//GPeffddDjjggLj0adOm8fjjjzdof8+ePcnIyGDQoEFx6R999BHHHntswjXsv//+zJs3LxqHoyFmzpxJdnY2X375JZ988gmLFi0C4H/+53+44447Gj3WLRbIycGCFzmYFsnD7bzFx4FXROR/gRQRmQDcQxMOCdsav/Y46tIebtUbet7TXm7VhwwZAjS+OrdXr14cf/zxAHTv3p3DDjusTWa6/PDDD9Z4hFmxYoXdMMOYFknEzSpBQAi5PM8iFMzp6/Bnac3qw9ZubgI5eYEXbtVfeumlaJ4XbtUj1LUlcn11KS0t1aFDh2pubm407Z///Kdee+219ZbbEvxQFwzDj9AevqrC55qjqqNUdXdVPST8WZs+uu3oSLNnvvzyS9LT0+v1VRUIBCgtLeXTTz9l9uzZnHvuuZEGm2AwyLvvvkvv3r359ttvo8fMmDGDP/3pT3Tp0gWAqqqqaN7ChQsThpiSwcqVK0lLS2PHjh0Nrjivj7pDdoFAgPPPP5/f/va3HHjggUm2suP0RNuD+hZIdlZMi+TheomtiAwBxgG9Y9NV9bkk2+SajjBfPyMjg+nTp1NQUMCAAQOoqKhAVUlPT2fZsmX07NmT1NRUzjrrLESEI488kpSUFEpKSthrr7148MEHGTNmDHfeeSfXXnsty5YtQ0RYvnw55513HgAlJSUsXLiQ3XffnTPPPLPZNtbW1ka78KeffnrCs4bi4mJ+/vOfU1xcTI8ePXj++efZsWMH6enpvPLKKwwbNqxZ57viiisYPnw4M2bMaLatbugI9aK9GDFihNcm+AbTInm4ajhE5GbgNkIu1WP/5ivgWcPREVYIp6enk5GRwcSJE/n444+59NJLufHGG+N6HWeeeSbvv/8+kyZNYt26dVRXVzNgwAC+++47/vrXv/L555+z11578dhjj/H444/z61//mg0bNkSPnz59Oj//+c9b1GhAaAZV3V5BLAMHDiQjI4NTTz2VefPm8cADD3DkkUcyZcqUZp/rlltuYfv27Y0+mG8t1dXV1niEyc/PZ/jw4V6b4QtMi+ThdlbV9cB4VT1cVY+N2Y5rS+OaoqP4JGoPt+qxWnjhVv2LL74gNTWVl156iSuvvJLRo0dH8yLTkgsKCrj77rvJysrisMMOIz09vU0akG7duiW9zI7K3nvv7bUJvsG0SB5u77zfEwqw5CsiYU/9zl577cWbb74JwKeffpqQ371793rXYTz3XHxnbvDgweTl5SXsN2/evIRnHBF++9vf8tvf/ralpkfp0qULy5YtA+Cdd95JyD/iiCManCEV6c2kpqbSHo/FAoFA9NlPZ2fbtm306dPHazN8gWmRPNz2OGYAj4rI4SKyf+zWhrY1iV8Ds3jhVr25WvjNrfr999/Pvffem5Qftl/rhRfYkJ2DaZE8xM0/QBE5A3iMOosACU248uyvXXp6utYdmz/88MOjkeM6EzU1NTZEEyaiRWetC7EUFxfHrQvqzJgWDiKyQlUPb+nxbv+azQVmAX2AbjFb95aeOBlYwB4H08LBtHAwR6AOpkXycPuMoyvwT1X11UMFG8d26CgTBdoD08Khb9++XpvgG0yL5OG2x3EfcJOISFsa01xinf11dmpqarw2wTeYFg6bN2/22gTfYFokD7d/zX4L7APMEpHvYzNU1bMH5N27ezpS5itMCwfTwmH//T2dv+IrTIvk4bbHcSFwAjAFuKjO5goROUlE1orIehG5qZ78C0RkdXhbKiJNOs/365hlstyq1+XSSy9l4MCBjBkzJi79hhtuYN999+W+++5LOGbx4sXsscce9S7WO//888nLy2POnDm88MIL0fT33nsvus7imGOOYf369QnHZmRkMGHCBEaPHs24ceN48cUXo3kXXHABe+65Z4Pu1dsav9YLL1i3bp3XJvgG0yJ5uOpxqOqS1pxERLoADwI/IxS//AsReU1Vs2J22wD8RFVLReRk4FHgqMbKdRPIadK8SQlp544+l2uOuIaKmgqmPJt4Q52ePp3p6dMpqShh6oKpcXmLpy9u8pzQsFv12267jVmzZjF1qlNurFv13XbbjeLi4nrLnD59Otdddx0XX3xxXPrs2bMb9QZ77LHH8sYbbySkb9iwgSFDhrBkyRIeeOCBaPrVV1/Nf/7zHw455BDmzp3LXXfdxbyIq/kwvXr14umnn2b48OFs2rSJ8ePHc+KJJ9K3b1+effZZpk+f3qA9bY0FcnIYO3as1yb4BtMiebie8C4i6SLyGxH5o4jcEdlcHn4ksF5Vv1HVauAF4IzYHVR1qaqWhj9+CqQ2VWhHcWZ3ww03MG7cOL744gsmTJjA448/ztVXXx31CdWYW/VYjjvuOPbcc89685rjfuWCCy5g1KhRrF27lvT0dN555x1OOeWU6CpuEaGsrAyA7du31+swccSIEVH3DYMGDWLgwIFs2bLFtQ1tiQVycrDgRQ6mRRJx40IXuIKQO/V/EYo7/q/w5+dcHj8VeDzm80XAA43sPzN2/3psWQ4sHzRokG7ZskU3bdqkBQUFunXrVk1LS9Pa2lqtqKjQYDCo5eXlqqpxr8FgUCsqKrS2tlYrKyu1pqZGq6qqtKqqSqurq3Xnzp0aCASiZfzwww8JZaiq/vDDD9EyAoGA7ty5U6urq3XdunU6atQoDQQCWllZqbW1tbpkyRK97rrrtLS0VCdOnBhXRlpamt588816xBFH6DHHHKNLly7Vqqoq3bBhg5500knRMioqKvSbb77RQw45JMGe2267Te+5556Ea3rnnXd0ypQpCdf09NNP63333adr1qzRqVOnxtmzePFi3XPPPXW//fbTgw8+WEtKSrS6ulo/+eQTvfTSS6P2RHRZvHixHnzwwVpWVhYt45JLLtFnn302TpeIxjU1NXHX1Fbf09ixY1VVdfXq1bpz505dt26dbt++Xb/99lvdvHmzbt68Wb/99lvdvn27rlu3Tnfu3KmrV69WVdXly5fHvWZkZGhNTY1+/fXXumPHDt2wYUNC3Vu/fr1WVFTomjVrtLa2VlesWBFXxooVK7S2tlbXrFmjFRUVun79et26dasWFBTopk2bdMuWLbphwwbdsWOHfv3111pTU6MZGRn12mPXZNfUmmuilW7V3TYc64Fjw+9Lw68nA0+5PP6cehqOfzSw7/GE4n30b6rcyA00Fj/EYKgvHsfDDz+sjz/+uK5evVovv/zyuLzRo0frb37zGw0Gg/rZZ5/pkCFDNBgMui5bVfXmm2/W2bNnJ6Q3FHPjpptu0nfffVdfe+01veuuu+LyfvGLX+inn36qqqp//vOf9bLLLmvwWjdt2qQjRozQZcuWxaXXF5ejvYg0HH6oC14TuXEYpkUsrW043M6qGqiqH4XfB0UkRVUXicizLo8vAAbHfE4FEnxZiMg4QtEGT1bV7+vm16UjjGW31q26WyIziT777DOuvPJKAO64444EFx4LFy5k1qxZbNiwgTfeeIMtW7aw++678+677/LBBx+wZcsWVq1axVFHhR4vTZs2jZNOOqnec5aVlXHKKadw1113cfTRR7dEnjbBov85WMQ7B9Miebh9xlEQjscBsA44Q0SOBdwOrH8BDBeRoSLSHTgPeC12h7Dfq1eBi1TV1fSHjhDIKeJWfcSIEWRlZfHTn/6Ut99+m4yMjOjD/YhbdSDOrXpziKxdOOqoo8jIyCAjI4PTTz89Yb8pU6awYsUKxowZQ2ZmJqNHj+bLL7/kgw8+AKBfv35s3749OgPlv//9L4ccckhCOdXV1fziF7/g4osv5pxzzmmWrW1NR3n21R6sWrXKaxN8g2mRPNw2HH8GInePO4BngPeBP7o5WFUDwHXA24SGoRao6hoRuUpErgrvdhvQH5grIhki0qSToY7itKylbtU3bdoUN432/PPPZ8KECaxdu5bU1FSeeOKJaF5zVkt/+eWXpKWlUV1dTU1NTVyvpGvXrjz22GOcffbZpKWlMX/+fGbPng3A8uXLo27ZFyxYwIcffsi8efNIT0+PNpB+wM1su85CrHv7zo5pkUSaGssiFG/8QKBrTFp3oHdrxsiSsdU31u+Hce2GnkO0JbNmzWrWM462xstnHBUVFarqj7rgNV9//bXXJvgG08KBto45Hj5JJhCMSatW1fK2aMiag19XCLe3W/UbbriBF198sd6x/e7du/PVV1+1KFpfS7ngggtYsmSJZz1Cv9YLL0hNbXJWe6fBtEgebt2qfwxcrqrZbW+Se8aNG6erV6+OS+usrrSrqqqi60A6OxEtOmtdiCUvL48hQ4Z4bYYvMC0cWutW3e3A+GLgLRGZB2wkFGscAFV9sqUnby0WsMfBtHAwLRx69+7ttQm+wbRIHm4bjh8TdglSJ10BzxoON72lzoJp4WBaOJinYAfTInm49VV1fFsbYhhG8rGgVg6mRfJodsSbcEyOaFwOVfXs27AhCQfTwsG0cOgIi2TbC9Miebj6hYnIfiLyr3AsjgBQE7N5hl8DOTXXrXpGRgZHH3006enpHH744Xz++ef1ltuYW/XU1NSkuVV/4IEHOOiggxARSkpK6rXFz27V/VovvGDr1q1em+AbTIvk4fav2cOEVolPBsqBwwit/L6qsYPamm7dujW5z6RJidvcuaG8ior68yMexEtKEvPc0pBb9aOOOoolS5Zw7LHHRtNvvPFG/vCHP5CRkcEdd9zRYDyO6dOn89ZbbyWkz549O+pmpD6OPfZYFi5cmJAe61Y91p4f//jHvPvuuxxwwAENlhlxq75mzRreeustZsyYwbZt2wB49tln61213l7YdFyH+jwbd1ZMi+ThtuGYCFyqqhmElnasAi4Drm8rw9zQHFfiXtKUW3U3bsyhcbfqzfmX3ZRb9UMPPbTJaYt+dqteVVXltQm+YcOGDV6b4BtMi+Th9hlHLaEhKoBtIrIXUAbs1yZWucTNArPFixvO69Wr8fwBAxrPd8vs2bM555xzmD9/Pn/961+ZNGkSn3zySTR/zpw5nHjiicycOZNgMMjSpUsB2LRpE5dffnm9vYW6NMflyLPPPsuCBQvYuHEjZ599NjfccAMvvfRSk8ctX76chx9+ONrARPj888+prq5m2LBhrm1oSzqKK5r24OCDD/baBN9gWiQPtz2OzwiFjYWQv6kXCTkk9HR1VUdyZvfll1+Snp5er6+qhx56iPvvv5+NGzdy//33c9lllwGhf/JuGg1o/lTDiD2ZmZmuV7gffvjhCY1GUVERF110Ef/85z9981C6I9WLtsYv/sP8gGmRPNz+Tb0Ip5GZQSjQUm9gTvJNck9HmCXhxq36U089xd/+9jcAzjnnnKgjweaQLLfqzcHcqvufww47zGsTfINpkTxc/UVU1W2qujX8vlJV71TV36tqUdua1zgd4Z+lG7fqgwYNYsmSUFj3999/P/rsoDlEnve01q16c87nV7fqFjrWwcKlOpgWycPtdNzu4RjjOSLyQ/j1ThHxdDC5I/Q4oGm36o899hjXX389aWlpzJo1i0cffRSgWW7VmzOTqDG36gB///vfSU1NpaCggHHjxkV7QB3Frbr1OBwseJGDaZFE3LjQBZ4APiYULnZU+PVD4MnWuOZt7daRQse2Nc0NHdvWWOhYfxCJPW2YFrHQ1m7Vw5wJnKqqi1Q1S1UXhdPOTG4z1jz82uPwwq36ggULzK16GL/WCy9orzrYETAtkodbt+prgJ+p6qaYtP2Ad1TVs7BaY8aM0a+++iou7cgjj+STTz5xtThwV6KystIi34WprKyka9eu/PjHP25wFX5nISsrK2FotLNiWji01q262x7HfEJu1X8tIieLyBXAQuBpEflpZGupES2lvnH9gw8+mPnz53c6T5gWi8MhJSWF+fPn27x9YOjQoV6b4BtMi+ThtsfhZsmlquqBrTfJPWPHjtXMzMy4tOLiYmbOnEl2dnan8oYZCASatQhwV6a2tpaxY8dy3333MXDgQK/N8ZTc3FzfLMz0GtPCoV0COamqL5vq+m6UAwcO5Omnn/bAGm8pLS2lX79+XpvhC0wLh4Zc1HRGTIvk0W5LfUXkJBFZKyLrReSmevJFRP4ezl8tIk2u1ulMPYqm6AhrWtoL08LBtHAwLZJHuzQcItIFeBBnOu/5IlL3KdXJwPDwdgXwUHvYtqvgF3cffsC0cDAtHEyL5NFeSh4JrFfVb1S1GngBOKPOPmcAT4enGX8K9BWRfRsrNBRTygB3LuY7C6aFg2nhYFokj/Z6mrofsDHmcwFwlIt99gPi3JqEZ3RdEf5YJSLx83E7LwOA+qMudT5MCwfTwsG0cBjZmoPbq+Gor2tQdzqXm31Q1UeBRwFEZHlrZgbsSpgWDqaFg2nhYFo4iEirPJu311BVATA45nMqsKkF+xiGYRge014NxxfAcBEZKiLdgfMIhZ6N5TXg4vDsqqOB7eqx913DMAwjkXYZqlLVgIhcRygIVBdCzhHXiMhV4fyHCa1EnwKsByqAX7ko+tE2MrkjYlo4mBYOpoWDaeHQKi1crRw3DMMwjAg2sdkwDMNoFtZwGIZhGM2iwzYcTbkw2ZURkcEi8oGIfC0ia0Tk/4XT9xSR/4YjNP5XRDqFwyYR6SIiX4rIG+HPnVWHviLysohkh+vGhE6sxf+EfxtficjzItKjM2khIk+KSHHsOrfGrl9Ebg7fS9eKyIlNld8hGw6XLkx2ZQLA9ap6CHA0cG34+m8C3lPV4cB74c+dgf8HfB3zubPq8DfgLVU9GEgjpEmn0yIcK+i3wOGqOobQhJzz6FxazANOqpNW7/WH7x3nAaPDx8wN32MbpEM2HLhzYbLLoqpFqroy/H4HoRvEfoQ0eCq821N4HKGxPRCRVOAU4PGY5M6oQx/gOEJhnlHValXdRifUIkxXoKeIdAV6EVoT1mm0UNUPga11khu6/jOAF1S1SlU3EJrZemRj5XfUhqMh9ySdDhEZAhwKfAbsHVn7En7tDMEo5gA3ArGukjujDgcCW4B/hoftHheR3emEWqhqIXAfkE/IZdF2VX2HTqhFHRq6/mbfTztqw+HKPcmujoj0Bl4BZqhqmdf2tDcicipQrKorvLbFB3QFDgMeUtVDgR/YtYdiGiQ8dn8GMBQYBOwuIhd6a5Wvafb9tKM2HJ3ePYmIdCPUaDyrqq+GkzdHPAqHX4u9sq+d+DFwuojkERqu/KmIPEPn0wFCv4kCVf0s/PllQg1JZ9TiBGCDqm5R1RrgVWAinVOLWBq6/mbfTztqw+HGhckui4T8yT8BfK2qf43Jeg24JPz+EuA/7W1be6KqN6tqqqoOIVQH3lfVC+lkOgCo6nfARhGJeD2dDGTRCbUgNER1tIj0Cv9WJhN6DtgZtYiloet/DThPRHYTkaGEYiJ93lhBHXbluIhMITS+HXFhcre3FrUfInIM8BGQiTO2P4vQc44FwP6EfjznqGrdB2S7JCIyCZipqqeKSH86oQ4ikk5okkB34BtCbntS6Jxa/BGYRmgG4pfA5UBvOokWIvI8MImQK/nNwB+Af9PA9YvI/wKXEtJrhqouarT8jtpwGIZhGN7QUYeqDMMwDI+whsMwDMNoFtZwGIZhGM3CGg7DMAyjWVjDYRiGYTQLaziMTknYc+okj869v4iUN+VIzjD8ik3HNTo1InI7cFB44WBbnSMPuFxV322rcxhGe2I9DsNoBWHvq4bRqbCGw+iUiEhe2EniLGBaeOhoVThvDxF5QkSKRKRQRO6KDCuJyHQR+URE7heRrcDtIjJMRN4Xke9FpEREnhWRvuH95xNaqft6+Bw3isgQEdFIoyMig0TkNRHZGg6m8+sYO28XkQUi8rSI7AgPsR3evmoZRjzWcBidmZ3APcCLqtpbVdPC6U8Rcr1wECGX9T8n5LIiwlGEXHoMBO4m5F30XkKeWA8h5DDudgBVvYiQe4fTwuf4cz12PE/I0dwgYCpwj4hMjsk/nZATx76E/Ao90JqLNozWYg2HYcQgInsTiiw5Q1V/UNVi4H5CThQjbFLVf6hqQFUrVXW9qv43HAhnC/BX4CcuzzcYOAb4varuVNUMQv6mLorZ7WNVXaiqtcB8QtH9DMMzbHzWMOI5AOgGFIUcqwKhP1ixgW5i3yMiA4G/A8cCPwrvX+ryfIOAreFIjhG+BWKHo76LeV8B9BCRrqoacHkOw0gq1uMwOjt1pxVuBKqAAaraN7z1UdXRjRxzbzhtnKr2AS4kPjhOY1MXNwF7isiPYtL2BwqbcxGG0Z5Yw2F0djYDQ0QkBaIhNd8B/iIifUQkJfzwu7Ghpx8B5cA2EdkPuKGecxxY34GquhFYCtwrIj1EZBxwGfBsq67KMNoQaziMzs5L4dfvRWRl+P3FhGJaZBEacnoZ2LeRMv5IKNreduBNQhHnYrkXuEVEtonIzHqOPx8YQqj38S/gD6r63+ZfimG0D7YA0DAMw2gW1uMwDMMwmoU1HIZhGEazsIbDMAzDaBbWcBiGYRjNwhoOwzAMo1lYw2EYhmE0C2s4DMMwjGZhDYdhGIbRLP4/vbgSIvgIaZMAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "\n",
@@ -529,15 +238,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:09:48.305829Z",
-     "iopub.status.busy": "2021-12-23T15:09:48.305135Z",
-     "iopub.status.idle": "2021-12-23T15:09:50.893043Z",
-     "shell.execute_reply": "2021-12-23T15:09:50.894061Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We can do everything all over again with angles, almost identically\n",
@@ -563,55 +265,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:09:50.915557Z",
-     "iopub.status.busy": "2021-12-23T15:09:50.905030Z",
-     "iopub.status.idle": "2021-12-23T15:10:39.048409Z",
-     "shell.execute_reply": "2021-12-23T15:10:39.049171Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "step 0\tloss: 21.02607536315918\n",
-      "step 10\tloss: 16.632198333740234\n",
-      "step 20\tloss: 12.741817474365234\n",
-      "step 30\tloss: 9.425061225891113\n",
-      "step 40\tloss: 6.769171714782715\n",
-      "step 50\tloss: 4.838072299957275\n",
-      "step 60\tloss: 3.499711751937866\n",
-      "step 70\tloss: 2.4333364963531494\n",
-      "step 80\tloss: 1.4277300834655762\n",
-      "step 90\tloss: 0.427642822265625\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(100.0, 120.0)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAENCAYAAADZp8imAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABN7ElEQVR4nO2deXxU5fX/3yeBsIiIlIIgIu4gWwSq37iiaN1t3fWnVqyWWm1dKlqxLrgrolK1bkVLRbRaba1adzRqJbUiJCwxGlNiSIjESCCErJM5vz/mTu5knyQzuTeZ83697uvOPPfe557nM3fmmWc7R1QVwzAMw4gnSV4bYBiGYfR+rLIxDMMw4o5VNoZhGEbcscrGMAzDiDtW2RiGYRhxxyobwzAMI+50S2UjIk+LSImIrI1Iu09EckRktYj8Q0SGRBybKyJfi8iXInJsK3kOFZF3RSTX2e/cDUUxDMMwOkF3tWwWA8c1SXsXmKiqk4GvgLkAIrI/cA4wwbnmURFJbiHP64FlqroPsMx5bxiGYfiQbqlsVPUjYHOTtHdUNeC8/Q8w2nn9E+CvqlqjquuBr4EDW8j2J8BfnNd/AX4aa7sNwzCM2NDHawMcfg684LzelVDlE6bQSWvKCFUtBlDVYhEZ3lrmIjIbmA0wcODAafvssw9hzwlJSUkEAgH69u1LbW0t/fv3p7KykoEDBzbbV1dXk5KSQl1dHX369CEYDIbzJxgM0qdPH2pra+nXrx/V1dUMGDCgWR5VVVX079+f2tpa+vTpQ319PUlJoTo/GAySnJxMIBAgJSWl3TxqampISUkhEAiQlJRkZbIyWZmsTHEr06pVq0pV9Yet/c62h+eVjYj8HggAS8NJLZzWJZ86qvok8CTApEmTNDMzsyvZ9Rry8vLYa6+9vDbDF5gWLqaFi2nhIiLfdOV6T2ejiciFwEnAeeo6aSsEdos4bTSwsYXLN4nISCefkUBJNPfs08fz+tU3DB061GsTfINp4WJauJgWscOzykZEjgN+B5yiqpURh14FzhGRfiKyB7AP8N8WsngVuNB5fSHwz2juG27WGlBZWdn+SQmCaeFiWriYFrGju6Y+Pw9kAPuJSKGIXAw8AuwIvCsimSLyOICqrgNeBLKBt4DLVbXeyWeRiEx3sr0HOEZEcoFjnPdGBwj3AxumRSSmhYtpETsk0UIMpKamNhuzKSkpYc6cOeTk5CRUyycYDNqXySFeWiQlJTFu3DgWLFjA8OGtzmHxFaWlpQwbNsxrM3yBaeEiIp+r6vT2z2yZhBvAaKkymTNnDkceeSRPPfUUffv29cAqb6ipqaFfv35em+EL4qVFXV0dS5YsYc6cOTzzzDMxzz8eVFRU2A+sg2kROxLub21LEwRycnI4//zzE6qiAZssEUm8tOjbty8XXHABOTk5cck/HtiPq4tpETsSrrKpra1tlhYMBhOuooGWtUhU4qlF3759e1T3bGFhodcm+AbTInYkXGVj3UYu/fv399oE32BauOy9995em+AbTIvYkXCVTXV1tdcm+IaqqiqvTfANpoXLunXrvDbBN5gWsSPhKpsBAwZ4bUKL5OfnM2DAAFJTUxtcSsybNw+AlmYMPvLII+y9996ICKWlpQ3pL7zwAnvvvTcnnXRSu/ccOHAgixcv5oc//CGXXHJJs+MzZsygurqaq666iv/8x/UgVFtby+zZs9l3330ZN24cL7/8MgBXXHEFt99+e8N5d955J5dffnmjPBcsWNDM5jAbNmzgyCOPZPz48UyYMIE//OEPDceuvfZadtllFxYsWNDsuvT0dHbaaSdOOOEEgKj0O+6445gyZQoTJkzg0ksvbWjxPvjgg4wZM4Zf//rXLYuWAEyZMsVrE3yDaRE7Em6E2M+LtPbaay8yMzN59tln2bhxI9XV1cyfP59Ro0Zx/vnnNzr3kEMO4aSTTmLGjBmN0s8++2xGjBjR4o9yU7Zv395wzSOPPNLoWFVVFcnJyfTv35/PPvuM++67r+HYnXfeyfDhw/nqq68IBoNs3hzysXrHHXeQmprKeeedh4iwaNEiVq1a1XDdhg0bePfddxkzZkyL9vTp04f777+fqVOnsm3bNqZNm8YxxxzD/vvvz3333ccOO+zQalkOO+wwXn/9dSBUYQwePJjt27fz+9//niOOOIIf//jHjc5/8cUXGTx4MKrKGWecwZIlS5g1axZXX301O++8MytWrGhXv97K559/zrRp07w2wxeYFrEj4SqbgQMHtntO0x9wgLPOOovLLruMysrKhn/QkcyaNYtZs2ZRWlrKGWec0ehYenp6h2w8//zzef7557n++ut57rnnOOecc5qdc8ABB3Qoz5Zo7cf7yCOPZMOGDWzbto1JkybxzTff8KMf/Yi77rqLE044gaeffrphdlVSUlLDjJ3Bgwdz5513NrQKbrvtNoYMGdKQ79VXX838+fP5yU9+0uJ9R44cyciRIwHYcccdGT9+PEVFRey///4dKtdvf/tb7rnnHh566CHee+89DjvssGbnDB48GIBAIEBtba1vW7xeYD+uLqZF7Ei4bjQ/t2zCPPfcc2zYsIHrrruOgoICnnvuOQBOOOEENm5syU1c6+Tn53PGGWcwefJkLrvsMj777DM++eQT5syZ09CyacoHH3zA7NmzefTRR3n44Yf55S9/SWZmJieccAJbtmwB4KabbmLq1KmceeaZbNq0qeHac889l7KyMsrLy7ngggsa0l999VV23XXXZt0SGzdubLHyzs/PZ9WqVRx00EEdKi/AwoULGTZsGFdccQVvvfUW7777LgCpqamNzjv22GMZPnw4O+64I8cff3yH79Nb+fzzz702wTeYFrHDWjYt0FZLZODAgW0eHzZsWIdbMk0599xzERHmzZvHdddd1zDm8MYbb3Q4rw8++IBbb72Vfffdl8WLF/OLX/yCH/zgBzzwwANtdkutWrWK008/nTfeeKPRj3QgEKCwsJBDDjmEBx54gAceeIA5c+awZMkSIDRV9Ntvv0VEqKioYNCgQVRWVnLnnXfyzjvvNLvPqFGjmpWroqKC008/nYULFza0QDrClVde2aDfvHnzGvRr6jni7bffprq6mvPOO49PP/2UY445psP36o3Yv3kX0yJ2JFzLpifMOhIJRVkID3CH33eGiy66iAkTJtC3b19+8YtfkJmZybJly5gyZUqLrbxFixaRmprKa6+9xumnn84tt9zCHXfcwXnnnQfAD37wAwYOHMipp54KwJlnnsnKlSsbrr/yyiuZN28eZ511FrfeeisQctO+fv16pkyZwtixYyksLGTq1Kl8++23ze5fV1fH6aefznnnncdpp53WYpk+/fRTUlNTSU1N5dVXX212vCP69e/fn1NOOaVhkoMBa9as8doE32BaxI6Ea9nYegqXlrS45JJLOOWUU7jkkkt49dVXOfDAA/nvf12n2yLCySefTHp6OkcddRTLli1rGFN58803KSkp4Wc/+xmVlZVMmTKFiy66iEmTJlFS4kaAGDt2LCtWrGi2OltVufjiixk/fjy//e1vW7X7oIMOatRK6WhLsqKigm3btjFy5EgCgQBvvPEGhx56aIfy6M3su+++XpvgG0yL2JFwLZuevGo+cszmoYceYvTo0RQWFjJ58uQWpy63R2tafPTRRxx66KFs2LCB3Xffvdnxe++9l3nz5jF58mSWLFnC/fff3zBF+tFHH0VE2GGHHZg/f367U4gjx2w++eQTlixZwvvvv9/QculM12FrhLsDt2/fzimnnMLkyZOZMmUKw4cP56KLLorZfXo6BQUFXpvgG0yL2JFwLZue7A8s8of3iiuu4IorruhSfq256ImcTfe3v/2t2fHdd9+djz76qFn6l19+2ej9aaed1mJXWH5+fsPryDGbQw89tMU1MbEi3BoaMWIEn332WaNj9fX1cbtvT2PEiBFem+AbTIvYkXAtG7/+qCQnJ7N169ZmM6Y6ygsvvMBll13Gzjvv3O65gUCAAQMG8Oabb3aqZdSdXHvttTz77LMtTmpISUlh7dq1Lc5qi5ZAIACE1ujcfffdnZqY0FsIzzg0TItYYvFsgOnTpyfkIr66urqEdEDaEvHWoic9YyUlJT0m9k68MS1cuhrPJuFaNoZhGEb3k3CVTU9y9R5vTAsX08LFnNW6mBaxo1sqGxF5WkRKRGRtRNqZIrJORIIiMj0i/TwRyYzYgiKS2kKe80SkKOK8qDrsk5OTY1Km3kBPniwRa0wLl0gXQ4mOaRE7uqtlsxg4rknaWuA0oNG0JlVdqqqpqpoKXADkq2pmK/k+GD5XVaOaIxseCDZC4xRGCNPCJdL9UKJjWsSOqCsbERkkIqNFZFBHb6KqHwGbm6R9oapftnJJmHOB5zt6v7ZISUmJZXYxo7tCDCQnJ5OamsrGjRsbafHEE0+wePFiMjMzufTSSxvSCwoKOPLIIznggAOYPHlyi+teKisrOfHEExk3bhwTJkzg+uuvbzjWlsv+yDJHlrOtcl988cVMmTKFyZMnc8YZZ1BRURFVudvDr8+FF7TmlTsRMS1iR5uVjYhMFJGHReR/wFagANgqInki8oiITIqzfWfTdmXzaxFZ7XTTtT/XF3/3wYZDDCxdupT58+c3hBhYunRps3MPOeQQ3nvvvWaLLs8++2wWLVrU6j0GDBhAZmYmo0aNaqTFxx9/zGGHHcaHH37YyEvyHXfcwVlnncWqVav461//ymWXXdZivnPmzCEnJ4dVq1bxySef8OabbwIhT8+33XZbu2UGoir3gw8+SFZWFqtXr2bMmDENoRHaK3d7+Pm56G6++uorr03wDaZF7Gi1shGR54HngGLgfGAYkOLsLwCKgKUi8td4GCYiBwGVqrq2lVMeA/YCUh0b728jr9kiskJEVmzZsoXS0lKKi4spKiqirKyMQCBAMBikqqoKVaX+sMNgxoxGe/3jH6mqqiJYUUHw8MPRI44gGLHV/elP1NfXU7VhAzpjBvWHH+7mgRs7prKykmAwSHV1NfX19dTU1FBXV0ddXV3o3vX1nHHGGey6667Mnz+fMWPGNPghi8wjNTW1YcFZOI/a2lpqa2upr68nGAw2KlNTD8/bt29nwIABzJ8/n9TUVP7xj39w2mmnNfhCmz17NjU1NQB8//33qCqbNm1i1KhRDXlF5nnEEUdQXV1NcnIyU6ZM4ZtvvqGuro6amhqCwWCDxmF/bOFrwwPzlZWVnHfeeYwYMYL58+czcuRIzj777IYyBQIBqqurGTRoUOhzCAYpLy9HRBryCvu9Cx+vrq5uCCFQW1vbYE99fX2DLmF7wq2oaD6ncB7V1dUtlikyD1VtuFd+fn6zZy8vL4+qqiqys7MJBoMNfubC3oZXrlxJMBgkOzubqqoq8vLyKCsro6ioiOLiYkpLS8nPz6eiooKcnBwCgQBZWVmN8gjv16xZQ01NDbm5uZSXl1NQUEBJSQklJSUUFBRQXl5Obm4u++67b4NPsKZ5ZGVlEQgEyMnJoaKioseUqaamplNlGjp0aK8rU2c/py6jqi1uwMmtHWty3klRnjcWWNtCejowvYX0B4EbupJ3S9v48eO1KdOmTWuccMQRzbc//jF0bPv2lo//+c+h49991/xYFKxfv14nTJigqqpLly7Ve++9V3/3u9/pvffeq0uXLlVV1eOPP16LiooaXbf77rvrd9991yjtgw8+0BNPPLHF++ywww4NrysqKlRVtaSkRE8++WRVVZ0+fXqj8zdu3KgTJ07UXXfdVYcMGaIrVqxoODZlypRm+ZeVlekee+yheXl5DWl//vOf9fLLL2+zzB0p96xZs3T48OE6Y8YM3b59e1Tlbo+wFvGi2TPmYyI/40THtHABVmgUv7Gtba1OwVHV16KsrF7vXDXXOiKSBJwJHN7GOSNVtdh5eyqhCQftEk2IAdpy7DhwYNvHhw1r+3gUxDLEQFuEV+OvXLmSKVOmsG3btmaeB55//nlmzZrFNddcQ0ZGBhdccAFr164lKSmpmcv+QCDAueeeyxVXXMGee+7ZYXuiLfef//xn6uvr+c1vfsMLL7wQE79mbYVbSDTMrb6LaRE7OjJB4Mcicp2I3Ba5RXnt80AGsJ+IFIrIxSJyqogUAmnAv0Tk7YhLDgcKVfV/TfJZFDFNer6IrBGR1cCRwNXR2NITgqfFKsRAfX19g0PLm2++udnx9evXk5qaykUXXcTSpUs54IADyMrKIjU1lby8PACeeuopzjrrLADS0tKorq5uNCEhktmzZ7PPPvtw1VVXtXh8w4YNDfY8/vjjzY53pNzJycmcffbZMQsN0FoguUTEAoa5mBaxI6rFBSLyCHAW8AEQ+Wsdla8bVT23lUP/aOX8dOD/Wki/JOL1BU2PR0NULZteQnJycrPWRyR77LEHmZmZnHTSSSxevJhHHnmEAw88sJGPsTFjxrBs2TJmzZrFF198QXV1NT/84Q+b5XXjjTeydevWNgfpd9ttt0b2RDrkjAZVJS8vj7333htV5bXXXmPcuHEdyqM1rGXjYv/mXUyL2BFty+ZcYJqqnq2qF0VsP4+ncfGgJwRPa41YhxiorKykvr6e77//nmHDhrF8+fJmcV3uv/9+/vSnPzFlyhTOPfdcFi9e3NDiCE9ZLiws5M477yQ7O5upU6eSmprapZlhTQmXW1W58MILmTRpEpMmTaK4uLjFFltn6Akt3u4iPHBtmBaxJNpl098DW+JoR7fRk4OnxTrEwIABAxARMjIyAFoM27z//vvzySeftHh9uJUyevTouIYGiCx3a7Z0lQEDBsQl357IhAkTvDbBN5gWsaOtqc97hjdC04qXikhaZLpzrEcRns7rN7orxMDgwYMbFnV2x9qStlz2x6rM0LHQCi1h62xcvv76a69N8A2mRexoNcSAiAQJjcm0NTqtqtqjnI1NnTpVw/PJw/Qk9++xpL6+3nzFOcRbi570jFVUVDBoUIcdhfRKTAuXuIUYUNUkVU129q1tPe6XynyjuZgWLqaFS2uzDRMR0yJ2dMoRp9OF1jw4fQ8gKSnhoiq0imnhYlq42D95F9MidkT1DROR50XkYOf1RcA6IFtELo6ncfEgngPZPQ3TwsW0cDEP2C6mReyI9u/cTCDc4fxb4GjgQOD6Vq8wDKNHYoHkXEyL2BFtZZOiqrUisiswVFU/UdV1wIg42hYX/Npd0tTdfpi5c+eSnp7OK6+8wj333NOQ/re//Y0JEyaQlJTU5sDzz3/+c4YPH87EiRMbpV977bWMGTOGBQsWNLsmPT2dnXbaqdHizjDnnnsu+fn5LFy4kL/+1fXBqqr8/ve/Z99992X8+PE89NBDADzwwANcfLHbAF66dCknnnhiozxfeuklRKTFcsQqfEEkLWmalJQUlabV1dUceOCBTJkyhQkTJnDLLbc0HLv22mvZZZddWtS0J5FIC5/bw7SIHdH+8maKyFzgJuBfAE7FUx4vw+KFnweCI93th/n000856KCDmrn+nzhxIn//+985/PBW3ccBMGvWLN56661m6ffdd1+bC0EPO+ywFn2xrV+/nrFjxzazZ/HixWzYsIGcnBy++OILzjnnHCC0Hujzzz/nk08+YcuWLdx44408/PDDDddt27aNhx56iIMOOqhVW2IRviCSljQNBAJRadqvXz/ef/99srKyyMzM5K233uI///kPENI0MhZQT2Xz5s3tn5QAZGzI4M6P7iRjQ4anNtz98d2e2hArol3UeTFwO1AHXOukpQHNA474nPxt+cxYPKNR2rbabQDUB+v5evPXXPCPxp5w+ib35bxJ5/GLqb9gXck6Zr8+u9HxlOQULpl6Cf9v4v9jZfFKrnir8WLLdy54hyH9h1BdV803W79pZtPIHUcCENQgX5aG4snNnzeff3/wbwq/KeSg/zuI9f9bz7vvvctRJx7F5XMuJ+mHof8JlXWVVAdCa0TKa8op3lbcKO8R+4+AstDrLdVb2FThRh7cUruF2u211AZqSemTwuaqzXy3/TsKthZQUVvRYMueO+/JrJ/NYsXKFXxb/C3jJ47nm/XfcPSxR3Pexecx98q5PPbYYzy86GFyN+eGMk+CstLQjR999FEuu+wyJh4wkVPOOYW6wXUNed91411cd911LFiwgO+2f9eQHiY5KZkjjzwSgJLqEvYYvwcrclaw549CS7xKtpc0nFuwtYCqupCHiMLNhdTW15K/JZ+xQ8YCMPs3s/nw/Q8p/KaQqT+aSkF+AW+98xbnnn0uN954I/126UddfR2VdZXkb8lnx9Id2SFlB0YPHg3A15u/pj5YH7pZNVRVVlFZU9ngUeGr77+itLKUSqlsKMdO/Xdil0G7ADR77gDOmnAWl/3oMirrKjlhafOW5KzUWcxKnUVpZSlnvHhGs+O/mv4rzp54Nhu2bmj23AJck3YNJ+93Ml+WfskvX/9ls+M3Hn4jR+95NJnfZnLVW1cBoa6jpI9Dz9ddM+/i4N0OZvmG5dyw7IZm1y88biGpu6Ty3v/e446P7mh2/ImTnmC/Yfvx2pevcX9G8yggS05dwm477cYLa1/gsRWPAbC1Zitbq7eyU/+dePeCdxk2cBiLMxezOHNxs+vfOO8NBvYdyKOfPcqL615sdjx9VjoAC5Yv4PWvGvsMHtB3AG+eF/rjcvuHt7Ns/bKGY1trtrJmU8h9/6NrH+WM8WdQUF7Q6PrRg0fz7GnPAnDVW1eR+W1mo+P7/mBfnjz5SQBmvzabr75vHBsndZdUFh63EIDz/34+heWFjY6PGTyGl754idr6WgAmjZjETv12ajg+c4+Z3HTETQAcv/T4hmc/zEn7nsScg+cA8Xn2OkpULRtVzVPV/6eqF6pqiZP2kqr+rssWdDNB7Rl9sNfNu447HryDU885lQ+Xf8jkyZP5z+f/4fI5l7d53aZvNzH7nNltnhOmI4PiS5cu5dobruXS317KI888wuEzD+eV9Fc484IzAcjLy+OVl1/h9KNP5xdn/4L8vPyGaw8++GDGjx/Px+kfc8mv3dZU9upsvi36tsXomj+d8dNmaVu3bOWDdz4g7bC0qO2O5Ibbb2jQ9G/v/o399t+Pt5e/zc0339zmYt+NGzc26lKsr6/npzN+yiHjD+HwIw9vs1XWE/FygevWmq2s3rSa9VvWs3rTaj4r+swbO6q3Uq/11Gs9tfW1zSqa7qCgvIDa+toGO7ZWb+12G2JKa7EHgAsiXv+8ta0r8Q282FqKK+KHWCNNY7uoqj7++OO6aNEiXb16tV5yySUtXnfEEUfoZ5991uG8VVVvvvlmve+++5qltxYX5vrrr9f33ntPX331Vb3jjjsaHdthhx10wYIFqqr68ssv66GHHtpwbNu2bbr33nvr6NGjdcOGDaqqWl9fr0cccYSuX78+qnLU1dXpcccdpw8++GCj9Ghj5YRpTdNgMNjwOhpNVUOxe2bMmKFr1qxpSLvlllta1NQPz1i01NfXe3bvuz66S5NvTVbmocm3JutdH93liR3LC5brgDsGaPKtyTrgjgG6vGB5QtoQCfGKZ0PI+eYS53VrHpYVeLrrVV730RMcLmZmZjJr1iwKCwsZNmxYQ8TH1NRUMjIyYubHKzyt89NPP+WXvwx1sdx2223NXMu88cYb3HDDDaxfv57XX3+d7777jh122IH33nuPDz74AAj5Rzv99NMBOPXUUxvFmLnllls4//zzGTFiBFdffTV/+9vf2LZtG2vXrmXGjBkAfPvtt5xyyim8+uqrTJ/efJFyNOELTj75ZAAuvfRSjjvuuEbH29M0GAx22PPzkCFDmDFjBm+99VazCRg9lYwNGSxdvpTzDj6PtN0614LsCjPGziAlOYXa+lpSklOYMXZGt9sAkLZbGst+tsxTLcI2pOenM2PsDE9siCldqal64taTWjZpaWlaX1+vF154oa5bt67F67rSsmntX3hLLZtAIKAHH3ywqqoeddRRunXr1kbHf/e73+lTTz3VcH044ufq1at1v/3206qqKq2vr9cf/ehH+s4773SoHL///e/1tNNOa/Efd0dbNl3VtKSkRMvKylRVtbKyUg899FB97bXXGo735JaNX/5JLy9Yrnd9dJfn/+SNxtDFlk2H5wGLSI9eW9MTWjYA3333HTvvvDNJSUnk5OSw//77Nzr+j3/8g9GjR5ORkcGJJ57IscceCzQfXzj33HNJS0vjyy+/ZPTo0Tz11FMNx2pra6O2Z9WqVUyZMoXa2lrq6uqatX6uv/56Xn75ZSZNmsTcuXNZtGgRqsqvfvUrHnzwQfr3709SUhKPPvooV155Zbv3jkf4grY03b59e1SaFhcXc+SRRzJ58mR+9KMfccwxx7Q45tQTSc9PbxgjqK2vJT0/3RM70nZLY+5hc33xT96Cp8WOaGejRXIDcE+7Z/mUnjJv/oc//CH/+te/ABqm1kZy6qmncuqppzZLHzVqVKMpy88//3yr90hJSYnanunTpzd0b3300UfNjg8ZMqTB3kj+/e9/N8snOzu72XnpTUJpxyN8QVua7rDDDlFpOnnyZFatWhUTe/yGX7qw/IQFT4sdnVnh2LkYxT7Bry2bWLrbj4Zrr72WJUuWtDhOkZKSwtq1a1tc1OknYhm+IBZhoa+99lqeffbZHhv1MzxGcOl+l7LsZ8t80bLwmqYe4o3O02qIgVYvEHlMVX8VJ3vizvTp07Xp6vADDzyQTz75hL59+3pklTeoasMakUQnnlrU1dVxyCGH8N///jcu+ceaYDDoW08b3Y1p4RK3EAOt3CwJaH3JduvXPS0iJSKyNiLtTBFZJyJBEZkekT5WRKpEJNPZHm8lz6Ei8q6I5Dr7qKJmtbSGYNy4cSxZsiThnO5ZwDCXeGlRV1fHkiVLGDduXFzyjwc5OTlem+AbTIvYEVXLRkSGAI8CZwB1qrqDiJwCHKiqN0Zx/eFABfCMqk500sYDQeAJYI6qrnDSxwKvh89rI8/5wGZVvceZtLCzRrHItKXgaSUlJQ0uURLJ8Z61bFzipUVSUhLjxo1jwYIFDB8+vNXzMjZk+GaKa1VVlYXJdjAtXLrasol2gsDjhJye7A6ER3czCIWLbreyUdWPnEokMu0LoCtf8J8AM5zXfwHSgXYrm5ZaL8OHD+eZZ57prB09lry8PPbaay+vzfAFXmqRsSGDmc/MbBiY93q8ZOPGjfZcOJgWsaMjIQauUNViQgs5UdXvgNb/qnWNPURklYh8KCKHtXLOCMcenH2rtojIbBFZISIrvv/+e0pLSykuLqaoqIiysjLy8vKoqqoiOzubYDDYMCgYnva4cuVKgsEg2dnZVFVVkZeXR1lZGUVFRRQXF1NaWkp+fj4VFRXk5OQQCATIyspqlEd4v2bNGmpqasjNzaW8vJyCggJKSkooKSmhoKCA8vJycnNzqampYc2aNS3mkZWVRSAQICcnh4qKCvLz8ztVpp133rnXlamzn1NJSYlnZXr363epCdSEphwHQlOOvXz2Bg0a5NvPqbufvUAg0OvK1NnPqatE2432NXCYqhaLyGZVHSoiY4B3VDWqzujWusdEJJ3G3Wj9gEGq+r2ITANeASaoanmT67ao6pCI92Wq2u64zZQpUzT8ISc6RUVF7Lrrrl6b4Qu81MJvLRt7LlxMC5fu6kZbBLwsIr8HkkQkDbiLUPdaTFHVGqDGef25iOQB++IGbwuzSURGOhXgSKAEo0PYLBsXL7Xwm1sSey5cTIvYEW1lcy9QDfwR6EvIH9oTwB9ibZCI/JDQwH+9iOwJ7AP8r4VTXwUuJLTA9ELgn1HmHytTezyJNtW7LbzWIm23NM8rmTBea+EnTIvYEW2IAVXVhaq6v6ruoKrjnfdRLdIRkecJTSjYT0QKReRiETlVRAoJxcX5l4i87Zx+OLBaRLKAl4BLVXWzk8+iiGnS9wDHiEgucAxRejVIpNlm7VFRUeG1Cb7BtHAxLVxMi9jR6piNiBwVTQaq+n5MLYozLU19TlQqKioYNGiQ12b4AtPCxbRwMS1c4jlm81Qbx8IosGdnb+4FHXE+2dspLCzsUYsN44lp4WJauJgWsaPVykZV9+hOQ7qLfv36eW2Cb9h77729NsE3mBYupoWLaRE7Em6qhblocVm3bp3XJvgG08LFtHAxLWJHtOtsNuAs5mxCDVAI/B14TFUDsTUv9rTkiNMwDMNom+5yxPkQIXc1twKXEHLG+T3wZ+AF4ApC6258j19DDHiBBYYKkbEhg1+/8GsyNmR4bYovsOfCxbSIHdG2bNYBx6jqxoi0XQl5EJggIvsB76nqbvEzNTZYy8aIxG+r9w3Dr3RXy2YkIa/NkWwHRjmvvwKGdNaI7sRaNi72r80/oZD9hD0XLqZF7Ii2snkN+KeIHC0i40TkaOBlJx1CCzPz42BfzOkpYaG7Awt564ZCTpZkC4XsYM+Fi2kRO6KtbH4JfErIRc0q4EngM+BS5/j/gBNjbl0ciIX30t5C2GNsIhP2S3b5/pdbF5qDPRcupkXs6HBY6J7OtGnT1JrGIWpqamzdkYNp4WJauJgWLt0WFlpE9hORs0Tk55FbZ2/sFeZBwKWgoMBrE3yDaeFiWriYFrEjKq/PInIDcDOQBUSOsCshD9A9hj59onV03fsZMWKE1yb4BtPCxbRwMS1iR7S/vFcBB6rq6jja0i3U19d7bYJv2LJlC4MHD/baDF9gWriYFi6mReyIthutCsiJpyHdhQVDcunfv7/XJvgG08LFtHAxLWJHtL+8NwEPi8hIEUmK3OJpnGEYhtE7iLYbbbGzvyQiTQiN2STH0qB4Y8HTXMwpqYtp4WJauJgWsSPayqbXhBtITu5RdWNcGTJkiNcm+AbTwsW0cDEtYkdUlY2qfhNvQ7qLQMD3jqm7jU2bNtngp4Np4WJauJgWsaMj62xOEZH7ReQvIvJMeIvy2qdFpERE1kaknSki60QkKCLTI9KPEZHPRWSNs28xPLWIzBORIhHJdLYTorElJSUlmtMSgjFjxnhtgm8wLVxMCxfTInZEVdmIyC2EXNUkAWcSCi9wLLAlyvssBo5rkrYWOA34qEl6KXCyqk4CLgSWtJHvg6qa6mxvRGOI9cG6fPXVV16b4BtMCxfTwsW0iB3Rtmx+TijEwNVArbM/GRgbzcWq+hGwuUnaF6r6ZQvnrooIZbAO6C8iMfMXMWDAgFhl1eOZNGmSp/fP2JDB3R/f7Ys4Ml5r4SdMCxfTInZEW9kMUdVwF1itiPRV1f8CR8TJrjCnA6tUtaaV478WkdVON93OrWUiIrNFZIWIrCgsLKS0tJTi4mKKioooKysjLy+PqqoqsrOzCQaDrFy5EnDdi69cuZJgMEh2djZVVVXk5eVRVlZGUVERxcXFlJaWkp+fT0VFBTk5OQQCAbKyshrlEd6vWbOGmpoacnNzKS8vp6CggJKSEkpKSigoKKC8vJzc3FxqamoanAA2zSMrK4tAIEBOTg4VFRXk5+d3qkwrVqzwrEx/fu/PzHxmJje+fyMzn5nJMx88E5MydfZzevfdd337OXX3s/ff//6315Wps5/Txx9/3OvK1NnPqatEGzxtJXCBqq4TkfeBVwhF7rxdVcdGdSORscDrqjqxSXo6MEdVVzRJnwC8CvxYVfNayG8EoS43BW4HRqpqu77aLHiaP7j747u56YObqNd6kiWZ24+8nbmHzfXaLMMwWqG7HHHeCPzAeX09oTDQ9wG/7eyN20JERgP/AH7WUkUDoKqbVLVeVYPAn4ADo8nbgqe5eOn92m9xZMwTuItp4WJaxI5uCzEQbctGRIYAHwK3qerLbeQ3UlWLnddXAwep6jnt2WEtG/+QsSGD9Px0ZoydYXFkDMPnxK1lIyLDozSgXbeoIvI8kAHsJyKFInKxiJwqIoWEonz+S0Tedk7/NbA3cFPEtObhTj6LIqZJz3emR68GjgSujsZeC57mEu4z9oq03dKYe9hcX1Q0XmvhJ0wLF9MidrTashGRdYRaGEuAT53uqvCxJELdVj8DDm/aWvEzFjzNJRAIWMgFB9PCxbRwMS1c4jlmcwCQTSgE9DanFbFcRNYA24DHgTXA1M7e3Atqalqb2JZ4fP31116b4BtMCxfTwsW0iB2tVtmqWgs8AjwiIrsBk4AhhGahrVbVom6xMMaYBwGX0aNHe22CbzAtXEwLF9MidkTrG20DsCHOtnQL5hvNpbS0lEGDBnlthi8wLVxMCxfTInYkXDwaC57mYl8iF9PCxbRwMS1iR8L98nbXVO+eQF1dndcm+AbTwsW0cDEtYkfCVTaGiwWSczEtXEwLF9MidnSosnFCQY+MlzHdgXWjuQwcONBrE3yDaeFiWriYFrEj2hADQ0TkOaAa+NpJO0VE7oincfHAJgi4bN68uf2TEgTTwsW0cDEtYke0f/MfB7YCuwO1TloGcHY8jIonffv29doE3zBq1CivTfANpoWLaeFiWsSOaCubmcAVji8yBVDV74CoXNr4idra2vZPShDWr1/vtQm+wbRwMS1cTIvYEW1lsxUYFpkgImOA4phbFGf69+/vtQm+IGNDBq+UvuKLwGV+YNy4cV6b4BtMCxfTInZEW9ksAl4WkSOBJBFJA/5CqHutR2EhBkIVzcxnZnLTBzcx85mZVuEAmZmZXpvgG0wLF9MidkRb2dwLvAj8EegLPA38E/hDnOyKGza7BNLz06mtryVIkNr6WtLz0702yXOmTu1RLv7iimnhYlrEjqgqGw2xUFX3V9UdVHW8877HrZC0lk1E4DL8EbjMD5gncBfTwsW0iB3RhoU+qrVjqvp+TC2KMxY8LYQFLjMMoyN0NcRAtIEanmry/odAClAI7NnZm3uBtWxCpO2WRr/v+jF1N+smAFi5cqV1mTiYFi6mRezoVFhoEUkGbgS2qeoDMbcqjkzfdVdd8dJLkGb/5oPBoHlUcDAtXEwLF9PCJZ7B01pFVeuBO4HrOntjz9i4EWbOhAybgZWTk+O1Cb7BtHAxLVxMi9jRlSr7GCAqL3Ui8rSIlIjI2oi0M0VknYgERWR6k/PnisjXIvKliBzbSp5DReRdEcl19jtHbXltLaSnR316b2WPPfbw2gTfYFq4mBYupkXsiNY32gYRKYjYSoG/AddHeZ/FwHFN0tYCpwEfNbnX/sA5wATnmkedbrumXA8sU9V9gGUdsAVSUmDGjKhP761s3LjRaxN8g2nhYlq4mBaxI9oJAuc3eb8d+EpVy6O5WFU/EpGxTdK+ABCRpqf/BPirqtYA60Xka+BAQr7Ymp43w3n9FyAd+F17tgRHjoSXX/ZuzCYjI9SqmjHD83GjoUOHenp/P2FauJgWLqZF7Ih2nc2HTbYV0VY0nWBXGoegLnTSmjLC8dWGs2/VT5uIzBaRFSKy4lugdJ99KC4upqioiLKyMvLy8qiqqiI7O5tgMMjKlSsBd479ypUrCQaDZGdnU1VVRV5eHmVlZRQVFVFcXExpaSn5+flUVFSQk5NDIBAgKyurUR6ff/45ZGQQPOoo9KabCB51FNvfe4+CggJKSkooKSmhoKCA8vJycnNzqampYc2aNc3zALKysggEAuTk5FBRUUF+fj6lpaUdLtP27du7XiZgzZo11NTUkJubS3l5uadl6uzntHbt2l5Xps5+Tlu3bu11Zers51RYWNjrytTZz6mrtDobTUSW4DjdbAtV/VlUNwq1bF5X1YlN0tOBOaq6wnn/RyBDVZ913j8FvKGqLze5bouqDol4X6aq7Y7bTJkyRcMfcrdz991w001QXw/JyXD77TB3rje2AMXFxYwc2aPDE8UM08LFtHAxLVziuc7m685m2kUKgd0i3o8GWuo43SQiI1W12AnoVhJN5i1023UfM2aExotqa30xbmThFlxMCxfTwsW0iB2tVjaqemt3GhLBq8BzIvIAMArYB/hvK+ddCNzj7P8ZTeaehnlNS4Nly3wzZlNRUcGwYcPaPzEBMC1cTAsX0yJ2RDtBABFJAfYjFGqgoXkQjbsaEXme0GD+MBEpBG4BNgMPE/JG8C8RyVTVY1V1nYi8CGQDAeByZ10PIrIIeNzpcrsHeFFELgYKgDOjKUefPlEXOT6kpXleyQCQkcHIt9+GY4/1hz0eYz8oLqaFi2kRO6L1jXYooanO/YDBQDmwI7BBVXuUu5qJEydqeDA4YcnIgJkz0ZoapF+/UGsrwSucnJwci13iYFq4mBYu3eVB4EFgvqoOJeSiZihwO/BoZ2/sFf369fPaBO9JT4faWiQYtAWuDnvvvbfXJvgG08LFtIgd0VY2+9I8ds09wNWxNSf+VFdXe3r/jA0Z3P3x3d4GLHMmKmhysi8mKviBdevWeW2CbzAtXEyL2BFtN1oBMFlVt4hINnAG8D2hhZ07xdnGmOJliIFwhMza+lpSklNY9rNl3rn399HiUsMw/E93daP9HTjBef0U8AHwOaFxnB6FlyEGwhEy67Xe+wiZaWl8/uMfW0XjYEGyXEwLF9MidnQ2xMChhCYIvK2qHs4l7jjWsvER1royjB5Dt7RsROSnItKwuklV/62qb/a0iga8bdmk7ZbGsp8t4/Yjb/dFRePpvzZnRhw33eSLkA/2D9bFtHAxLWJHtGM2mcAYQt1pS1X1gzjbFTcsLLRP8JnrHsMw2qZbWjaqmgocCnwL/ElECkXkfhGZ1tkbe0UsHMr1FsJO/Dwh7LrHJzPiPNXCZ5gWLqZF7OjsmM3/AbcBM1W1pVgzvmXatGlqTeMQNTU13q478tGYjeda+AjTwsW0cOnWsNAispuIXAs8BkwH/tzZG3tFbW2t1yb4hoKCAm8NSEsLdZ35YHKA51r4CNPCxbSIHdFOELhMRP5NyF/ZdOBWYBdVvSSexsUDz32j+YgRI0Z4bYJvMC1cTAsX0yJ2RNuyORl4Ahipqmer6iuq2iObCPX19V6b4Bu2bNnitQm+wbRwMS1cTIvYEdXffFU9Pt6GdBdJSR3qOezV9O/f32sT/EFGBkNffx1OOskXXXpeY8+Fi2kRO+yX10hsnPU+O9x7ry/W+xhGbyXhKhtPg6f5DK+dkvqCsAfs+nrzgO1gz4WLaRE7Eq6ySU7uUTO148qQIUO8NsF7zAN2M+y5cDEtYke7lY2IJItInoj0isnmgUDAaxN8w6ZNm7w2wXucUN3fX3mlBZFzsOfCxbSIHe1OEFDVehGpB/oDNfE3Kb6kpKR4bYJvGDNmjNcm+IO0NHacOhVs8R5gz0UkpkXsiLYbbSHwoogcISJ7icie4S2ai0XkaREpEZG1EWlDReRdEcl19js76eeJSGbEFhSR1BbynCciRRHnndD0nJb4suhLnnzzyagK3dv56quvvDbBN5gWLqaFi2kRO6J1xNnaqLpG465GRA4HKoBnVHWikzYf2Kyq94jI9cDOqvq7JtdNAv6pqs0qNRGZB1So6oJ2CxB53ShRfg5PHPIEs4+f3ZFLDcMwEpbucsSZ1MoW1Wi7qn4EbG6S/BPgL87rvwA/beHSc4Hno7lHh0iClz9/OebZ9jTMR5yLaeFiWriYFrGjM77R/i9G9x6hqsUAzn54C+ecTduVza9FZLXTTbdzayeJyGwRWSEiodgCQTh6r6MpKiqirKyMvLw8qqqqyM7OJhgMsnLlSsB90FauXEkwGCQ7O5uqqiry8vIoKyujqKiI4uJiSktLyc/Pp6KigpycHAKBAFlZWY3yCO/XrFlDTU0Nubm5lJeXU1BQQElJCSUlJRQUFFBeXk5ubi41NTUNHmeb5pGVlUUgECAnJ4eKigry8/MpLS2luLi4Q2U64IADel2ZOvs5hfGqTOufe47gXXfx5eLFnj97EydO9O3n1N3P3i677NLrytTZz6nLqGq7G6FYNp8A2wl1XQGcASyK5nrn/LHA2oj3W5ocL2vy/iBgTRv5jQCSCVWYdwJPR2PHDiN20CfeeEIN1RUrVnhtgm/wVIvly1UHDFBNTg7tly/3zha15yIS08IFWKFR/t63tEXbsnkC+BehUNB1Ttq7wDGdr+bYJCIjAZx9SZPj59BGq0ZVN6lqvYaihf4JODCam44bPc7GahymTetx4YjihqdaOAtL8cnCUnsuXEyL2BFtZXMgcI/zw64AqroV2KkL934VuNB5fSHwz/ABEUkCzgT+2trF4YrK4VRgbWvnRmLB01yadiElMp5q4bNAcvZcuJgWsSNaf/ubgL2BhnmAIrI/EFWwBxF5HpgBDBORQuAW4B5C06kvdvI5M+KSw4FCVf1fk3wWAY+r6gpgvjMlWoF84JfR2GKO9VwmTJjgtQm+wVMtnIWlfgkkZ8+Fi2kRO6Kd+vxz4HrgbuAPhH7YbyDU2lkaVwtjzMSJE3Xt2qgaQb2enJwcxo0b57UZvsC0cDEtXEwLl65OfY42xMDTIrIZmA1sAH4G3KSqr3T2xl5hHgRcRo8e7bUJvsG0cDEtXEyL2BFVZSMiBzkVyytN0g9U1f/Gwa64Yb7RXEpLSxk0aJDXZvgC08LFtHAxLWJHtBME3m0l/a1YGdJdWPA0F/sSuZgWLqaFi2kRO9ps2TizwiT0UsR5HWYvoMc1E6IZo0oU6urq2j8pQTAtXEwLF9MidrT3Nz8A1AIDndd1EVs28GhcreuFZGRkcPfdd5Phg4iQFkjOxbRwyMhg4EMPWcRSB3suYkd7YzZ7EGrNfEhoOrIQmmqswHeq2uMWrXjZjZaRkcHMmTOpra0lJSWFZcuWkebhNNeBAwd6dm+/YVrQECJ7cG0t/OEPFt8Hey5iSZu/vKr6jarmq+ruqvoNofUwtapa0BMrGvB2gkB6ejq1tbXU19dTW1tLuscrxTdvbuobNXExLbAQ2S1gz0XsiOpvvogMEZHngGrgayftFBG5I57GxYO+fft6du8ZM2aQkpJCcnIyKSkpzPB4pfioUaM8vb+fMC2wENktYM9F7Ii2T+lxYCuwO6ExHIAMQl6ZexS1tbXtnxQn0tLSWLZsGbfffrvnXWgA69ev9/T+fsK0oMGTQclvfmNdaA72XMSOaD0IfAeMUtU6EdmsqkOd9K2q2hX/aN3O9OnTdcWKFV6b4QuCwaBNBXcwLVxMCxfTwqVbgqcRatUMa3LjMUBxZ2/sFZWVlV6b4BsyMzO9NsE3mBYupoWLaRE7oq1sFgEvi8iRQJKIpBGKrvl43CyLEza7xGXq1Klem+AbTAsX08LFtIgd0VY29wIvAn8E+gJPEwoJ8Ic42RU3rGXjYiFvXUwLF9PCxbSIHVGN2fQmbMzGMAyj43TXmA0iMtaZ7vz/IrfO3tgrrGXjEo45bpgWkZgWLqZF7Ih2Ntpc4GZgHRC5mFNV9fA42RYXrGXjYjNtXEwLF8+1yMjwTSA5z7XwEd3VsrkGmKaq01X1sIitR1U0ANXV1V6b4AsyMjK45pprfOGjzQ/k5OR4bYJv8FQLx2UON90U2nv8fNpzETuirWy+JxR6ucdjwdNcH20PP/wwM2fOtAoH2GOPPbw2wTd4qoXjMgefuMyx5yJ2RFvZXAU8KSLTRWRM5BbNxSLytIiUiMjaiLShIvKuiOQ6+52d9LEiUiUimc7W4vTq1q5vD3MZ7j8fbX5g48aNXpvgGzzVwnGZg09c5thzETuirWxSgB8D/yXUwglv0fpyWAwc1yTtemCZqu4DLHPeh8lT1VRnu7SVPNu6vlX69IkqOGmvxm8+2vzA0KFDvTbBN3iqheMyh9tv94XLHHsuYke0lc2jwA3AYELrbMJbVH1SqvoR0NR96k8ILQzF2f80Slu6dL3Fp3B9tF177bW+8NHmB2yWoovnWqSlwdy5nlc04AMtehHRVjZ9gD+raoWq1kduXbj3CFUtBnD2wyOO7SEiq0TkQxE5rBPXN0JEZovIChFZ8d1331FaWkpxcTFFRUWUlZWRl5dHVVUV2dnZBIPBhumO4QVdK1euJBgMkp2dTVVVFXl5eZSVlVFUVERxcTGlpaXk5+dTUVFBTk4OgUCArKysRnmE92vWrKGmpobc3FzKy8spKCigpKSEkpISCgoKKC8vJzc3l5qaGtasWdNiHllZWQQCAXJycqioqCA/P7/DZerXrx+/+c1v2GmnnXpNmbryOYUdLvamMnX2c6qvr+91Zers51RWVtbrytTZz6mrRDv1+VpCrZi7tJOrQEVkLPC6qk503m9R1SERx8tUdWcR6QcMUtXvRWQa8AowQVXLm+TX4vXt2ZGamqrm7yhEaWkpw4YNa//EBMC0cDEtXEwLl+6a+nwFMA+oEJGCyK2zNwY2ichIAGdfAqCqNar6vfP6cyAP2Dfa69vDutFcKioqPL2/n0Jke62FnzAtXEyL2BHtaPn5cbj3q8CFwD3O/p8AIvJDYLOq1ovInsA+wP+ivb49bIKAi5f/2PwWItv+vbqYFi6mReyIqmWjqh+2tkVzvYg8TyjY2n4iUigiFxOqJI4RkVzgGOc9wOHAahHJAl4CLlXVzU4+i0Qk3Ixr7fo28TJ4mt8oLCz07N5+m37tpRZ+w7RwMS1iR9SOOEUkFTiMUFwbCaer6s1xsSxOTJs2Tc2Ta4hAIOBZS89vLRsvtfAbpoVDRgb1779P8lFH+WJmnNd0y5iNiMwGPgGOAn4HTCLkwmbvzt7YK8xdjcu6des8u7ffQmR7qYXfMC1ocJuTdPPNvnCb0xuI9u/LdcBxqvqxM+vrVBE5HjgnjrbFhQEDBnhtgm+YMmWKp/dPS0vzvJKBUCsrPT2dyspKX9jjNV4/F77AcZsjwaDrNseejS4R7Wy04ar6sfM6KCJJqvomcHKc7IobtkjLxboT3e68G2+80fzEOdhzQYPbHPWJ25zeQLSVTaGzTgbgK+AnzmLLHjfabmGhXaZNm+a1CZ4TnqgQDAY9najgl2ngGRkZvPPOO57a4Qst0tJYs3AhH86cyZqFCz1r1fhCixgRbTfafGA8IX9otxGaJZZCaP1Nj+KLL75o5gvsrLPO4rLLLqOyspITTjih2TWzZs1i1qxZlJaWcsYZZzQ7/qtf/Yqzzz6bDRs2cMEFFzQ7fs0113DyySfz5Zdf8stf/rLZ8RtvvJGjjz6azMxMrrrqqmbH77rrLg4++GCWL1/ODTfc0Oz4woULSU1N5b333uOOO+5odvyJJ55gv/3247XXXuP+++9vSN+2bRs77rgjS5YsYbfdduOFF17gsccea3b9Sy+9xLBhw1i8eDGLFy9udvyNN95g4MCBPProo7z44ovNjod/wBcsWMDrr7/e6NiAAQN48803ARrGbyL5wQ9+wMsvvwzA3Llzm33pRo8ezbPPPgvAVVddRdMFu/vuuy9PPvkkALNnz+arr75qdHzEiBGkpKQ0zFJ88cUXefvttxuOp6WlcffddwNw+umn8/333ze6fubMmdx0000AHH/88c1WWp900knMmTMHoEUfdGeddRYHHHAAM2fOpKqqiqSkJCZPnsxOO+0EdO+zd9FFF7F69eqGGC6TJ0/mj3/8Y1yevTBNn72tW7c2suH111/n+OOP7/Znb+vWraxZswZVpd/HH3PGv/9NQUHjZYVdffZSU1NZuHAhAOeff36zmW9jxozhpZdeang2J02a1PBcQGyeva787nWUdisbERHgI6AAQFXfdDwsp6hqj1vxZIGQXHbccUevTfCckSNHsmzZMtLT00lPT6empqbbbQi3riC06Hjr1q2NflS6i61btzYseg7b4bUNn3zyCccff7wndtTXh7xx1dbWNqtouoOCgoKG5QFhm7x4LmKGqra7AduBpGjO9fu2//77qxFi9erVXpvgG7zUYvny5TpgwABNTk7WAQMG6PLlyxPWDj/Y4Bc7/GBDJMAK7cJvb7S+0f4NXKKqPT5sna2zcampqaFfv35em+ELvNYiPCNuxowZns6Iy8jI4L333uPoo4/2zA7TorENftACur7OJtrK5g5CLmsWAxuAhotU9enO3twLJk2apGFPqYlObm4u++yzj9dm+ALTwsW0cDEtXLpa2UQ7QeAQQoHSjmiSrkCPqmxsZbTLiBEjvDbBN5gWLqaFi2kRO6L65VXVI+NtSHcRHmwzYMuWLQwePNhrM3yBaeFiWrh4rkVGRmhB6YwZPX5RaYf/5juz0yJ9o/Uon/02G82lf//+XpvgG0wLF9PCxVMtHJc51NaGFpb6IEx2V4jWN9quIvIPEfkeCAB1EZthGIYRaxyXOdTXuy5zejDR/s1/nJC3gJlABTCVUDyZS+NkV9yw4Gku5pTUxbRwMS1cPNXCcZlDL3GZE2032sHAGFXdLiKqqllOTJrlwJ/iZ17sSU5O9toE3zBkyBCvTfANpoWLaeHiqRZpaaGuswQbs6kn1H0GsMWJplkO7BoXq+KIfPVV838IZ50Fl10GlZXQgtsGZs0KbaWl0JLbhl/9Cs4+GzZsgBZchnDNNXDyyfDll9CCyxBuvBGOPhoyM6EFdzXcdRccfDAsXw4tuAxh4UJITYX33oMWXIbwxBOw337w2msQ4TKkT1UVDBgAS5bAbrvBCy9AC+5qeOklGDYMFi8ObU154w0YOBAefRRacBnS0PxfsACauAxhwABwXIZw++2hL1ckP/gBOO5qmDu3uav30aPBcRnCVVeFNIxk333BcRnC7NnQxGUIqamwcCGbNm1i8GWXQdNgWWlp4Lir4fTToYm7GmbOBMdlCMcfD01chnDSSeC4DGnxn6kPn72G5wLi9uw14PNnb9M994QmCMTx2QPg/PNbf/bS0vz57HWQaLvRPgXC1rwNvAD8HVjRZQu6GZsg4NLfFnQ2MGbMGK9N8A32XLjYcxE7ol3UOYSQu5rNIjIAmAMMAhaqanF8TYwtEyZMUAsOFWLNmjVMmjTJazN8gWnhYlq4mBYu3eJBoKuIyNPASUCJqk500oYSaiGNJeRN+ixVLRORY4B7CHmVrgWuVdX3W8hzHvAL4Dsn6QZVfaM9W6ZPn64rVvS4BplhGIandFdY6BQRuU1EckVku7O/XUSinYS+GDiuSdr1wDJV3QdY5rwHKAVOVtVJwIXAkjbyfVBVU52t3YoGLHhaJOYjzsW0cDEtXEyL2BFtN9pTwH7AncA3wO7AXOBrVf15VDcKBV97PaJl8yUwQ1WLRWQkkK6q+zW5RghVPqNUtabJsXlAhaouiOb+YaxlYxiG0XG6pWUD/BQ4SVXfVNVsDYWE/qmzdZYR4fEeZz+8hXNOB1Y1rWgi+LWIrBaRp50YO+1iLRsX+9fmYlq4mBYupkXsiLay+RZoGk95ABC3yQEiMgG4F2hhviYAjwF7AamOHS3Mq2zIa7aIrBCRFVu3bqW0tJTi4mKKioooKysjLy+PqqoqsrOzCQaDrFy5EnAftJUrVxIMBsnOzqaqqoq8vDzKysooKiqiuLiY0tJS8vPzqaioICcnh0AgQFZWVqM8wvs1a9ZQU1NDbm4u5eXlFBQUUFJSQklJCQUFBZSXl5Obm0tNTQ1h79RN88jKyiIQCJCTk0NFRQX5+fmdKtMBBxzQ68rU2c8pTG8qU2c/p4kTJ/a6MnX2c9pll116XZk6+zl1lWi70a4H/h/wMFAI7AZcDjwHfBY+r6WB/Ig8xhJlN5qIjAbeBy5S1U+isK9R3m1hs9FcsrKymDJlitdm+ALTwsW0cDEtXLorns36KPJSVd2zjTzG0riyuQ/4XlXvcSqzoap6nTPN+kPgNlV9uY38Roa74UTkauAgVT2nPSMteJpLIBCwkAsOpoWLaeFiWrh0y5iNqu4RxdZWRfM8kAHsJyKFjqube4BjRCQXCE93Bvg1sDdwk4hkOttwJ59FIhIu7HwRWSMiq4EjgaujKYsXMeb9ytdff+21Cb7BtHAxLVxMi9jRLets/MTUqVM13DeZ6FRUVDBo0CCvzfAFpoWLaeFiWrh012y0XkMgEGj/pAShtLTUaxN8g2nhYlq4mBaxI+EqG/ON5mL/2FxMCxfTwsW0iB0J98ubaN2GbVFXZ7HvwpgWLqaFi2kROxKusjFcLJCci2nhYlq4mBaxI+EqG+tGcxk4sOk63cTFtHAxLVxMi9iRcL+8NkHAZfPmzV6b4BtMCxfTwsW0iB0JV9n07dvXaxN8w6hRo7w2wTeYFi6mhYtpETsSrrKpra312gTfsH59NI4hEgPTwsW0cDEtYkfCLeq0EAMuwWDQxrAcTAsX08LFtHCxRZ0dxEIMuGRmZnptgm8wLVxMCxfTInZYy8YwDMNoF2vZdBBr2biY92sX08LFtHAxLWKHtWwMwzCMdrGWTQexlo2Leb92MS1cTAsX0yJ2WMsmgbGZNi6mhYtp4WJauFjLpoNUV1d7bYJvyMnJ8doE32BauJgWLqZF7Ei4yiYlJcVrE3zDHnvs4bUJvsG0cDEtXEyL2JFwlY25DHfZuHGj1yb4BtPCxbRwMS1iR8JVNn369PHaBN8wdOhQr03wDaaFi2nhYlrEjm6pbETkaREpEZG1EWlDReRdEcl19jtHHJsrIl+LyJcicmwrebZ6fVtYfAoXm5nnYlq4mBYupkXs6K6WzWLguCZp1wPLVHUfYJnzHhHZHzgHmOBc86iIJLeQZ4vXG9Fjs2xcTAsX08LFtIgd3aKkqn4ENA0M8RPgL87rvwA/jUj/q6rWqOp64GvgwBaybe36NhGRqO3u7Vi4BRfTwsW0cDEtYoeXAxgjVLUYQFWLRWS4k74r8J+I8wqdtGivb4aIzAZmO29rIrvzEpxhQKnXRvgE08LFtHAxLVz268rFfhwtb6np0aWVp6r6JPAkgIis6MrCpN6EaeFiWriYFi6mhYuIdGk1vJcdkptEZCSAsy9x0guB3SLOGw20NP+wtesNwzAMn+FlZfMqcKHz+kLgnxHp54hIPxHZA9gH+G8HrjcMwzB8RndNfX4eyAD2E5FCEbkYuAc4RkRygWOc96jqOuBFIBt4C7hcVeudfBaJSLhJ2+L1UfBkjIrVGzAtXEwLF9PCxbRw6ZIWCeeI0zAMw+h+bBK5YRiGEXessjEMwzDiTsJUNiJynOP+5msRSShvAyKym4h8ICJfiMg6EbnSSe+Uy5/egIgki8gqEXndeZ+QWojIEBF5SURynOcjLYG1uNr5fqwVkedFpH+iaBEPl2JNSYjKxnF380fgeGB/4FzHLU6iEACuUdXxwP8BlzvlT2SXP1cCX0S8T1Qt/gC8parjgCmENEk4LURkV+AKYLqqTgSSCbnNShQtFhN7l2KNSIjKhpC7m69V9X+qWgv8lZC7m4RAVYtVdaXzehuhH5Rd6aTLn56OiIwGTgQWRSQnnBYiMhg4HHgKQFVrVXULCaiFQx9ggIj0AQYSWt+XEFrEyaVYIxKlstkV2BDxvjUXOL0eERkLHAB8ShOXP0CrLn96GQuB64BIF+CJqMWewHfAn50uxUUisgMJqIWqFgELgAKgGNiqqu+QgFpE0FrZO/V7miiVTcxd4PRERGQQ8DJwlaqWe22PF4jISUCJqn7utS0+oA8wFXhMVQ8AttN7u4naxBmP+AmwBzAK2EFEzvfWKt/Sqd/TRKlsonWB02sRkb6EKpqlqvp3JzkRXf4cApwiIvmEulOPEpFnSUwtCoFCVf3Uef8SoconEbU4Glivqt+pah3wd+BgElOLMF11KdaIRKlsPgP2EZE9RCSF0ODWqx7b1G1IKK7CU8AXqvpAxKGEc/mjqnNVdbSqjiX0HLyvqueTmFp8C2wQkbA335mEPHcknBaEus/+T0QGOt+XmYTGNhNRizBddSnWiITxICAiJxDqq08GnlbVO721qPsQkUOBj4E1uOMUNxAat3kRGEPoy3amqjYdJOy1iMgMYI6qniQiPyABtRCRVEITJVKA/wEXEfoTmoha3AqcTWj25irgEmAQCaCF41JsBqGQCpuAW4BXaKXsIvJ74OeEtLpKVd9s9x6JUtkYhmEY3pEo3WiGYRiGh1hlYxiGYcQdq2wMwzCMuGOVjWEYhhF3rLIxDMMw4o5VNoYRJY5H4Bke3XuMiFRE4/DQMPyITX02jA4iIvOAvZ3FoPG6Rz5wiaq+F697GEZ3Yi0bw+hmHK/ChpFQWGVjGFEiIvmOI88bgLOdbq0s59hOIvKUiBSLSJGI3BHu8hKRWSLyiYg8KCKbgXkispeIvC8i34tIqYgsFZEhzvlLCK3afs25x3UiMlZENFxRicgoEXlVRDY7Qax+EWHnPBF5UUSeEZFtTvff9O5VyzAaY5WNYXSMauAu4AVVHaSqU5z0vxBy3bE3oRAOPybk7iTMQYTcwQwH7iTkOfduQh6GxxNybDgPQFUvIOQe5GTnHvNbsON5Qg4RRwFnAHeJyMyI46cQcjQ6hJAvq0e6UmjD6CpW2RhGFxGREYSiwF6lqttVtQR4kJCjzzAbVfVhVQ2oapWqfq2q7zoBqL4DHgCOiPJ+uwGHAr9T1WpVzSTk3+yCiNP+rapvqGo9sIRQFE7D8AzrOzaMrrM70BcoDjkMBkJ/5CIDTEW+RkSGAw8BhwE7OueXRXm/UcBmJ+pqmG+AyK6ybyNeVwL9RaSPqgaivIdhxBRr2RhGx2k6hXMDUAMMU9UhzjZYVSe0cc3dTtpkVR0MnE/joFRtTRPdCAwVkR0j0sYARR0phGF0J1bZGEbH2QSMFZEkaAiZ+w5wv4gMFpEkZwJAW91iOwIVwBYR2RW4toV77NnShaq6AVgO3C0i/UVkMnAxsLRLpTKMOGKVjWF0nL85++9FZKXz+meEYsJkE+oOewkY2UYetxKKirkV+BehyJCR3A3cKCJbRGROC9efC4wl1Mr5B3CLqr7b8aIYRvdgizoNwzCMuGMtG8MwDCPuWGVjGIZhxB2rbAzDMIy4Y5WNYRiGEXessjEMwzDijlU2hmEYRtyxysYwDMOIO1bZGIZhGHHn/wNIXTmCFyJ1ygAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "\n",

--- a/examples/packed_box.ipynb
+++ b/examples/packed_box.ipynb
@@ -2,16 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "40714e5a-2dce-44ca-a9b9-9c9abee01caa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:10:46.033877Z",
-     "iopub.status.busy": "2021-12-23T15:10:46.032682Z",
-     "iopub.status.idle": "2021-12-23T15:10:56.554081Z",
-     "shell.execute_reply": "2021-12-23T15:10:56.554563Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pprint import pprint\n",
@@ -29,15 +22,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "792ab4fc-baf0-4352-8f24-5dc0be3e5180",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:10:56.560710Z",
-     "iopub.status.busy": "2021-12-23T15:10:56.559677Z",
-     "iopub.status.idle": "2021-12-23T15:10:57.042457Z",
-     "shell.execute_reply": "2021-12-23T15:10:57.043424Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -50,16 +37,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c8b95182-dd20-43be-9c3a-36e2440022ca",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:10:57.052362Z",
-     "iopub.status.busy": "2021-12-23T15:10:57.051330Z",
-     "iopub.status.idle": "2021-12-23T15:24:31.208836Z",
-     "shell.execute_reply": "2021-12-23T15:24:31.209351Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The OpenFF Topology currently requires that all molecular representations have\n",
@@ -74,16 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "40331ad6-f8f0-4eaf-ba77-8070293dbafa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:24:31.216019Z",
-     "iopub.status.busy": "2021-12-23T15:24:31.215157Z",
-     "iopub.status.idle": "2021-12-23T15:24:31.895250Z",
-     "shell.execute_reply": "2021-12-23T15:24:31.895974Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load in a mainline OpenFF force field\n",
@@ -92,16 +65,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "e7437723-5c17-4dc7-ad9b-cd98ad3ae6fd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:24:31.976948Z",
-     "iopub.status.busy": "2021-12-23T15:24:31.938255Z",
-     "iopub.status.idle": "2021-12-23T15:42:56.517707Z",
-     "shell.execute_reply": "2021-12-23T15:42:56.519260Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an Interchange object\n",
@@ -110,16 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "948afe33-1281-493b-afbb-b351d4af7b91",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:42:56.534968Z",
-     "iopub.status.busy": "2021-12-23T15:42:56.531312Z",
-     "iopub.status.idle": "2021-12-23T15:42:56.556192Z",
-     "shell.execute_reply": "2021-12-23T15:42:56.557398Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The OpenFF Topology represents a chemical graph without explicit positions, so\n",
@@ -129,16 +88,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8b1c0f1b-2da8-4a23-a5f6-e97158d919ab",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:42:56.566970Z",
-     "iopub.status.busy": "2021-12-23T15:42:56.565486Z",
-     "iopub.status.idle": "2021-12-23T15:42:56.569157Z",
-     "shell.execute_reply": "2021-12-23T15:42:56.569850Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Topology.from_openmm(), however, reads the periodic vectors from the PDB file and\n",
@@ -152,25 +104,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "6b49e507-f19c-4945-bd7b-cc722e6dc03d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T15:42:56.577748Z",
-     "iopub.status.busy": "2021-12-23T15:42:56.575253Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.018023Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.018532Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The Interchange package includes a module for obtaining single-point energies of\n",
     "# Interchange objects by calling out to molecular mechanics engines. Here we query,\n",
@@ -188,157 +125,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "5b58bf55-302b-464a-8d89-740bcfdb7803",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:11.027811Z",
-     "iopub.status.busy": "2021-12-23T16:27:11.025307Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.031216Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.031637Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Energies:\n",
-      "\n",
-      "Bond:          \t\t42.18247985839844 kJ / mol\n",
-      "Angle:         \t\t17956.1171875 kJ / mol\n",
-      "Torsion:       \t\t1310.050048828125 kJ / mol\n",
-      "Nonbonded:     \t\tNone\n",
-      "vdW:           \t\t-7173.355622467902 kJ / mol\n",
-      "Electrostatics:\t\t-2839.989448849101 kJ / mol\n",
-      "\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(openmm_energies)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "6933beb9-48f9-407c-9289-e011b00cf28c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:11.037252Z",
-     "iopub.status.busy": "2021-12-23T16:27:11.035704Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.039273Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.039758Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Energies:\n",
-      "\n",
-      "Bond:          \t\t42.18257141113281 kJ / mol\n",
-      "Angle:         \t\t17956.171875 kJ / mol\n",
-      "Torsion:       \t\t1310.049072265625 kJ / mol\n",
-      "Nonbonded:     \t\tNone\n",
-      "vdW:           \t\t-7173.39599609375 kJ / mol\n",
-      "Electrostatics:\t\t-2841.615219116211 kJ / mol\n",
-      "\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(gromacs_energies)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "0176e44f-1f48-407c-b585-ad1460710320",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:11.048628Z",
-     "iopub.status.busy": "2021-12-23T16:27:11.047781Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.050656Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.051062Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Energies:\n",
-      "\n",
-      "Bond:          \t\t11.541868 kcalorie_per_mole\n",
-      "Angle:         \t\t4291.6175 kcalorie_per_mole\n",
-      "Torsion:       \t\t313.10955 kcalorie_per_mole\n",
-      "Nonbonded:     \t\tNone\n",
-      "vdW:           \t\t-1832.22855 kcalorie_per_mole\n",
-      "Electrostatics:\t\t-678.79 kcalorie_per_mole\n",
-      "\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(lammps_energies)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "35e93c9b-7643-4742-ae31-d3d80c7ff8cc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:11.058859Z",
-     "iopub.status.busy": "2021-12-23T16:27:11.057833Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.064426Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.065095Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'Angle': <Quantity(-0.0546875, 'kilojoule / mole')>,\n",
-      " 'Bond': <Quantity(-9.15527344e-05, 'kilojoule / mole')>,\n",
-      " 'Electrostatics': <Quantity(1.62577027, 'kilojoule / mole')>,\n",
-      " 'Torsion': <Quantity(0.0009765625, 'kilojoule / mole')>,\n",
-      " 'vdW': <Quantity(0.0403736258, 'kilojoule / mole')>}\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pprint(openmm_energies - gromacs_energies)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ab97cb6b-d0df-4356-a9a0-4ad5378503fd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:11.071059Z",
-     "iopub.status.busy": "2021-12-23T16:27:11.070346Z",
-     "iopub.status.idle": "2021-12-23T16:27:11.073083Z",
-     "shell.execute_reply": "2021-12-23T16:27:11.073650Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'Angle': <Quantity(-0.0104325, 'kilojoule / mole')>,\n",
-      " 'Bond': <Quantity(-6.10869585, 'kilojoule / mole')>,\n",
-      " 'Electrostatics': <Quantity(0.0679111509, 'kilojoule / mole')>,\n",
-      " 'Torsion': <Quantity(-0.000308371875, 'kilojoule / mole')>,\n",
-      " 'vdW': <Quantity(492.688631, 'kilojoule / mole')>}\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pprint(openmm_energies - lammps_energies)"
    ]

--- a/examples/parameter_replacement.ipynb
+++ b/examples/parameter_replacement.ipynb
@@ -2,15 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:16.975748Z",
-     "iopub.status.busy": "2021-12-23T16:27:16.974997Z",
-     "iopub.status.idle": "2021-12-23T16:27:24.053072Z",
-     "shell.execute_reply": "2021-12-23T16:27:24.053523Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openff.toolkit.topology import Molecule, Topology\n",
@@ -21,15 +14,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:24.058245Z",
-     "iopub.status.busy": "2021-12-23T16:27:24.057662Z",
-     "iopub.status.idle": "2021-12-23T16:27:24.070077Z",
-     "shell.execute_reply": "2021-12-23T16:27:24.070585Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an OpenFF Topology consisting of two ethanol molecules\n",
@@ -38,15 +24,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:24.074512Z",
-     "iopub.status.busy": "2021-12-23T16:27:24.073953Z",
-     "iopub.status.idle": "2021-12-23T16:27:25.092480Z",
-     "shell.execute_reply": "2021-12-23T16:27:25.093252Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load in two versions of OpenFF 1.x.x (\"Parsley\")\n",
@@ -56,15 +35,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:25.119442Z",
-     "iopub.status.busy": "2021-12-23T16:27:25.118867Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.938217Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.938652Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Construct an Interchange object from each force field and the common topology\n",
@@ -74,29 +46,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.948690Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.948069Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.950586Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.950959Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[*:1]~[#6X4:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(101.737336, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(107.660782, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[*:1]-[#8:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(112.364889, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(110.25178, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[#1:1]-[#6X4:2]-[#1:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(74.2870153, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(107.599151, 'degree')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look into each object's angle values ...\n",
     "sys_100.handlers[\"Angles\"].potentials"
@@ -104,29 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.955089Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.954439Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.956862Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.957475Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[*:1]~[#6X4:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(99.2339941, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(113.65694, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[*:1]-[#8:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(134.501978, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(110.289839, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[#1:1]-[#6X4:2]-[#1:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(66.5522943, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(114.294085, 'degree')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# ... and notice that they're (slightly) different values\n",
     "sys_130.handlers[\"Angles\"].potentials"
@@ -134,15 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.963123Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.960852Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.965361Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.965744Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# This can be verified by directly comparing the objects\n",
@@ -151,15 +76,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.969975Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.969167Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.981698Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.982213Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# (This first step not strictly necessary, as the typing did not change between versions of this force field line)\n",
@@ -172,15 +90,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.987512Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.986968Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.988830Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.989206Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert sys_100.handlers[\"Angles\"] == sys_130.handlers[\"Angles\"]"
@@ -188,29 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:27.995178Z",
-     "iopub.status.busy": "2021-12-23T16:27:27.993900Z",
-     "iopub.status.idle": "2021-12-23T16:27:27.998044Z",
-     "shell.execute_reply": "2021-12-23T16:27:27.998426Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[*:1]~[#6X4:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(99.2339941, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(113.65694, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[*:1]-[#8:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(134.501978, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(110.289839, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[#1:1]-[#6X4:2]-[#1:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(66.5522943, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(114.294085, 'degree')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Or, more verbosely, we can again inspect the objects themselves ...\n",
     "sys_100.handlers[\"Angles\"].potentials"
@@ -218,29 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:28.003086Z",
-     "iopub.status.busy": "2021-12-23T16:27:28.002474Z",
-     "iopub.status.idle": "2021-12-23T16:27:28.004783Z",
-     "shell.execute_reply": "2021-12-23T16:27:28.005447Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[*:1]~[#6X4:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(99.2339941, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(113.65694, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[*:1]-[#8:2]-[*:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(134.501978, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(110.289839, 'degree')>}, map_key=None),\n",
-       " PotentialKey(id='[#1:1]-[#6X4:2]-[#1:3]', mult=None, associated_handler='Angles', bond_order=None): Potential(parameters={'k': <Quantity(66.5522943, 'kilocalorie / mole / radian ** 2')>, 'angle': <Quantity(114.294085, 'degree')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# ... and see that they are now both using the `openff-1.3.0` values\n",
     "sys_130.handlers[\"Angles\"].potentials"
@@ -248,15 +119,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:28.011895Z",
-     "iopub.status.busy": "2021-12-23T16:27:28.010673Z",
-     "iopub.status.idle": "2021-12-23T16:27:28.013001Z",
-     "shell.execute_reply": "2021-12-23T16:27:28.013382Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# But we didn't change any other values, i.e. bonds\n",
@@ -265,15 +129,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:28.017048Z",
-     "iopub.status.busy": "2021-12-23T16:27:28.016269Z",
-     "iopub.status.idle": "2021-12-23T16:27:28.018000Z",
-     "shell.execute_reply": "2021-12-23T16:27:28.018541Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# TODO: Add a trip to disk"

--- a/examples/parameter_splitting.ipynb
+++ b/examples/parameter_splitting.ipynb
@@ -2,15 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:32.272933Z",
-     "iopub.status.busy": "2021-12-23T16:27:32.272199Z",
-     "iopub.status.idle": "2021-12-23T16:27:36.651857Z",
-     "shell.execute_reply": "2021-12-23T16:27:36.652368Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import openmm\n",
@@ -24,15 +17,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:36.657518Z",
-     "iopub.status.busy": "2021-12-23T16:27:36.656960Z",
-     "iopub.status.idle": "2021-12-23T16:27:37.863923Z",
-     "shell.execute_reply": "2021-12-23T16:27:37.864667Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "propanol = Molecule.from_smiles(\"CCCO\")\n",
@@ -44,15 +30,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:37.890191Z",
-     "iopub.status.busy": "2021-12-23T16:27:37.887157Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.245560Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.246027Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "interchange = Interchange.from_smirnoff(sage, topology)\n",
@@ -62,62 +41,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.255603Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.254967Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.257700Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.258147Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{TopologyKey(atom_indices=(0, 1), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 4), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 5), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 6), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 2), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 7), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 8), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(2, 3), mult=None, bond_order=None): PotentialKey(id='[#6:1]-[#8:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(2, 9), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(2, 10), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(3, 11), mult=None, bond_order=None): PotentialKey(id='[#8:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None)}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "interchange.handlers[\"Bonds\"].slot_map"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.264400Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.263587Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.265941Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.266502Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 1) PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None)\n",
-      "(1, 2) PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for bond in topology.bonds:\n",
     "    if all(atom.atomic_number == 6 for atom in bond.atoms):\n",
@@ -141,15 +76,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.270109Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.269565Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.271775Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.272152Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# First, clone the existing C-C bond PotentialKey\n",
@@ -159,28 +87,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.278015Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.277140Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.280168Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.280549Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " PotentialKey(id='[#6X4:1]-[#6X4:2]_MODIFIED', mult=None, associated_handler='Bonds', bond_order=None))"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect the original and modified keys\n",
     "(pot_key, pot_key_mod)"
@@ -188,15 +97,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.285516Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.284839Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.286554Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.287017Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Look up the existing potential on these bonds and modify the k value by 5%\n",
@@ -207,28 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.291189Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.290616Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.294306Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.295073Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Potential(parameters={'k': <Quantity(529.242972, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.52190126, 'angstrom')>}, map_key=None),\n",
-       " Potential(parameters={'k': <Quantity(555.70512, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.52190126, 'angstrom')>}, map_key=None))"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect the original and modified keys\n",
     "(pot, pot_mod)"
@@ -236,14 +119,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.299121Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.298567Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.301162Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.301607Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -261,15 +138,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.305617Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.304959Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.306556Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.307004Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a topology key representing this bond\n",
@@ -278,15 +148,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.312112Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.311067Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.313258Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.313637Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# This topology key is already in the handler, as it points to an existing bond\n",
@@ -302,15 +165,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.317622Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.317024Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.319402Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.319779Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "interchange.handlers[\"Bonds\"].slot_map[top_key] = pot_key_mod"
@@ -318,42 +174,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.323700Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.323053Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.326890Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.327715Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Potential(parameters={'k': <Quantity(555.70512, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.52190126, 'angstrom')>}, map_key=None)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "interchange.handlers[\"Bonds\"].potentials[pot_key_mod]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.332583Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.331998Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.613391Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.614199Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# openff_sys[\"Electrostatics\"].method = \"cutoff\"\n",
@@ -362,15 +193,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:40.621082Z",
-     "iopub.status.busy": "2021-12-23T16:27:40.620347Z",
-     "iopub.status.idle": "2021-12-23T16:27:40.622574Z",
-     "shell.execute_reply": "2021-12-23T16:27:40.622967Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Look at the force constant in the original and modified OpenMM exports\n",

--- a/examples/protein_ligand/protein_ligand.ipynb
+++ b/examples/protein_ligand/protein_ligand.ipynb
@@ -422,7 +422,6 @@
     "jupyter": {
      "outputs_hidden": true
     },
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],

--- a/examples/smirnoff_argon.ipynb
+++ b/examples/smirnoff_argon.ipynb
@@ -2,15 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:45.325243Z",
-     "iopub.status.busy": "2021-12-23T16:27:45.324564Z",
-     "iopub.status.idle": "2021-12-23T16:27:49.824599Z",
-     "shell.execute_reply": "2021-12-23T16:27:49.825261Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -24,15 +17,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:49.833969Z",
-     "iopub.status.busy": "2021-12-23T16:27:49.832373Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.057950Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.058392Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load a minimal SMIRNOFF forcefield and Argon topology\n",
@@ -46,15 +32,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.072101Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.068969Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.678876Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.678206Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use a monkey-patched function to parametrize the topology against a force field\n",
@@ -63,27 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.687784Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.687073Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.689690Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.690067Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['vdW', 'Electrostatics'])"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at which ParameterHandler objects from the OpenFF toolkit\n",
     "# have been made into Potentialhandler objects\n",
@@ -92,15 +53,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.695016Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.694029Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.696169Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.696642Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Store this handler to inspect its contents\n",
@@ -109,27 +63,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.701362Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.700745Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.703102Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.703640Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('vdW', '4*epsilon*((sigma/r)**12-(sigma/r)**6)', {'r'})"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at some ~metadata\n",
     "vdw.type, vdw.expression, vdw.independent_variables"
@@ -137,36 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.707831Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.707207Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.711798Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.712194Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{TopologyKey(atom_indices=(0,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(2,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(3,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(4,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(5,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(6,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(7,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(8,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None),\n",
-       " TopologyKey(atom_indices=(9,), mult=None, bond_order=None): PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None)}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Return a mapping between atom indices and SMIRKS identifiers\n",
     "vdw.slot_map"
@@ -174,27 +83,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.716484Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.715643Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.718270Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.718737Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[#18:1]', mult=None, associated_handler='vdW', bond_order=None): Potential(parameters={'sigma': <Quantity(0.3, 'nanometer')>, 'epsilon': <Quantity(0.1, 'kilojoules_per_mole')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Return a mapping between SMIRKS identifiers and Potential objects;\n",
     "# Note the de-duplication, resulting from a many-to-few mapping between\n",
@@ -204,27 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.722989Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.722319Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.724629Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.725192Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Potential(parameters={'sigma': <Quantity(0.3, 'nanometer')>, 'epsilon': <Quantity(0.1, 'kilojoules_per_mole')>}, map_key=None)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at this contents of this Potential object\n",
     "potential_key = PotentialKey(id=\"[#18:1]\", associated_handler=\"vdW\")\n",
@@ -233,33 +106,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.730951Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.730337Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.733456Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.733045Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "0.3 nm"
-      ],
-      "text/latex": [
-       "$0.3\\ \\mathrm{nm}$"
-      ],
-      "text/plain": [
-       "0.3 <Unit('nanometer')>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Further, look at the particular value of one of its parameters\n",
     "vdw.potentials[potential_key].parameters[\"sigma\"]"
@@ -267,33 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:50.738896Z",
-     "iopub.status.busy": "2021-12-23T16:27:50.738270Z",
-     "iopub.status.idle": "2021-12-23T16:27:50.740641Z",
-     "shell.execute_reply": "2021-12-23T16:27:50.741179Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "0.3 nm"
-      ],
-      "text/latex": [
-       "$0.3\\ \\mathrm{nm}$"
-      ],
-      "text/plain": [
-       "0.3 <Unit('nanometer')>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look up, from the highest-level object, this same data, using the\n",
     "# SMIRKS pattern as a key connecting the topological data to the\n",

--- a/examples/smirnoff_ethanol.ipynb
+++ b/examples/smirnoff_ethanol.ipynb
@@ -2,15 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:55.474613Z",
-     "iopub.status.busy": "2021-12-23T16:27:55.473904Z",
-     "iopub.status.idle": "2021-12-23T16:27:59.801703Z",
-     "shell.execute_reply": "2021-12-23T16:27:59.802147Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -24,15 +17,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:27:59.807028Z",
-     "iopub.status.busy": "2021-12-23T16:27:59.806366Z",
-     "iopub.status.idle": "2021-12-23T16:28:00.352012Z",
-     "shell.execute_reply": "2021-12-23T16:28:00.352420Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load in a mainline OpenFF forcefield and construct a minimal ethanol topology\n",
@@ -43,15 +29,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:00.380765Z",
-     "iopub.status.busy": "2021-12-23T16:28:00.379776Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.175714Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.177216Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use a monkey-patched function to parametrize the topology against a force field\n",
@@ -60,27 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.186067Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.185451Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.187760Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.188134Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['Bonds', 'Constraints', 'Angles', 'ProperTorsions', 'ImproperTorsions', 'vdW', 'Electrostatics'])"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at which ParameterHandler objects from the OpenFF toolkit\n",
     "# have been made into Potentialhandler objects\n",
@@ -89,15 +50,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.191389Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.190840Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.195113Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.194655Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Store the bond handler to inspect its contents\n",
@@ -106,27 +60,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.199672Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.198929Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.201348Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.201721Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('Bonds', 'k/2*(r-length)**2', {'r'})"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at some ~metadata\n",
     "bonds.type, bonds.expression, bonds.independent_variables"
@@ -134,42 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.206210Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.205499Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.207938Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.208419Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{TopologyKey(atom_indices=(0, 1), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 3), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 4), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(0, 5), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 2), mult=None, bond_order=None): PotentialKey(id='[#6:1]-[#8:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 6), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(1, 7), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(2, 8), mult=None, bond_order=None): PotentialKey(id='[#8:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(9, 10), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(9, 12), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(9, 13), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(9, 14), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(10, 11), mult=None, bond_order=None): PotentialKey(id='[#6:1]-[#8:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(10, 15), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(10, 16), mult=None, bond_order=None): PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None),\n",
-       " TopologyKey(atom_indices=(11, 17), mult=None, bond_order=None): PotentialKey(id='[#8:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None)}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Return a mapping between atom indices and SMIRKS identifiers\n",
     "bonds.slot_map"
@@ -177,30 +80,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.214401Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.213734Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.216776Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.217162Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{PotentialKey(id='[#6X4:1]-[#6X4:2]', mult=None, associated_handler='Bonds', bond_order=None): Potential(parameters={'k': <Quantity(531.137374, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.5203759, 'angstrom')>}, map_key=None),\n",
-       " PotentialKey(id='[#6X4:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None): Potential(parameters={'k': <Quantity(758.093177, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.09288838, 'angstrom')>}, map_key=None),\n",
-       " PotentialKey(id='[#6:1]-[#8:2]', mult=None, associated_handler='Bonds', bond_order=None): Potential(parameters={'k': <Quantity(669.141517, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.41428792, 'angstrom')>}, map_key=None),\n",
-       " PotentialKey(id='[#8:1]-[#1:2]', mult=None, associated_handler='Bonds', bond_order=None): Potential(parameters={'k': <Quantity(1120.58324, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(0.970768759, 'angstrom')>}, map_key=None)}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Return a mapping between SMIRKS identifiers and Potential objects;\n",
     "# Note the de-duplication, resulting from a many-to-few mapping between\n",
@@ -210,27 +92,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.221859Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.221199Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.223493Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.224044Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Potential(parameters={'k': <Quantity(758.093177, 'kilocalorie / angstrom ** 2 / mole')>, 'length': <Quantity(1.09288838, 'angstrom')>}, map_key=None)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look at this contents of one of the Potential objects\n",
     "potential_key = PotentialKey(id=\"[#6X4:1]-[#1:2]\", associated_handler=\"Bonds\")\n",
@@ -239,33 +103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.229727Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.228839Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.231556Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.231933Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "758.0931772913 kcal/(mol Å<sup>2</sup>)"
-      ],
-      "text/latex": [
-       "$758.0931772913\\ \\frac{\\mathrm{kcal}}{\\left(\\mathrm{mol} \\cdot \\mathrm{Å}^{2}\\right)}$"
-      ],
-      "text/plain": [
-       "758.0931772913 <Unit('kilocalorie / angstrom ** 2 / mole')>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Further, look at the particular value of one of its parameters\n",
     "bonds.potentials[potential_key].parameters[\"k\"]"
@@ -273,33 +113,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-23T16:28:02.237578Z",
-     "iopub.status.busy": "2021-12-23T16:28:02.236888Z",
-     "iopub.status.idle": "2021-12-23T16:28:02.239587Z",
-     "shell.execute_reply": "2021-12-23T16:28:02.239964Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "758.0931772913 kcal/(mol Å<sup>2</sup>)"
-      ],
-      "text/latex": [
-       "$758.0931772913\\ \\frac{\\mathrm{kcal}}{\\left(\\mathrm{mol} \\cdot \\mathrm{Å}^{2}\\right)}$"
-      ],
-      "text/plain": [
-       "758.0931772913 <Unit('kilocalorie / angstrom ** 2 / mole')>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Look up, from the highest-level object, this same data, using the\n",
     "# SMIRKS pattern as a key connecting the topological data to the\n",


### PR DESCRIPTION
I'm getting impatient with notebooks providing noisy diffs and forgetting if I should run before committing (slow) or clearing and saving. Ideally there's automation that keeps the output saved in a way that keeps the files up-to-date for wandering eyes but does not get in the way of development. Short of that I'm using [`nbstripout`](https://github.com/kynan/nbstripout) to standardize everything on empty outputs.

If others feel strong enough and/or can provided other tools that reduce this friction I'd be happy to adopt them.