### PR TITLE
Updates for new Foyer `TopologyGraph` API

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - jaxlib
   - unyt
   - mbuild
-  - foyer >=0.8.1
+  - foyer >=0.11.3
   # Testing
   - intermol
   - openff-evaluator

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -16,7 +16,7 @@ dependencies:
   - jaxlib
   - unyt
   - mbuild
-  - foyer >=0.8.1
+  - foyer >=0.11.3
   # Testing
   - intermol
   - openff-recharge

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - jaxlib
   - unyt
   - mbuild
-  - foyer >=0.8.1
+  - foyer >=0.11.3
   # Examples
   - intermol
   - openff-evaluator-base

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   # Optional features
   - unyt
   - mbuild
-  - foyer >=0.8.1
+  - foyer >=0.11.3
   # Testing
   - intermol
   - openff-evaluator

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   # Optional features
   - unyt
   - mbuild
-  - foyer >=0.8.1
+  - foyer >=0.11.3
   # Examples
   - nglview
   - ipywidgets >7,<8  # https://github.com/nglviewer/nglview/issues/1032

--- a/openff/interchange/components/smirnoff.py
+++ b/openff/interchange/components/smirnoff.py
@@ -781,7 +781,7 @@ class SMIRNOFFImproperTorsionHandler(SMIRNOFFPotentialHandler):
             self.potentials[potential_key] = potential
 
 
-class _SMIRNOFFNonbondedHandler(SMIRNOFFPotentialHandler, abc.ABC):
+class _SMIRNOFFNonbondedHandler(SMIRNOFFPotentialHandler, abc.ABC):  # noqa
     """Base class for handlers storing non-bonded potentials produced by SMIRNOFF force fields."""
 
     type: str = "nonbonded"

--- a/openff/interchange/drivers/report.py
+++ b/openff/interchange/drivers/report.py
@@ -120,7 +120,7 @@ class EnergyReport(DefaultModel):
                         "ener2": [other.energies[key]],
                     }
                     error = pd.DataFrame.from_dict(data)
-                    errors = errors.append(error)
+                    errors = errors.append(error)  # type: ignore[operator]
 
                 continue
 
@@ -142,7 +142,7 @@ class EnergyReport(DefaultModel):
                     "ener2": [other_nonbonded],
                 }
                 error = pd.DataFrame.from_dict(data)
-                errors = errors.append(error)
+                errors = errors.append(error)  # type: ignore[operator]
 
         if len(errors) > 0:
             for col_name in ["diff", "tol", "ener1", "ener2"]:

--- a/openff/interchange/tests/unit_tests/components/test_foyer.py
+++ b/openff/interchange/tests/unit_tests/components/test_foyer.py
@@ -23,10 +23,7 @@ from openff.interchange.tests import (
 if has_package("foyer"):
     import foyer
 
-    from openff.interchange.components.foyer import (
-        _RBTorsionHandler,
-        _topology_graph_from_openff_topology,
-    )
+    from openff.interchange.components.foyer import _RBTorsionHandler
 
 if HAS_GROMACS:
     from openff.interchange.drivers.gromacs import (
@@ -242,14 +239,3 @@ class TestRBTorsions(TestFoyer):
         ]
 
         assert (omm - rb_torsion_energy_from_foyer).m_as(kj_mol) < 1e-6
-
-
-@skip_if_missing("foyer")
-def test_from_openff_topology():
-    from openff.toolkit.topology import Molecule
-
-    topology = Molecule.from_smiles("CCO").to_topology()
-    topology_graph = _topology_graph_from_openff_topology(topology)
-
-    assert topology_graph.number_of_nodes() == topology.n_atoms
-    assert topology_graph.number_of_edges() == topology.n_bonds


### PR DESCRIPTION
### Description
Foyer 0.11.3 adds a `TopologyGraph.from_openff_topology` method that works with the new stack. I found Interchange was previously using some temporary code, which can now be removed.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
