### PR TITLE
Fix particle-particle exceptions in OpenMM

### DIFF
--- a/openff/interchange/tests/data/tip5p.offxml
+++ b/openff/interchange/tests/data/tip5p.offxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-  <vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" switch_width="1.0 * angstroms" cutoff="9.0 * angstroms" method="cutoff">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" switch_width="0.0 * angstrom" cutoff="9.0 * angstrom"/>
+  <vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" switch_width="0.0 * angstroms" cutoff="0.0 * angstroms" method="cutoff">
     <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31536 * nanometers" epsilon="0.64852 * kilojoules_per_mole" />
     <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1 * nanometers" epsilon="0 * kilojoules_per_mole" />
   </vdW>
@@ -11,11 +12,11 @@
     <VirtualSite
       type="DivalentLonePair"
       name="EP"
-      smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
+      smirks="[#1:2]-[#8X2H2+0:1]-[#1:3]"
       distance="0.15 * angstrom"
-      charge_increment1="0.241 * elementary_charge"
-      charge_increment2="0.0 * elementary_charge"
-      charge_increment3="0.241 * elementary_charge"
+      charge_increment1="0.0 * elementary_charge"
+      charge_increment2="0.1205* elementary_charge"
+      charge_increment3="0.1205* elementary_charge"
       sigma="1.0 * angstrom"
       epsilon="0.0 * kilocalories_per_mole"
       outOfPlaneAngle="54.71384225*degree"

--- a/openff/interchange/tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/tests/interoperability_tests/test_openmm.py
@@ -450,6 +450,19 @@ class TestOpenMMVirtualSites(_BaseTest):
             sage_with_monovalent_lone_pair.create_openmm_system(mol.to_topology()),
         )
 
+    def test_tip5p_num_exceptions(self):
+        tip5p = ForceField(get_test_file_path("tip5p.offxml"))
+        water = Molecule.from_smiles("O")
+        water.generate_conformers(n_conformers=1)
+
+        out = Interchange.from_smirnoff(tip5p, [water]).to_openmm(
+            combine_nonbonded_forces=True
+        )
+
+        for force in out.getForces():
+            if isinstance(force, openmm.NonbondedForce):
+                assert force.getNumExceptions() == 12
+
 
 class TestOpenMMToPDB(_BaseTest):
     def test_to_pdb(self, sage):


### PR DESCRIPTION
### Description
This fixes a bug in which non-bonded exceptions aren't properly added between particles on adjacent or the same parent molecule, i.e. in TIP5P water.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
