### PR TITLE
Fix intramolecular scale factors in `write_lammps_input`

### DIFF
--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -157,12 +157,29 @@ class MDConfig(DefaultModel):
             lmp.write("improper_style cvff\n")
 
             # TODO: LAMMPS puts this information in the "run" file. Should it live in MDConfig or not?
-            scale_factors = {"vdW": [0, 0.5, 1], "Electrostatics": [0, 0.8333333333, 1]}
+            scale_factors = {
+                "vdW": {
+                    "1-2": 0.0,
+                    "1-3": 0.0,
+                    "1-4": 0.5,
+                    "1-5": 1,
+                },
+                "Electrostatics": {
+                    "1-2": 0.0,
+                    "1-3": 0.0,
+                    "1-4": 0.8333333333,
+                    "1-5": 1,
+                },
+            }
             lmp.write(
-                "special_bonds lj {} {} {} coul {} {} {}\n\n".format(
-                    *scale_factors["vdW"],
-                    *scale_factors["Electrostatics"],
-                )
+                "special_bonds lj "
+                f"{scale_factors['vdw']['1-2']} "
+                f"{scale_factors['vdw']['1-3']} "
+                f"{scale_factors['vdw']['1-4']} "
+                "coul "
+                f"{scale_factors['Electrostatics']['1-2']} "
+                f"{scale_factors['Electrostatics']['1-3']} "
+                f"{scale_factors['Electrostatics']['1-4']} "
             )
 
             vdw_cutoff = round(self.vdw_cutoff.m_as(unit.angstrom), 4)  # type: ignore[union-attr]


### PR DESCRIPTION
### Description
In #442 I broke the LAMMPS input/run file writer by mangling the intramolecular scale factors. SMIRNOFF handlers keep track of 1-3, 1-4, and 1-5, but LAMMPS's `special_bonds` command cares about 1-2, 1-3, and 1-4. Ctrl+F on the [diff](https://github.com/openforcefield/openff-interchange/pull/442/files) makes it more obvious. In an attempt to prevent future developers from being as confused as I was, I replaced the lists with some extremely verbose and explicit dicts.

Thanks to @Yoshanuikabundi for isolating this bug.

### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
