### PR TITLE
Loosen tolerance in tests requiring Wiberg bond order interpolation

### DIFF
--- a/openff/interchange/tests/unit_tests/components/test_smirnoff.py
+++ b/openff/interchange/tests/unit_tests/components/test_smirnoff.py
@@ -769,7 +769,7 @@ class TestBondOrderInterpolation(_BaseTest):
         ):
             k1 = bonds.potentials[pot_key1].parameters["k"].m_as(kcal_mol_a2)
             k2 = bonds_mod.potentials[pot_key2].parameters["k"].m_as(kcal_mol_a2)
-            assert k1 == pytest.approx(k2)
+            assert k1 == pytest.approx(k2, rel=1e-5), (k1, k2)
 
     def test_input_conformers_ignored(self):
         """Test that conformers existing in the topology are not considered in the bond order interpolation
@@ -802,7 +802,7 @@ class TestBondOrderInterpolation(_BaseTest):
         for key1, key2 in zip(bonds.potentials, bonds_mod.potentials):
             k1 = bonds.potentials[key1].parameters["k"].m_as(kcal_mol_a2)
             k2 = bonds_mod.potentials[key2].parameters["k"].m_as(kcal_mol_a2)
-            assert k1 == pytest.approx(k2), (k1, k2)
+            assert k1 == pytest.approx(k2, rel=1e-5), (k1, k2)
 
     def test_fractional_bondorder_invalid_interpolation_method(self):
         """


### PR DESCRIPTION
### Description
The default tolerances of [`pytest.approx`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-approx) are a little too strict for Wiberg bond order interpolation via our wrapped toolkits. This causes many false negatives in tests.
