### PR TITLE
Update ligand in water notebook

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -66,4 +66,4 @@ jobs:
     - name: Run example notebooks
       if: always()
       run: |
-        python -m pytest examples/ --nbval-lax --ignore=examples/deprecated/ --ignore=examples/ligand_in_water/
+        python -m pytest examples/ --nbval-lax --ignore=examples/deprecated/

--- a/examples/ligand_in_water/ligand_in_water.ipynb
+++ b/examples/ligand_in_water/ligand_in_water.ipynb
@@ -36,8 +36,7 @@
     "from openff.units import unit\n",
     "from openff.units.openmm import from_openmm, to_openmm\n",
     "\n",
-    "from openff.interchange import Interchange\n",
-    "from openff.interchange.interop.openmm import to_openmm_positions"
+    "from openff.interchange import Interchange"
    ]
   },
   {
@@ -231,11 +230,15 @@
     "    integrator = openmm.LangevinIntegrator(\n",
     "        300 * openmm.unit.kelvin,\n",
     "        1 / openmm.unit.picosecond,\n",
-    "        0.1 * openmm.unit.femtoseconds,\n",
+    "        1 * openmm.unit.femtoseconds,\n",
     "    )\n",
     "\n",
     "    simulation = openmm.app.Simulation(topology, system, integrator)\n",
     "    simulation.context.setPositions(positions)\n",
+    "\n",
+    "    # https://github.com/openmm/openmm/issues/3736#issuecomment-1217250635\n",
+    "    simulation.minimizeEnergy()\n",
+    "\n",
     "    simulation.context.setVelocitiesToTemperature(300 * openmm.unit.kelvin)\n",
     "    simulation.context.computeVirtualSites()\n",
     "\n",
@@ -302,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_simulation(simulation, n_steps=2000)"
+    "run_simulation(simulation, n_steps=5000)"
    ]
   },
   {
@@ -379,26 +382,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openff.interchange.interop.openmm._positions import to_openmm_positions\n",
+    "\n",
     "simulation = create_simulation(\n",
     "    system,\n",
     "    interchange.to_openmm_topology(),\n",
     "    to_openmm(to_openmm_positions(interchange)),\n",
     "    pdb_stride=100,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb37fada",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    run_simulation(simulation, n_steps=2000)\n",
-    "except openmm.OpenMMException:\n",
-    "    # This simulation sometimes crashes on some platforms for unclear reasons\n",
-    "    pass"
+    ")\n",
+    "\n",
+    "run_simulation(simulation, n_steps=5000)"
    ]
   },
   {
@@ -412,7 +405,9 @@
     "import mdtraj\n",
     "import nglview\n",
     "\n",
-    "show_virtual_sites = True\n",
+    "# NGLview likes to infer bonds between virtual sites in ways that look messy,\n",
+    "# but you can flip this to `True` just to ensure they're there\n",
+    "show_virtual_sites = False\n",
     "\n",
     "if show_virtual_sites:\n",
     "    view = nglview.show_file(\"trajectory.pdb\")\n",
@@ -420,13 +415,12 @@
     "    import numpy\n",
     "\n",
     "    trajectory = mdtraj.load(\"trajectory.pdb\")\n",
-    "    n_atoms = (\n",
-    "        interchange.topology.molecule(0).n_atoms\n",
-    "        + (interchange.topology.n_molecules - 1) * 3\n",
-    "    )\n",
-    "    view = nglview.show_mdtraj(\n",
-    "        trajectory.atom_slice(atom_indices=numpy.arange(n_atoms))\n",
-    "    )\n",
+    "\n",
+    "    atom_indices = numpy.where(\n",
+    "        [a.element.mass > 0.0 for a in trajectory[0].topology.atoms]\n",
+    "    )[0]\n",
+    "\n",
+    "    view = nglview.show_mdtraj(trajectory.atom_slice(atom_indices))\n",
     "\n",
     "view"
    ]

--- a/examples/ligand_in_water/ligand_in_water.ipynb
+++ b/examples/ligand_in_water/ligand_in_water.ipynb
@@ -382,7 +382,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openff.interchange.interop.openmm._positions import to_openmm_positions\n",
+    "from openff.interchange.interop.openmm import to_openmm_positions\n",
     "\n",
     "simulation = create_simulation(\n",
     "    system,\n",


### PR DESCRIPTION
### Description

This PR updates the ligand-in-water notebook after we figured out the reasons for the simulations crashing (https://github.com/openmm/openmm/issues/3736) and virtual particle ordering.

@Yoshanuikabundi do you think it would be worth including short GROMACS simulations in this notebook? One one hand, it's a common user need (https://github.com/openforcefield/openff-toolkit/issues/1328) and not _that_ much of a leap from running the same state in OpenMM. On the other hand, it takes a significant amount of cruft to run GROMACS simulations in notebooks and the scope boundary here is hard to define - should the same be done when we support many engines?


### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
