### PR TITLE
List the central atom first in CVFF style dihedrals in LAMMPS export

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,9 +62,10 @@ jobs:
         conda info
         conda list
 
-    - name: License OpenEye
+    - name: Install and license OpenEye Toolkits
       if: ${{ matrix.openeye == true }}
       run: |
+        micromamba install openeye-toolkits -c openeye -yq
         echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
         python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
       env:

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pydantic
   - openmm
   # OpenFF stack
-  - openff-toolkit >=0.11.0
+  - openff-toolkit >=0.11.2
   # Optional features
   - jax
   - jaxlib

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pip
   - pydantic
   - pint
-  - openff-toolkit-base >=0.11.0
+  - openff-toolkit-base >=0.11.2
   - openmm >=7.6
   - intermol
   - jax
@@ -23,4 +23,3 @@ dependencies:
   - sphinx-notfound-page
   - pip:
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
-    - git+https://github.com/openforcefield/openff-toolkit.git@fix-import-loop

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -2,7 +2,6 @@ name: openff-interchange-env
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
-  - openeye
 dependencies:
   # Core
   - python
@@ -19,7 +18,6 @@ dependencies:
   # Testing
   - intermol
   - openff-evaluator
-  - openeye-toolkits
   - jax
   - jaxlib
   - pytest

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,8 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## 0.2.3 - Current development
 
+### Bugfixes
+* #545 List the central atom first in CVFF style dihedrals in LAMMPS export
 
 ## 0.2.2 - 2022-10-12
 

--- a/openff/interchange/interop/internal/lammps.py
+++ b/openff/interchange/interop/internal/lammps.py
@@ -409,12 +409,15 @@ def _write_impropers(lmp_file: IO, openff_sys: Interchange):
 
                 improper_type_idx = improper_type_map_inv[pot_key]
 
+                # https://github.com/openforcefield/openff-interchange/issues/544
+                # LAMMPS, at least with `improper_style cvff`, lists the
+                # central atom FIRST, whereas `indices` lists it SECOND
                 lmp_file.write(
                     "{:d}\t{:d}\t{:d}\t{:d}\t{:d}\t{:d}\n".format(
                         improper_idx + 1,
                         improper_type_idx + 1,
-                        indices[0] + 1,
                         indices[1] + 1,
+                        indices[0] + 1,
                         indices[2] + 1,
                         indices[3] + 1,
                     )


### PR DESCRIPTION
### Description

Fixes #544 

```python
In [1]: from openff.toolkit import Molecule, ForceField
   ...: from openff.interchange import Interchange
   ...: from openff.units import unit
   ...: import numpy
   ...:
   ...:
   ...: molecule = Molecule.from_smiles('C1=CN=CN1')
   ...: sage = ForceField("openff_unconstrained-2.0.0.offxml")
   ...: molecule.generate_conformers()
   ...: cubic_box = unit.Quantity(10.0 * numpy.eye(3), unit.angstrom)
   ...:
   ...: interchange = Interchange.from_smirnoff(topology=[molecule], force_field=sage, box=cubic_box)
   ...: interchange.to_lammps("imidazole.lmp")
/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/smirnoff99frosst/smirnoff99frosst.py:11: UserWarning: Module openff was already imported from None, but /Users/mattthompson/software/openff-interchange is being added to sys.path
  from pkg_resources import resource_filename

In [2]: !tail -n 15 imidazole.lmp

Impropers

3	3	4	8	3	5
4	1	1	5	6	2
6	1	2	7	1	3
11	2	5	4	9	1
14	2	5	9	1	4
15	3	4	5	8	3
16	1	1	6	2	5
17	3	4	3	5	8
18	1	2	3	7	1
21	2	5	1	4	9
22	1	2	1	3	7
23	1	1	2	5	6

```

The first column should maybe be sequential; I'm not sure if that matters, but it wasn't sequential before. The second column is the periodicity, the third through sixth columns are the atoms in each improper. The third column only lists atoms indexed 1, 2, 4, and 5, which are the atoms in the ring that can have dihedrals (atom 3 is a nitrogen with only two bonded neighbors). So that passes the eye test.

I'm thinking about a way to validate that this is processed appropriately by LAMMPS but I'm coming up short. I can pass it through MDAnalysis, which happily reports to me that the first atom is listed first, but I think punts on the definition of "central" (sensibly, since it's both confusing and [probably reversible](https://github.com/MDAnalysis/mdanalysis/issues/2386#issuecomment-556033474)

```ipython
In [39]: u = MDAnalysis.Universe("imidazole.lmp",  atom_style='id type x y z', topology_format='DATA')
    ...:

In [40]: [i.atoms[0].index + 1 for i in u.impropers]
Out[40]: [1, 1, 1, 1, 1, 2, 2, 3, 4, 4, 4, 5]
```

### Checklist
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
