### PR TITLE
Allow creation of `openmm.System` with no vdW parameters

### DIFF
--- a/openff/interchange/tests/data/no_vdw.offxml
+++ b/openff/interchange/tests/data/no_vdw.offxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Electrostatics version="0.4" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" cutoff="6.0 * angstrom ** 1" switch_width="0.0 * angstrom ** 1" periodic_potential="Ewald3D-ConductingBoundary" nonperiodic_potential="Coulomb" exception_potential="Coulomb"></Electrostatics>
+    <LibraryCharges version="0.3">
+        <LibraryCharge smirks="[#1:1]" charge1="1.0 * elementary_charge ** 1"></LibraryCharge>
+        <LibraryCharge smirks="[#17:1]" charge1="-1.0 * elementary_charge ** 1"></LibraryCharge>
+    </LibraryCharges>
+</SMIRNOFF>

--- a/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
+++ b/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
@@ -266,7 +266,7 @@ class TestGROMACS(_BaseTest):
         out.to_gro("out.gro", writer="internal")
         out.to_top("out.top", writer="internal")
 
-        omm_energies = get_openmm_energies(out)
+        omm_energies = get_openmm_energies(out, combine_nonbonded_forces=True)
         by_hand = A * exp(-B * r) - C * r**-6
 
         resid = omm_energies.energies["vdW"] - by_hand

--- a/openff/interchange/tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/tests/interoperability_tests/test_openmm.py
@@ -18,7 +18,7 @@ from openff.interchange.exceptions import (
     UnsupportedExportError,
 )
 from openff.interchange.interop.openmm import from_openmm
-from openff.interchange.tests import _BaseTest
+from openff.interchange.tests import _BaseTest, get_test_file_path
 
 # WISHLIST: Add tests for reaction-field if implemented
 
@@ -266,6 +266,19 @@ class TestOpenMM(_BaseTest):
             combine_nonbonded_forces=True
         )
         assert no_angles.getNumForces() == 2
+
+    def test_openmm_only_electrostatics_no_vdw(self):
+        force_field_only_charges = ForceField(get_test_file_path("no_vdw.offxml"))
+        molecule = Molecule.from_smiles("HCl")
+
+        system = Interchange.from_smirnoff(
+            force_field_only_charges, [molecule]
+        ).to_openmm(
+            combine_nonbonded_forces=True,
+        )
+
+        assert system.getForce(0).getParticleParameters(0)[0]._value == 1.0
+        assert system.getForce(0).getParticleParameters(1)[0]._value == -1.0
 
 
 class TestOpenMMSwitchingFunction(_BaseTest):

--- a/openff/interchange/tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/tests/interoperability_tests/test_openmm.py
@@ -269,7 +269,7 @@ class TestOpenMM(_BaseTest):
 
     def test_openmm_only_electrostatics_no_vdw(self):
         force_field_only_charges = ForceField(get_test_file_path("no_vdw.offxml"))
-        molecule = Molecule.from_smiles("HCl")
+        molecule = Molecule.from_smiles("[H][Cl]")
 
         system = Interchange.from_smirnoff(
             force_field_only_charges, [molecule]


### PR DESCRIPTION
Evaluator needs this.