### PR TITLE
Ignore `if TYPE_CHECKING` lines in test coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,11 @@
 omit =
     openff/interchange/_version.py
 
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+
 [flake8]
 max-line-length = 119
 ignore = E203


### PR DESCRIPTION
Because it's not cheating the metrics if it's never meant to be available at runtime.