### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a bug involving Interchange
+
+---
+
+**Description**
+
+Please describe what you were trying to do, what you expected to happen, and what happened instead.
+
+**Reproduction**
+
+Please include a [minimally reproducing example](https://stackoverflow.com/help/minimal-reproducible-example) of this bug.
+
+**Output**
+
+Please include the output, including full tracebacks of any errors, resulting from the reproduction.
+
+**Software versions**
+
+- Which operating system and version are you using?
+- How did you install Interchange?
+- What is the output of running `conda list`?

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,8 @@
+---
+name: Feature request
+about: Suggest an improvement to Interchange
+
+---
+
+**Description**
+Please describe the behavior you would like added to Interchange.

--- a/.github/ISSUE_TEMPLATE/USER_SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/USER_SUPPORT.md
@@ -1,0 +1,8 @@
+---
+name: User support
+about: Ask for help using Interchange in your work
+
+---
+
+**Description**
+Please describe what you are trying to do, what you have done so far, and how Interchange can enable your work.


### PR DESCRIPTION
I only now realized we don't have issue templates - this might explain why I'm not seeing i.e. `conda list` outputs.