### PR TITLE
Mdconfig docs

### DIFF
--- a/docs/using/output.md
+++ b/docs/using/output.md
@@ -7,7 +7,7 @@ source of truth is the rich chemical information in the `Interchange`
 object, and exported files are tools to perform some operation.
 
 (sec-mdconfig)=
-### Run control/config files
+## Run control/config files
 
 SMIRNOFF force fields include several parameters that many MD engines do not
 include as part of their topologies. These values are essential for accurately

--- a/docs/using/output.md
+++ b/docs/using/output.md
@@ -6,6 +6,32 @@ stored in an `Interchange`; they support a design where the principle
 source of truth is the rich chemical information in the `Interchange`
 object, and exported files are tools to perform some operation.
 
+(sec-mdconfig)=
+### Run control/config files
+
+SMIRNOFF force fields include several parameters that many MD engines do not
+include as part of their topologies. These values are essential for accurately
+simulating output from Interchange, but they are configured in the same files
+that are used for general control of simulation runtime behavior. As a result,
+Interchange cannot simply provide complete versions of these files.
+
+Instead, Interchange provides [`MDConfig`], a class that writes stub versions of
+MD engine run input files. These files must be modified and completed before
+they can be used to run a simulation.
+
+`MDConfig` can be constructed from an existing Interchange:
+
+```python
+from openff.interchange import Interchange
+from openff.interchange.components.mdconfig import MDConfig
+
+interchange = Interchange.from_smirnoff(...)
+
+mdconfig = MDConfig.from_interchange(interchange)
+```
+
+[`MDConfig`]: openff.interchange.components.mdconfig.MDConfig
+
 ## General purpose
 
 An [`Interchange`] can be written out as the common PDB structure format
@@ -25,22 +51,13 @@ interchange.to_gro("out.gro")
 interchange.to_top("out.top")
 ```
 
-<!--
-:::{TODO}
-We should either make this a public method or document it, not both
-:::
-
-An `.mdp` file with settings inferred from data in the `Interchange` object can
-also be written. Note that this file will only run a single-point energy
-calculation. `nsteps` and other lines should be modified to before running an
-MD simulation. This will write a file `auto_generated.mdp`:
+A .MDP file can be written from an [MDConfig object] constructed from the
+interchange. The resulting file will run a single-point energy calculation and
+should be modified for the desired simulation:
 
 ```python
-from openff.interchange.drivers.gromacs import _write_mdp_file
-
-_write_mdp_file(interchange)
+mdconfig.write_mdp_file(mdp_file="auto_generated.mdp")
 ```
--->
 
 ## LAMMPS
 
@@ -51,22 +68,12 @@ An [`Interchange`] object can be written to a LAMMPS data file with
 interchange.to_lammps("data.lmp")
 ```
 
-<!--
-:::{TODO}
-We should either make this a public method or document it, not both
-:::
-
-An input file with settings inferred from data in the `Interchange` object can
-also be written. Note that this file will only run a single-point energy
-calculation. `run` and other commands should be modified to before running an
-MD simulation. This will write a file `run.inp`:
+An input file can be written from an [MDConfig object] constructed from the interchange. The resulting file will run a single-point energy calculation and
+should be modified for the desired simulation:
 
 ```python
-from openff.interchange.drivers.lammps import _write_lammps_input
-
-_write_lammps_input(interchange, "run.inp")
+mdconfig.write_lammps_input(input_file="auto_generated.in")
 ```
--->
 
 ## OpenMM
 
