### PR TITLE
Add warning about overriding missing box vectors in GRO writer

### DIFF
--- a/openff/interchange/interop/internal/gromacs.py
+++ b/openff/interchange/interop/internal/gromacs.py
@@ -142,6 +142,12 @@ def to_gro(openff_sys: "Interchange", file_path: Union[Path, str], decimal=8):
                 n_virtual_sites += 1
 
         if openff_sys.box is None:
+            warnings.warn(
+                "WARNING: System defined with no box vectors, which GROMACS does not offically "
+                "support in versions 2020 or newer (see "
+                "https://gitlab.com/gromacs/gromacs/-/issues/3526). Setting box vectors to a 5 "
+                " nm cube."
+            )
             box = 5 * np.eye(3)
         else:
             box = openff_sys.box.m_as(unit.nanometer)

--- a/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
+++ b/openff/interchange/tests/interoperability_tests/internal/test_gromacs.py
@@ -75,6 +75,17 @@ class TestGROMACSGROFile(_BaseTest):
         n_decimals = len(str(internal_coords[0, 0]).split(".")[1])
         assert n_decimals == 12
 
+    def test_vaccum_warning(self, sage):
+        molecule = Molecule.from_smiles("CCO")
+        molecule.generate_conformers(n_conformers=1)
+
+        out = Interchange.from_smirnoff(force_field=sage, topology=[molecule])
+
+        assert out.box is None
+
+        with pytest.warns(UserWarning, match="gitlab"):
+            out.to_gro("tmp.gro")
+
     @pytest.mark.slow()
     def test_residue_info(self, sage):
         """Test that residue information is passed through to .gro files."""


### PR DESCRIPTION
### Description
This is strictly an invalid modification of users' inputs, but I would rather warn than raise an exception here unless user feedback disagrees.

### Checklist
- [x] Add tests
- [x] Lint
- [x] Update docstrings
