### PR TITLE
Use `Interchange.box` when exporting to PDB via OpenMM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         'flake8-no-pep420',
     ]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.1.0
+  rev: v3.2.0
   hooks:
   - id: pyupgrade
     files: ^openff/interchange

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - pip
   - pydantic
-  - pint
+  - pint =0.19
   - openff-toolkit-base >=0.11.2
   - openmm >=7.6
   - intermol

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -559,7 +559,10 @@ class Interchange(DefaultModel):
         if writer == "openmm":
             from openff.interchange.interop.openmm import _to_pdb
 
-            _to_pdb(file_path, self.topology, self.positions)
+            _topology = Topology(other=self.topology)
+            _topology.box_vectors = self.box
+
+            _to_pdb(file_path, _topology, self.positions)
         else:
             raise UnsupportedExportError
 


### PR DESCRIPTION
### Description
Fixes #548

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
