### PR TITLE
Auto-detect GROMACS and LAMMPS executables

### DIFF
--- a/openff/interchange/drivers/lammps.py
+++ b/openff/interchange/drivers/lammps.py
@@ -1,5 +1,6 @@
 """Functions for running energy evluations with LAMMPS."""
 import subprocess
+from distutils.spawn import find_executable
 from typing import List, Optional
 
 import numpy as np
@@ -9,6 +10,17 @@ from openff.interchange import Interchange
 from openff.interchange.components.mdconfig import MDConfig
 from openff.interchange.drivers.report import EnergyReport
 from openff.interchange.exceptions import LAMMPSRunError
+
+
+def _find_lammps_executable() -> Optional[str]:
+    """Attempt to locate a LAMMPS executable based on commonly-used names."""
+    lammps_executable_names = ["lammps", "lmp_serial", "lmp_mpi"]
+
+    for name in lammps_executable_names:
+        if find_executable(name):
+            return name
+
+    return None
 
 
 def get_lammps_energies(
@@ -40,6 +52,8 @@ def get_lammps_energies(
         An `EnergyReport` object containing the single-point energies.
 
     """
+    lmp = _find_lammps_executable()
+
     if round_positions is not None:
         off_sys.positions = np.round(off_sys.positions, round_positions)
 
@@ -49,7 +63,7 @@ def get_lammps_energies(
         input_file="tmp.in",
     )
 
-    run_cmd = "lmp_serial -i tmp.in"
+    run_cmd = f"{lmp} -i tmp.in"
 
     proc = subprocess.Popen(
         run_cmd,

--- a/openff/interchange/tests/__init__.py
+++ b/openff/interchange/tests/__init__.py
@@ -11,11 +11,12 @@ from openff.toolkit.tests.utils import get_data_file_path
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.units import unit
-from openff.utilities.utilities import has_executable
 from openmm import unit as openmm_unit
 from pkg_resources import resource_filename
 
 from openff.interchange import Interchange
+from openff.interchange.drivers.gromacs import _find_gromacs_executable
+from openff.interchange.drivers.lammps import _find_lammps_executable
 
 
 def get_test_file_path(test_file) -> str:
@@ -231,8 +232,8 @@ class _BaseTest:
     """
 
 
-HAS_GROMACS = any(has_executable(e) for e in ["gmx", "gmx_d"])
-HAS_LAMMPS = any(has_executable(e) for e in ["lammps", "lmp_mpi", "lmp_serial"])
+HAS_GROMACS = _find_gromacs_executable() is not None
+HAS_LAMMPS = _find_lammps_executable() is not None
 
 needs_gmx = pytest.mark.skipif(not HAS_GROMACS, reason="Needs GROMACS")
 needs_lmp = pytest.mark.skipif(not HAS_LAMMPS, reason="Needs GROMACS")

--- a/openff/interchange/tests/unit_tests/drivers/test_all.py
+++ b/openff/interchange/tests/unit_tests/drivers/test_all.py
@@ -6,6 +6,7 @@ from distutils.spawn import find_executable
 import pytest
 
 from openff.interchange.drivers.all import get_all_energies
+from openff.interchange.drivers.gromacs import _find_gromacs_executable
 from openff.interchange.tests import _BaseTest
 
 
@@ -26,16 +27,11 @@ class TestDriversAll(_BaseTest):
         out.box = [4, 4, 4]
 
         summary = get_all_energies(out)
-        assert ("GROMACS" in summary) == (find_executable("gmx") is not None)
+        assert ("GROMACS" in summary) == (_find_gromacs_executable() is not None)
 
         assert ("Amber" in summary) == (find_executable("sander") is not None)
 
         # FIXME: Add back when LAMMPS export fixed
-        # assert ("LAMMPS" in summary) == (find_executable("lmp_serial") is not None)
-        number_expected_drivers = 1 + sum(
-            int(find_executable(exec) is not None)
-            # FIXME: Add "lmp_serial" in this list
-            for exec in ["gmx", "sander"]
-        )
+        # assert ("LAMMPS" in summary) == (_find_lammps_executable() is not None)
 
-        assert len(summary) == number_expected_drivers
+        assert len(summary) == 3


### PR DESCRIPTION
Closes #149 

This works locally with a `gmx_mpi` executable in my environment, pulled in from

```shell
$ mamba install "gromacs >=2021=mpi_openmpi_h*" -c conda-forge
```

(Just grabbing `"gromacs >=2021=mpi*"` pulls in a double-precision MPI build)

I'm not too interested in adding these cases to CI at the moment. If these become common use cases and/or pain points for users we can revisit that.