### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/ci_minimal.yaml
+++ b/.github/workflows/ci_minimal.yaml
@@ -24,8 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
     env:
-      CI_OS: ${{ matrix.os }}
-      PYVER: ${{ matrix.python-version }}
+      COV: --cov=openff/interchange --cov-report=xml --cov-config=setup.cfg --cov-append
 
     steps:
     - uses: actions/checkout@v3
@@ -59,4 +58,4 @@ jobs:
     - name: Run unit tests
       if: always()
       run: |
-        python -m pytest -v -nauto --durations=10 openff/interchange/tests/unit_tests/
+        python -m pytest -v -nauto --durations=10 $COV openff/interchange/tests/unit_tests/

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -18,6 +18,7 @@ dependencies:
   - python-constraint
   # Testing
   - pytest
+  - pytest-cov
   - pytest-xdist
   - mdtraj
   - pip:

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -519,22 +519,6 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
             )
             self.potentials[potential_key] = potential
 
-    @classmethod
-    def f_from_toolkit(
-        cls: Type[T],
-        parameter_handler: "AngleHandler",
-        topology: "Topology",
-    ) -> T:
-        """
-        Create a SMIRNOFFAngleHandler from toolkit data.
-
-        """
-        handler = cls()
-        handler.store_matches(parameter_handler=parameter_handler, topology=topology)
-        handler.store_potentials(parameter_handler=parameter_handler)
-
-        return handler
-
 
 class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
     """Handler storing proper torsions potentials as produced by a SMIRNOFF force field."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [coverage:run]
 omit =
     openff/interchange/_version.py
+    */*/*test*/*
 
 [coverage:report]
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [coverage:run]
 omit =
     openff/interchange/_version.py
-    */*/*test*/*
+    */*/tests/*
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
I don't know how many times I'll have to nurse CodeCov into doing what I want, but here goes another attempt:
- [x] Fix reporting paths (`/*/*/interoperability_tests`, `/*/*/energy_tests/`, `/*/*/unit_tests/`) that do not exist in the project
- [x] Try to actually ignore `if TYPE_CHECKING:` lines as specified in the setup
