### PR TITLE
Allow creation of OpenMM `System`s with no non-bonded forces

### DIFF
--- a/openff/interchange/interop/openmm.py
+++ b/openff/interchange/interop/openmm.py
@@ -336,6 +336,14 @@ def _process_nonbonded_forces(openff_sys, openmm_sys, combine_nonbonded_forces=F
     `combine_nonbondoed_forces=False`.
 
     """
+    from openff.interchange.components.smirnoff import _SMIRNOFFNonbondedHandler
+
+    for handler in openff_sys.handlers.values():
+        if isinstance(handler, _SMIRNOFFNonbondedHandler):
+            break
+    else:
+        return
+
     # TODO: Process ElectrostaticsHandler.exception_potential
     if "vdW" in openff_sys.handlers:
         vdw_handler = openff_sys["vdW"]

--- a/openff/interchange/tests/unit_tests/interop/test_openmm.py
+++ b/openff/interchange/tests/unit_tests/interop/test_openmm.py
@@ -1,0 +1,39 @@
+import pytest
+from openff.toolkit import ForceField, Molecule
+from openmm import (
+    HarmonicAngleForce,
+    HarmonicBondForce,
+    NonbondedForce,
+    PeriodicTorsionForce,
+)
+
+from openff.interchange import Interchange
+
+
+class TestOpenMM:
+    def test_no_nonbonded_force(self):
+        """
+        Ensure a SMIRNOFF-style force field can be exported to OpenMM even if no nonbonded handlers are present. For
+        context, see https://github.com/openforcefield/openff-toolkit/issues/1102
+        """
+
+        sage = ForceField("openff_unconstrained-2.0.0.offxml")
+        del sage._parameter_handlers["ToolkitAM1BCC"]
+        del sage._parameter_handlers["LibraryCharges"]
+        del sage._parameter_handlers["Electrostatics"]
+        del sage._parameter_handlers["vdW"]
+
+        water = Molecule.from_smiles("C")
+        openmm_system = Interchange.from_smirnoff(sage, [water]).to_openmm()
+
+        for force in openmm_system.getForces():
+            if isinstance(force, NonbondedForce):
+                pytest.fail("A NonbondedForce was found in the OpenMM system.")
+            elif isinstance(force, PeriodicTorsionForce):
+                assert force.getNumTorsions() == 0
+            elif isinstance(force, HarmonicBondForce):
+                assert force.getNumBonds() == 4
+            elif isinstance(force, HarmonicAngleForce):
+                assert force.getNumAngles() == 6
+            else:
+                pytest.fail(f"Unexpected force found, type: {type(force)}")


### PR DESCRIPTION
### Description
Implements https://github.com/openforcefield/openff-toolkit/issues/1102

This will not be implemented in other engines until it's clear to me that this behavior properly supported.

### Checklist
- [x] Add tests
- [x] Lint
- [ ] Update docstrings
