### PR TITLE
Fix assigning virtual site geometries and intramolecular exclusions through OpenMM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     exclude: '\.(pdb|gro|top|sdf)$'
   - id: debug-statements
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     files: ^openff

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -333,6 +333,9 @@ class Interchange(DefaultModel):
                     parameter_handler=force_field["VirtualSites"],
                     topology=sys_out._inner_data.topology,
                 )
+                virtual_site_handler.exclusion_policy = force_field[
+                    "VirtualSites"
+                ].exclusion_policy
                 sys_out.handlers.update({"VirtualSites": virtual_site_handler})
                 sys_out["vdW"]._from_toolkit_virtual_sites(
                     parameter_handler=force_field["VirtualSites"],

--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -242,6 +242,15 @@ def to_top(openff_sys: "Interchange", file_path: Union[Path, str]):
     if not isinstance(file_path, (str, Path)):
         raise Exception
 
+    if "VirtualSites" in openff_sys.handlers:
+        if len(openff_sys["VirtualSites"].slot_map) > 0:
+            raise UnsupportedExportError(
+                "Exporting virtual sites to GROMACS is not validated in this version."
+            )
+        else:
+            # Allow a handler with no particles to exist
+            pass
+
     if isinstance(file_path, str):
         path = Path(file_path)
     if isinstance(file_path, Path):

--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -654,7 +654,19 @@ def _process_virtual_sites(openff_sys, openmm_sys):
         if virtual_site_handler.exclusion_policy == "none":
             pass
         elif virtual_site_handler.exclusion_policy == "minimal":
-            root_parent_atom = virtual_site_key.atom_indices[0]
+            # TODO: This behavior is likely wrong but written to match the toolkit's behavior.
+            #       Exclusion policy "minimal" _should_ always exclude the 0th index atom, but
+            #       this is nont the case for one reason or another.
+            # root_parent_atom = virtual_site_key.atom_indices[0]
+            if len(virtual_site_key.atom_indices) == 2:
+                root_parent_atom = virtual_site_key.atom_indices[0]
+            elif len(virtual_site_key.atom_indices) >= 3:
+                root_parent_atom = virtual_site_key.atom_indices[1]
+            else:
+                raise NotImplementedError(
+                    "This should not be reachable. Please file an issue"
+                )
+
             non_bonded_force.addException(
                 root_parent_atom, virtual_site_index, 0.0, 0.0, 0.0, replace=True
             )

--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -671,13 +671,13 @@ def _create_virtual_site(
     interchange: "Interchange",
 ) -> "openmm.LocalCoordinatesSites":
 
+    handler = interchange.handlers["VirtualSites"]
+
     parent_atoms = virtual_site_key.atom_indices
-    origin_weight, x_direction, y_direction = interchange[
-        "VirtualSites"
-    ]._get_local_frame_weights(virtual_site_key)
-    displacement = interchange["VirtualSites"]._get_local_frame_position(
+    origin_weight, x_direction, y_direction = handler._get_local_frame_weights(
         virtual_site_key
     )
+    displacement = handler._get_local_frame_position(virtual_site_key)
 
     x, y, z = ((v / v.units).m for v in displacement)
     # x, y, z = displacement / displacement.units
@@ -686,10 +686,10 @@ def _create_virtual_site(
     for parent_atom in parent_atoms:
         parent_atom_positions.append(interchange.positions[parent_atom])
 
-    _origin_weight = np.atleast_2d(origin_weight)
+    # _origin_weight = np.atleast_2d(origin_weight)
     parent_atom_positions = np.atleast_2d(parent_atom_positions)
 
-    origin = np.dot(_origin_weight, parent_atom_positions).sum(axis=0)
+    # origin = np.dot(_origin_weight, parent_atom_positions).sum(axis=0)
 
     x_axis, y_axis = np.dot(
         np.vstack((x_direction, y_direction)), parent_atom_positions
@@ -706,14 +706,18 @@ def _create_virtual_site(
 
     x_axis, y_axis, z_axis = map(_normalize, (x_axis, y_axis, z_axis))
 
-    position = origin + x * x_axis + y * y_axis + z * z_axis
+    # position = origin + x * x_axis + y * y_axis + z * z_axis
+    local_frame_position = handler._get_local_frame_position(virtual_site_key).m_as(
+        off_unit.nanometer
+    )
 
     return openmm.LocalCoordinatesSite(
         parent_atoms,
         origin_weight,
+        # _origin_weight,
         x_direction,
         y_direction,
-        position,
+        local_frame_position,
     )
 
 

--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -597,7 +597,7 @@ def _process_virtual_sites(openff_sys, openmm_sys):
     except KeyError:
         return
 
-    _SUPPORTED_EXCLUSION_POLICIES = ["parents"]
+    _SUPPORTED_EXCLUSION_POLICIES = ["none", "minimal", "parents"]
 
     if virtual_site_handler.exclusion_policy not in _SUPPORTED_EXCLUSION_POLICIES:
         raise UnsupportedExportError(
@@ -651,9 +651,12 @@ def _process_virtual_sites(openff_sys, openmm_sys):
         # Notes: For each type of virtual site, the parent atom is defined as the _first_ (0th) atom.
         # The toolkit, however, might have some bugs from following different assumptions:
         # https://github.com/openforcefield/openff-interchange/pull/415#issuecomment-1074546516
-        if virtual_site_handler.exclusion_policy in ["none", "minimal"]:
-            raise UnsupportedCutoffMethodError(
-                f"Virtual site exclusion policy {virtual_site_handler.exclusion_policy} not yet supported."
+        if virtual_site_handler.exclusion_policy == "none":
+            pass
+        elif virtual_site_handler.exclusion_policy == "minimal":
+            root_parent_atom = virtual_site_key.atom_indices[0]
+            non_bonded_force.addException(
+                root_parent_atom, virtual_site_index, 0.0, 0.0, 0.0, replace=True
             )
         elif virtual_site_handler.exclusion_policy == "parents":
             for parent_atom_index in virtual_site_key.atom_indices:

--- a/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
+++ b/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
@@ -263,6 +263,7 @@ class TestGROMACS(_BaseTest):
             get_gromacs_energies(out, mdp="cutoff_buck")
 
 
+@pytest.mark.skip("Virtual site support in GROMACS not fully validated")
 @needs_gmx
 class TestGROMACSVirtualSites(_BaseTest):
     @pytest.fixture()


### PR DESCRIPTION
#415 fixed (for the most part) how partial charges are assigned when virtual sites are involved but left fixing geometry for another PR. This is that PR.

Geometries appear to be matching @j-wags's test set. Intramolecular exclusions still differ for most/all cases. Energies match for the case of `exclusion_policy="parents"` but no others.