### PR TITLE
Combine non-bonded forces by default

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,8 +11,12 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## 0.2.3 - Current development
 
+### Behavior changes
+* #554 `Interchange.to_openmm` now uses `combine_nonbonded_forces=True` by default.
+
 ### Bugfixes
 * #545 List the central atom first in CVFF style dihedrals in LAMMPS export
+
 
 ## 0.2.2 - 2022-10-12
 

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -516,7 +516,7 @@ class Interchange(DefaultModel):
         else:
             raise UnsupportedExportError
 
-    def to_openmm(self, combine_nonbonded_forces: bool = False):
+    def to_openmm(self, combine_nonbonded_forces: bool = True):
         """Export this Interchange to an OpenMM System."""
         from openff.interchange.interop.openmm import to_openmm as to_openmm_
 


### PR DESCRIPTION
### Description
The historical behavior of the OpenFF stack (and the [current behavior](https://github.com/openforcefield/openff-toolkit/blob/0.11.4/openff/toolkit/typing/engines/smirnoff/forcefield.py#L1128)) is to attempt to combine all non-bonded forces into a single `openmm.NonbondedForce` object. This change makes that behavior the default.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
