### PR TITLE
Fix handling of zero-residue case in prmtop export.

### DIFF
--- a/openff/interchange/interop/internal/amber.py
+++ b/openff/interchange/interop/internal/amber.py
@@ -494,7 +494,7 @@ def to_prmtop(interchange: "Interchange", file_path: Union[Path, str]):
                 for residue in interchange.topology.hierarchy_iterator("residues")
             ]
             if NRES > 1
-            else [1]
+            else [0]
         )
         prmtop.write("%FLAG RESIDUE_POINTER\n" "%FORMAT(10I8)\n")
         text_blob = "".join([str(val + 1).rjust(8) for val in residue_pointers])


### PR DESCRIPTION
### Description
Interchange.to_prmtop produces an invalid file when the number of residues is zero.   Here is an example:

from openff.toolkit import ForceField, Molecule, Topology
from openff.interchange import Interchange
import parmed

mol = Molecule.from_file("system.sdf")
top = Topology.from_molecules(mol)
ff = ForceField("openff-2.0.0.offxml")
itc = Interchange.from_smirnoff(force_field=ff, topology=top)
itc.to_prmtop("system.prmtop")
itc.to_inpcrd("system.inpcrd")

pmd = parmed.amber.AmberParm("system.prmtop")


This results in:


  File "/scratch/miniconda3/lib/python3.9/site-packages/parmed/amber/_amberparm.py", line 173, in __init__
    self.initialize_topology(xyz, box)
  File "/scratch/miniconda3/lib/python3.9/site-packages/parmed/amber/_amberparm.py", line 203, in initialize_topology
    self.load_structure()
  File "/scratch/miniconda3/lib/python3.9/site-packages/parmed/amber/_amberparm.py", line 503, in load_structure
    self._load_bond_info()
  File "/scratch/miniconda3/lib/python3.9/site-packages/parmed/amber/_amberparm.py", line 1434, in _load_bond_info
    Bond(self.atoms[i//3], self.atoms[j//3],
IndexError: list index out of range
 
### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
