### PR TITLE
Fix storing improper idivf

### DIFF
--- a/openff/interchange/tests/unit_tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/unit_tests/components/test_smirnoff.py
@@ -169,6 +169,32 @@ class TestSMIRNOFFHandlers(_BaseTest):
             TopologyKey(atom_indices=(0, 3, 1, 2), mult=0) in potential_handler.slot_map
         )
 
+    def test_store_nonstandard_improper_idivf(self):
+        acetaldehyde = Molecule.from_mapped_smiles(
+            "[C:1]([C:2](=[O:3])[H:7])([H:4])([H:5])[H:6]"
+        )
+        topology = acetaldehyde.to_topology()
+
+        handler = ImproperTorsionHandler(version=0.3)
+        handler.add_parameter(
+            {
+                "smirks": "[*:1]~[#6:2](~[#8:3])~[*:4]",
+                "periodicity1": 2,
+                "phase1": 180.0 * unit.degree,
+                "k1": 1.1 * unit.kilocalorie_per_mole,
+                "idivf1": 1.234 * unit.dimensionless,
+                "id": "i1",
+            }
+        )
+
+        potential_handler = SMIRNOFFImproperTorsionHandler._from_toolkit(
+            parameter_handler=handler, topology=topology
+        )
+
+        assert [*potential_handler.potentials.values()][0].parameters[
+            "idivf"
+        ] == 1.234 * unit.dimensionless
+
     def test_electrostatics_am1_handler(self):
         molecule = Molecule.from_smiles("C")
         molecule.assign_partial_charges(partial_charge_method="am1bcc")

--- a/openff/interchange/tests/unit_tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/unit_tests/components/test_smirnoff.py
@@ -191,9 +191,25 @@ class TestSMIRNOFFHandlers(_BaseTest):
             parameter_handler=handler, topology=topology
         )
 
+        handler = ImproperTorsionHandler(version=0.3)
+        handler.default_idivf = 5.555
+        handler.add_parameter(
+            {
+                "smirks": "[*:1]~[#6:2](~[#8:3])~[*:4]",
+                "periodicity1": 2,
+                "phase1": 180.0 * unit.degree,
+                "k1": 1.1 * unit.kilocalorie_per_mole,
+                "id": "i1",
+            }
+        )
+
+        potential_handler = SMIRNOFFImproperTorsionHandler._from_toolkit(
+            parameter_handler=handler, topology=topology
+        )
+
         assert [*potential_handler.potentials.values()][0].parameters[
             "idivf"
-        ] == 1.234 * unit.dimensionless
+        ] == 5.555 * unit.dimensionless
 
     def test_electrostatics_am1_handler(self):
         molecule = Molecule.from_smiles("C")


### PR DESCRIPTION
The idivf parameter in improper torsions is [hard-coded to 3.0](https://github.com/openforcefield/openff-interchange/blob/v0.2.0-alpha.3/openff/interchange/components/smirnoff.py#L726), despite it being a parameter in the force field. If it's not set, the toolkit [sets](https://github.com/openforcefield/openff-toolkit/blob/8533e71b7d3a8c88699f91b55a87d9d6ff92b795/openff/toolkit/typing/engines/smirnoff/parameters.py#L3347-L3349) it to be 3.0. As far as I can tell, every SMIRNOFF-style force field in the universe chooses not to set it, so setting it to 3.0 did not adversely affect use of any released force field.

Thanks to @SimonBoothroyd whose work uncovered this bug and @j-wags who navigated me through the turbulent waters of idivf.
