### PR TITLE
Faster parameter lookup

### DIFF
--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -285,7 +285,6 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
             self.potentials = dict()
         for topology_key, potential_key in self.slot_map.items():
             smirks = potential_key.id
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
             if topology_key.bond_order:
                 bond_order = topology_key.bond_order
@@ -509,9 +508,6 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
         """
         for potential_key in self.slot_map.values():
             smirks = potential_key.id
-            # ParameterHandler.get_parameter returns a list, although this
-            # should only ever be length 1
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
             potential = Potential(
                 parameters={
@@ -596,7 +592,6 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
         for topology_key, potential_key in self.slot_map.items():
             smirks = potential_key.id
             n = potential_key.mult
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
             # n_terms = len(parameter.k)
             if topology_key.bond_order:
@@ -746,7 +741,6 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
         for potential_key in self.slot_map.values():
             smirks = potential_key.id
             n = potential_key.mult
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
             if parameter.idivf is None:
                 idivf = None
@@ -835,7 +829,6 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
 
         for potential_key in self.slot_map.values():
             smirks = potential_key.id
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
             try:
                 potential = Potential(
@@ -1744,7 +1737,6 @@ class SMIRNOFFVirtualSiteHandler(SMIRNOFFPotentialHandler):
         for virtual_site_key, potential_key in self.slot_map.items():
             # TODO: This logic assumes no spaces in the SMIRKS pattern, name or `match` attribute
             smirks, _, _ = potential_key.id.split(" ")
-            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
             parameter = parameter_handler.parameters[smirks]
 
             virtual_site_potential = Potential(

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -285,7 +285,8 @@ class SMIRNOFFBondHandler(SMIRNOFFPotentialHandler):
             self.potentials = dict()
         for topology_key, potential_key in self.slot_map.items():
             smirks = potential_key.id
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
             if topology_key.bond_order:
                 bond_order = topology_key.bond_order
                 if parameter.k_bondorder:
@@ -510,7 +511,8 @@ class SMIRNOFFAngleHandler(SMIRNOFFPotentialHandler):
             smirks = potential_key.id
             # ParameterHandler.get_parameter returns a list, although this
             # should only ever be length 1
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
             potential = Potential(
                 parameters={
                     "k": parameter.k,
@@ -594,7 +596,8 @@ class SMIRNOFFProperTorsionHandler(SMIRNOFFPotentialHandler):
         for topology_key, potential_key in self.slot_map.items():
             smirks = potential_key.id
             n = potential_key.mult
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
             # n_terms = len(parameter.k)
             if topology_key.bond_order:
                 bond_order = topology_key.bond_order
@@ -743,7 +746,8 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
         for potential_key in self.slot_map.values():
             smirks = potential_key.id
             n = potential_key.mult
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
             if parameter.idivf is None:
                 idivf = None
             else:
@@ -831,7 +835,8 @@ class SMIRNOFFvdWHandler(_SMIRNOFFNonbondedHandler):
 
         for potential_key in self.slot_map.values():
             smirks = potential_key.id
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
             try:
                 potential = Potential(
                     parameters={
@@ -1739,7 +1744,8 @@ class SMIRNOFFVirtualSiteHandler(SMIRNOFFPotentialHandler):
         for virtual_site_key, potential_key in self.slot_map.items():
             # TODO: This logic assumes no spaces in the SMIRKS pattern, name or `match` attribute
             smirks, _, _ = potential_key.id.split(" ")
-            parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            #parameter = parameter_handler.get_parameter({"smirks": smirks})[0]
+            parameter = parameter_handler.parameters[smirks]
 
             virtual_site_potential = Potential(
                 parameters={


### PR DESCRIPTION
### Description
Uses ParameterList slicing instead of `get_parameter` to look up parameters by their SMIRKS. Cuts `ff.create_interchange` runtime by about 40%. 

Test code:

```python
%load_ext snakeviz

from openff.toolkit import Molecule, OpenEyeToolkitWrapper, RDKitToolkitWrapper, ForceField, Topology
from openff.toolkit.utils import get_data_file_path

ff = ForceField('openff-2.0.0.offxml', 'ff14sb_off_impropers_0.0.3.offxml')

protein = Molecule.from_polymer_pdb(get_data_file_path('proteins/T4-protein.pdb'))
ala = Molecule.from_polymer_pdb(get_data_file_path('proteins/MainChain_ALA.pdb'))
top = Topology()
top.add_molecule(protein)
for i in range(5):
    top.add_molecule(ala)
water = Molecule.from_smiles('O')
for i in range(50):
    top.add_molecule(water)
```

```python
%%snakeviz
interchange = ff.create_interchange(top)
```

Before these changes:

<img width="1017" alt="Screen Shot 2022-08-04 at 3 29 02 PM" src="https://user-images.githubusercontent.com/16329175/182963733-e5dbbd1a-e881-4519-9005-51756e71a457.png">


After these changes:

<img width="943" alt="Screen Shot 2022-08-04 at 3 34 21 PM" src="https://user-images.githubusercontent.com/16329175/182964118-b8d5eb10-04cf-4dbf-8e6e-6df3fe03291d.png">