@@ -97,6 +104,15 @@ coordinate files with [`Interchange.to_prmtop()`] and [`Interchange.to_inpcrd()`
 interchange.to_prmtop("out.prmtop")
 interchange.to_inpcrd("out.inpcrd")
 ```
+
+A run control file can be written from an [MDConfig object] constructed from the
+interchange. The resulting file will run a single-point energy calculation and
+should be modified for the desired simulation:
+
+```python
+mdconfig.write_sander_input_file(input_file="auto_generated.in")
+```
+
 <!--
 ## CHARMM
 
@@ -119,3 +135,4 @@ interchange.to_crd("out.to_crd")
 [`Interchange.to_psf()`]: openff.interchange.components.interchange.Interchange.to_psf
 [`Interchange.to_crd()`]: openff.interchange.components.interchange.Interchange.to_crd
 [`Topology.to_openmm()`]: openff.toolkit.topology.Topology.to_openmm
+[MDConfig object]: sec-mdconfig

--- a/examples/lammps/.gitignore
+++ b/examples/lammps/.gitignore
@@ -4,3 +4,4 @@ log.lammps
 test.in
 traj.dcd
 _tmp_pdb_file.pdb
+auto_generated.in

--- a/examples/lammps/lammps.ipynb
+++ b/examples/lammps/lammps.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,24 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "178942d2dae447b1829c023cd8469343",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NGLWidget()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "interchange.visualize(\"nglview\")"
    ]
@@ -116,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,38 +117,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "units real\n",
-      "atom_style full\n",
-      "\n",
-      "dimension 3\n",
-      "boundary p p p\n",
-      "\n",
-      "bond_style hybrid harmonic\n",
-      "angle_style hybrid harmonic\n",
-      "dihedral_style hybrid fourier\n",
-      "improper_style cvff\n",
-      "special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
-      "\n",
-      "pair_style lj/cut/coul/long 9.0 9.0\n",
-      "pair_modify mix arithmetic tail yes\n",
-      "\n",
-      "read_data out.lmp\n",
-      "\n",
-      "thermo_style custom ebond eangle edihed eimp epair evdwl ecoul elong etail pe\n",
-      "\n",
-      "kspace_style pppm 1e-6\n",
-      "run 0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mdconfig = MDConfig.from_interchange(interchange)\n",
     "mdconfig.write_lammps_input(input_file=\"auto_generated.in\")\n",
@@ -175,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That sample file will only perform a single point energy calculation; here's a more complete file that includes the above parameters but will run an actual MD simulation. \n",
+    "That sample file will only perform a single point energy calculation; here's a more complete file that includes the above parameters but will run an actual MD simulation. Note that `out.lmp` is changed to `interchange.lmp` to reflect the filename we used earlier:\n",
     "\n",
     "<div class=\"alert alert-warning\" style=\"max-width: 700px; margin-left: auto; margin-right: auto;\">\n",
     "    <b>⚠️ Don't use example input files in production</b><br />\n",
@@ -185,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,8 +158,7 @@
     "angle_style hybrid harmonic\n",
     "dihedral_style hybrid fourier\n",
     "improper_style cvff\n",
-    "special_bonds lj 0.0 0.0 0.5 coul 0.0 0.0 0.8333333333\n",
-    "# special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
+    "special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
     "\n",
     "# Non-bonded interactions in Sage force field\n",
     "pair_style lj/cut/coul/long 9.0 9.0\n",
@@ -242,124 +197,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "max angles/atom\n",
-      "  scanning dihedrals ...\n",
-      "  12 = max dihedrals/atom\n",
-      "  reading bonds ...\n",
-      "  3468 bonds\n",
-      "  reading angles ...\n",
-      "  6086 angles\n",
-      "  reading dihedrals ...\n",
-      "  7174 dihedrals\n",
-      "Finding 1-2 1-3 1-4 neighbors ...\n",
-      "  special bond factors lj:    0        0.5      1       \n",
-      "  special bond factors coul:  0        0.8333333333 1       \n",
-      "     4 = max # of 1-2 neighbors\n",
-      "     6 = max # of 1-3 neighbors\n",
-      "    10 = max # of special neighbors\n",
-      "  special bonds CPU = 0.001 seconds\n",
-      "  read_data CPU = 0.017 seconds\n",
-      "PPPM initialization ...\n",
-      "  using 12-bit tables for long-range coulomb (src/kspace.cpp:340)\n",
-      "  G vector (1/distance) = 0.33515339\n",
-      "  grid = 32 32 32\n",
-      "  stencil order = 5\n",
-      "  estimated absolute RMS force accuracy = 0.00028210222\n",
-      "  estimated relative force accuracy = 8.4954247e-07\n",
-      "  using double precision FFTW3\n",
-      "  3d grid and FFT values/proc = 59319 32768\n",
-      "Neighbor list info ...\n",
-      "  update every 1 steps, delay 10 steps, check yes\n",
-      "  max neighbors/atom: 2000, page size: 100000\n",
-      "  master list distance cutoff = 11\n",
-      "  ghost atom cutoff = 11\n",
-      "  binsize = 5.5, bins = 7 7 7\n",
-      "  1 neighbor lists, perpetual/occasional/extra = 1 0 0\n",
-      "  (1) pair lj/cut/coul/long, perpetual\n",
-      "      attributes: half, newton on\n",
-      "      pair build: half/bin/newton/tri\n",
-      "      stencil: half/bin/3d/tri\n",
-      "      bin: standard\n",
-      "Setting up Verlet run ...\n",
-      "  Unit style    : real\n",
-      "  Current step  : 0\n",
-      "  Time step     : 2\n",
-      "Per MPI rank memory allocation (min/avg/max) = 23.95 | 23.95 | 23.95 Mbytes\n",
-      "E_bond E_angle E_dihed E_impro E_pair E_vdwl E_coul E_long E_tail PotEng \n",
-      "   11.541868    4291.6175    313.10955            0    22259.885     21839.31    6677.6743   -6257.0989   -116.79125    26876.154 \n",
-      "ERROR on proc 0: Out of range atoms - cannot compute PPPM (src/KSPACE/pppm.cpp:1891)\n",
-      "LAMMPS (29 Sep 2021)\n",
-      "OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)\n",
-      "  using 1 OpenMP thread(s) per MPI task\n",
-      "Reading data file ...\n",
-      "  triclinic box = (-1.6550000 -2.0040000 -2.6770000) to (32.992000 32.643000 31.970000) with tilt (0.0000000 0.0000000 0.0000000)\n",
-      "  1 by 1 by 1 MPI processor grid\n",
-      "  reading atoms ...\n",
-      "  3808 atoms\n",
-      "  scanning bonds ...\n",
-      "  4 = max bonds/atom\n",
-      "  scanning angles ...\n",
-      "  6 = max angles/atom\n",
-      "  scanning dihedrals ...\n",
-      "  12 = max dihedrals/atom\n",
-      "  reading bonds ...\n",
-      "  3468 bonds\n",
-      "  reading angles ...\n",
-      "  6086 angles\n",
-      "  reading dihedrals ...\n",
-      "  7174 dihedrals\n",
-      "Finding 1-2 1-3 1-4 neighbors ...\n",
-      "  special bond factors lj:    0        0        0.5     \n",
-      "  special bond factors coul:  0        0        0.8333333333\n",
-      "     4 = max # of 1-2 neighbors\n",
-      "     6 = max # of 1-3 neighbors\n",
-      "    10 = max # of 1-4 neighbors\n",
-      "    14 = max # of special neighbors\n",
-      "  special bonds CPU = 0.002 seconds\n",
-      "  read_data CPU = 0.018 seconds\n",
-      "PPPM initialization ...\n",
-      "  using 12-bit tables for long-range coulomb (src/kspace.cpp:340)\n",
-      "  G vector (1/distance) = 0.33515339\n",
-      "  grid = 32 32 32\n",
-      "  stencil order = 5\n",
-      "  estimated absolute RMS force accuracy = 0.00028210222\n",
-      "  estimated relative force accuracy = 8.4954247e-07\n",
-      "  using double precision FFTW3\n",
-      "  3d grid and FFT values/proc = 59319 32768\n",
-      "Neighbor list info ...\n",
-      "  update every 1 steps, delay 10 steps, check yes\n",
-      "  max neighbors/atom: 2000, page size: 100000\n",
-      "  master list distance cutoff = 11\n",
-      "  ghost atom cutoff = 11\n",
-      "  binsize = 5.5, bins = 7 7 7\n",
-      "  1 neighbor lists, perpetual/occasional/extra = 1 0 0\n",
-      "  (1) pair lj/cut/coul/long, perpetual\n",
-      "      attributes: half, newton on\n",
-      "      pair build: half/bin/newton/tri\n",
-      "      stencil: half/bin/3d/tri\n",
-      "      bin: standard\n",
-      "Setting up Verlet run ...\n",
-      "  Unit style    : real\n",
-      "  Current step  : 0\n",
-      "  Time step     : 2\n",
-      "Per MPI rank memory allocation (min/avg/max) = 24.20 | 24.20 | 24.20 Mbytes\n",
-      "E_bond E_angle E_dihed E_impro E_pair E_vdwl E_coul E_long E_tail PotEng \n",
-      "   11.541868    4291.6175    313.10955            0   -2154.3309   -1715.4373    5818.2054   -6257.0989   -116.79125     2461.938 \n",
-      "   1028.3574    5494.1086    525.16072            0   -1862.6784   -1247.5194    5654.7114   -6269.8703   -116.79125    5184.9483 \n",
-      "Loop time of 14.5814 on 1 procs for 1000 steps with 3808 atoms\n",
-      "\n",
-      "Performance: 11.851 ns/day, 2.025 hours/ns, 68.581 timesteps/s\n",
-      "99.9% CPU "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "lmp = lammps()\n",
     "\n",
@@ -375,24 +215,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5dabc756c85c4a90a5805124857f865c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NGLWidget(max_frame=100)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "traj = md.load(\n",
     "    \"traj.dcd\",\n",
@@ -401,13 +226,6 @@
     "traj.make_molecules_whole()\n",
     "nglview.show_mdtraj(traj)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/lammps/lammps.ipynb
+++ b/examples/lammps/lammps.ipynb
@@ -158,7 +158,7 @@
     "angle_style hybrid harmonic\n",
     "dihedral_style hybrid fourier\n",
     "improper_style cvff\n",
-    "special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
+    "special_bonds lj 0.0 0.0 0.5 coul 0.0 0.0 0.8333333333\n",
     "\n",
     "# Non-bonded interactions in Sage force field\n",
     "pair_style lj/cut/coul/long 9.0 9.0\n",

--- a/examples/lammps/lammps.ipynb
+++ b/examples/lammps/lammps.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,6 +50,7 @@
     "from pandas import read_csv\n",
     "\n",
     "from openff.interchange import Interchange\n",
+    "from openff.interchange.components.mdconfig import MDConfig\n",
     "\n",
     "# Read a structure from the Toolkit's test suite into a Topology\n",
     "pdbfile = PDBFile(\n",
@@ -75,9 +76,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "178942d2dae447b1829c023cd8469343",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "interchange.visualize(\"nglview\")"
    ]
@@ -100,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,12 +127,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we need to write an input file for LAMMPS; here's one that's appropriate for the Sage force field. Note that other force fields may have different functional forms and need something different!"
+    "Now we need to write an input file for LAMMPS. Parts of these input files depend on force field parameters, so we should use a sample input file written for our interchange as a starting point. We can generate such a sample file from `MDConfig`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "units real\n",
+      "atom_style full\n",
+      "\n",
+      "dimension 3\n",
+      "boundary p p p\n",
+      "\n",
+      "bond_style hybrid harmonic\n",
+      "angle_style hybrid harmonic\n",
+      "dihedral_style hybrid fourier\n",
+      "improper_style cvff\n",
+      "special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
+      "\n",
+      "pair_style lj/cut/coul/long 9.0 9.0\n",
+      "pair_modify mix arithmetic tail yes\n",
+      "\n",
+      "read_data out.lmp\n",
+      "\n",
+      "thermo_style custom ebond eangle edihed eimp epair evdwl ecoul elong etail pe\n",
+      "\n",
+      "kspace_style pppm 1e-6\n",
+      "run 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "mdconfig = MDConfig.from_interchange(interchange)\n",
+    "mdconfig.write_lammps_input(input_file=\"auto_generated.in\")\n",
+    "with open(\"auto_generated.in\") as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That sample file will only perform a single point energy calculation; here's a more complete file that includes the above parameters but will run an actual MD simulation. \n",
+    "\n",
+    "<div class=\"alert alert-warning\" style=\"max-width: 700px; margin-left: auto; margin-right: auto;\">\n",
+    "    <b>⚠️ Don't use example input files in production</b><br />\n",
+    "    Note that this is still just an example! You should carefully write and inspect input files for all production simulations.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,9 +201,11 @@
     "bond_style hybrid harmonic\n",
     "angle_style hybrid harmonic\n",
     "dihedral_style hybrid fourier\n",
+    "improper_style cvff\n",
+    "special_bonds lj 0.0 0.0 0.5 coul 0.0 0.0 0.8333333333\n",
+    "# special_bonds lj 0 0.5 1 coul 0 0.8333333333 1\n",
     "\n",
     "# Non-bonded interactions in Sage force field\n",
-    "special_bonds lj 0.0 0.0 0.5 coul 0.0 0.0 0.8333333333\n",
     "pair_style lj/cut/coul/long 9.0 9.0\n",
     "pair_modify mix arithmetic tail yes\n",
     "\n",
@@ -171,9 +242,124 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "max angles/atom\n",
+      "  scanning dihedrals ...\n",
+      "  12 = max dihedrals/atom\n",
+      "  reading bonds ...\n",
+      "  3468 bonds\n",
+      "  reading angles ...\n",
+      "  6086 angles\n",
+      "  reading dihedrals ...\n",
+      "  7174 dihedrals\n",
+      "Finding 1-2 1-3 1-4 neighbors ...\n",
+      "  special bond factors lj:    0        0.5      1       \n",
+      "  special bond factors coul:  0        0.8333333333 1       \n",
+      "     4 = max # of 1-2 neighbors\n",
+      "     6 = max # of 1-3 neighbors\n",
+      "    10 = max # of special neighbors\n",
+      "  special bonds CPU = 0.001 seconds\n",
+      "  read_data CPU = 0.017 seconds\n",
+      "PPPM initialization ...\n",
+      "  using 12-bit tables for long-range coulomb (src/kspace.cpp:340)\n",
+      "  G vector (1/distance) = 0.33515339\n",
+      "  grid = 32 32 32\n",
+      "  stencil order = 5\n",
+      "  estimated absolute RMS force accuracy = 0.00028210222\n",
+      "  estimated relative force accuracy = 8.4954247e-07\n",
+      "  using double precision FFTW3\n",
+      "  3d grid and FFT values/proc = 59319 32768\n",
+      "Neighbor list info ...\n",
+      "  update every 1 steps, delay 10 steps, check yes\n",
+      "  max neighbors/atom: 2000, page size: 100000\n",
+      "  master list distance cutoff = 11\n",
+      "  ghost atom cutoff = 11\n",
+      "  binsize = 5.5, bins = 7 7 7\n",
+      "  1 neighbor lists, perpetual/occasional/extra = 1 0 0\n",
+      "  (1) pair lj/cut/coul/long, perpetual\n",
+      "      attributes: half, newton on\n",
+      "      pair build: half/bin/newton/tri\n",
+      "      stencil: half/bin/3d/tri\n",
+      "      bin: standard\n",
+      "Setting up Verlet run ...\n",
+      "  Unit style    : real\n",
+      "  Current step  : 0\n",
+      "  Time step     : 2\n",
+      "Per MPI rank memory allocation (min/avg/max) = 23.95 | 23.95 | 23.95 Mbytes\n",
+      "E_bond E_angle E_dihed E_impro E_pair E_vdwl E_coul E_long E_tail PotEng \n",
+      "   11.541868    4291.6175    313.10955            0    22259.885     21839.31    6677.6743   -6257.0989   -116.79125    26876.154 \n",
+      "ERROR on proc 0: Out of range atoms - cannot compute PPPM (src/KSPACE/pppm.cpp:1891)\n",
+      "LAMMPS (29 Sep 2021)\n",
+      "OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)\n",
+      "  using 1 OpenMP thread(s) per MPI task\n",
+      "Reading data file ...\n",
+      "  triclinic box = (-1.6550000 -2.0040000 -2.6770000) to (32.992000 32.643000 31.970000) with tilt (0.0000000 0.0000000 0.0000000)\n",
+      "  1 by 1 by 1 MPI processor grid\n",
+      "  reading atoms ...\n",
+      "  3808 atoms\n",
+      "  scanning bonds ...\n",
+      "  4 = max bonds/atom\n",
+      "  scanning angles ...\n",
+      "  6 = max angles/atom\n",
+      "  scanning dihedrals ...\n",
+      "  12 = max dihedrals/atom\n",
+      "  reading bonds ...\n",
+      "  3468 bonds\n",
+      "  reading angles ...\n",
+      "  6086 angles\n",
+      "  reading dihedrals ...\n",
+      "  7174 dihedrals\n",
+      "Finding 1-2 1-3 1-4 neighbors ...\n",
+      "  special bond factors lj:    0        0        0.5     \n",
+      "  special bond factors coul:  0        0        0.8333333333\n",
+      "     4 = max # of 1-2 neighbors\n",
+      "     6 = max # of 1-3 neighbors\n",
+      "    10 = max # of 1-4 neighbors\n",
+      "    14 = max # of special neighbors\n",
+      "  special bonds CPU = 0.002 seconds\n",
+      "  read_data CPU = 0.018 seconds\n",
+      "PPPM initialization ...\n",
+      "  using 12-bit tables for long-range coulomb (src/kspace.cpp:340)\n",
+      "  G vector (1/distance) = 0.33515339\n",
+      "  grid = 32 32 32\n",
+      "  stencil order = 5\n",
+      "  estimated absolute RMS force accuracy = 0.00028210222\n",
+      "  estimated relative force accuracy = 8.4954247e-07\n",
+      "  using double precision FFTW3\n",
+      "  3d grid and FFT values/proc = 59319 32768\n",
+      "Neighbor list info ...\n",
+      "  update every 1 steps, delay 10 steps, check yes\n",
+      "  max neighbors/atom: 2000, page size: 100000\n",
+      "  master list distance cutoff = 11\n",
+      "  ghost atom cutoff = 11\n",
+      "  binsize = 5.5, bins = 7 7 7\n",
+      "  1 neighbor lists, perpetual/occasional/extra = 1 0 0\n",
+      "  (1) pair lj/cut/coul/long, perpetual\n",
+      "      attributes: half, newton on\n",
+      "      pair build: half/bin/newton/tri\n",
+      "      stencil: half/bin/3d/tri\n",
+      "      bin: standard\n",
+      "Setting up Verlet run ...\n",
+      "  Unit style    : real\n",
+      "  Current step  : 0\n",
+      "  Time step     : 2\n",
+      "Per MPI rank memory allocation (min/avg/max) = 24.20 | 24.20 | 24.20 Mbytes\n",
+      "E_bond E_angle E_dihed E_impro E_pair E_vdwl E_coul E_long E_tail PotEng \n",
+      "   11.541868    4291.6175    313.10955            0   -2154.3309   -1715.4373    5818.2054   -6257.0989   -116.79125     2461.938 \n",
+      "   1028.3574    5494.1086    525.16072            0   -1862.6784   -1247.5194    5654.7114   -6269.8703   -116.79125    5184.9483 \n",
+      "Loop time of 14.5814 on 1 procs for 1000 steps with 3808 atoms\n",
+      "\n",
+      "Performance: 11.851 ns/day, 2.025 hours/ns, 68.581 timesteps/s\n",
+      "99.9% CPU "
+     ]
+    }
+   ],
    "source": [
     "lmp = lammps()\n",
     "\n",
@@ -189,9 +375,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5dabc756c85c4a90a5805124857f865c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget(max_frame=100)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "traj = md.load(\n",
     "    \"traj.dcd\",\n",
@@ -200,6 +401,13 @@
     "traj.make_molecules_whole()\n",
     "nglview.show_mdtraj(traj)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -173,13 +173,14 @@ class MDConfig(DefaultModel):
             }
             lmp.write(
                 "special_bonds lj "
-                f"{scale_factors['vdw']['1-2']} "
-                f"{scale_factors['vdw']['1-3']} "
-                f"{scale_factors['vdw']['1-4']} "
+                f"{scale_factors['vdW']['1-2']} "
+                f"{scale_factors['vdW']['1-3']} "
+                f"{scale_factors['vdW']['1-4']} "
                 "coul "
                 f"{scale_factors['Electrostatics']['1-2']} "
                 f"{scale_factors['Electrostatics']['1-3']} "
                 f"{scale_factors['Electrostatics']['1-4']} "
+                "\n"
             )
 
             vdw_cutoff = round(self.vdw_cutoff.m_as(unit.angstrom), 4)  # type: ignore[union-attr]

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -157,12 +157,29 @@ class MDConfig(DefaultModel):
             lmp.write("improper_style cvff\n")
 
             # TODO: LAMMPS puts this information in the "run" file. Should it live in MDConfig or not?
-            scale_factors = {"vdW": [0, 0.5, 1], "Electrostatics": [0, 0.8333333333, 1]}
+            scale_factors = {
+                "vdW": {
+                    "1-2": 0.0,
+                    "1-3": 0.0,
+                    "1-4": 0.5,
+                    "1-5": 1,
+                },
+                "Electrostatics": {
+                    "1-2": 0.0,
+                    "1-3": 0.0,
+                    "1-4": 0.8333333333,
+                    "1-5": 1,
+                },
+            }
             lmp.write(
-                "special_bonds lj {} {} {} coul {} {} {}\n\n".format(
-                    *scale_factors["vdW"],
-                    *scale_factors["Electrostatics"],
-                )
+                "special_bonds lj "
+                f"{scale_factors['vdw']['1-2']} "
+                f"{scale_factors['vdw']['1-3']} "
+                f"{scale_factors['vdw']['1-4']} "
+                "coul "
+                f"{scale_factors['Electrostatics']['1-2']} "
+                f"{scale_factors['Electrostatics']['1-3']} "
+                f"{scale_factors['Electrostatics']['1-4']} "
             )
 
             vdw_cutoff = round(self.vdw_cutoff.m_as(unit.angstrom), 4)  # type: ignore[union-attr]

--- a/openff/interchange/tests/unit_tests/drivers/test_all.py
+++ b/openff/interchange/tests/unit_tests/drivers/test_all.py
@@ -11,7 +11,7 @@ from openff.interchange.tests import _BaseTest
 
 @pytest.mark.slow()
 class TestDriversAll(_BaseTest):
-    def test_skipping_drivers(self, ethanol_top, parsley):
+    def test_skipping_drivers(self, ethanol_top, sage):
         from openff.toolkit.topology import Molecule
 
         from openff.interchange import Interchange
@@ -21,7 +21,7 @@ class TestDriversAll(_BaseTest):
         molecule.name = "MOL"
         topology = molecule.to_topology()
 
-        out = Interchange.from_smirnoff(parsley, topology)
+        out = Interchange.from_smirnoff(sage, topology)
         out.positions = molecule.conformers[0]
         out.box = [4, 4, 4]
 


### PR DESCRIPTION
### Description
This PR adds book-style documentation to the new `MDConfig` object and adds it to the LAMMPS example. The Amber example is still in PR and there is no GROMACS example until performance improves, so other uses of `MDConfig` are not yet in examples.

### Questions

- The LAMMPS example crashes with `special_bonds lj 0 0.5 1 coul 0 0.8333333333 1`, as outputted by MDConfig. The previous value of `special_bonds lj 0.0 0.0 0.5 coul 0.0 0.0 0.8333333333`, which IIRC was previously produced by `_write_lammps_input_file()`, works with the other changes to the sample file. I think this is an error/regression in MDConfig? I tried changing the 0s and 1s to 0.0s and 1.0s in case it was an int/float error but no dice. I've left the new value in the example as a reminder not to merge until we sort this out.
- Have we considered something like `Interchange.create_mdconfig()` instead of `MDConfig.from_interchange(...)`? This would save users an import and be less verbose
- Would it be possible to take a file object instead of a file name in the `MDConfig` export methods? Users will immediately want to either manually read or otherwise edit these files nearly every time they create them
