### PR TITLE
Lazy load `Interchange` at top level

### DIFF
--- a/openff/interchange/__init__.py
+++ b/openff/interchange/__init__.py
@@ -1,6 +1,13 @@
 """A project (and object) for storing, manipulating, and converting molecular mechanics data."""
+import importlib
+from types import ModuleType
+from typing import TYPE_CHECKING, Dict, List
+
 from openff.interchange._version import get_versions  # type: ignore
-from openff.interchange.components.interchange import Interchange
+
+if TYPE_CHECKING:
+
+    from openff.interchange.components.interchange import Interchange
 
 # Handle versioneer
 versions = get_versions()
@@ -8,6 +15,29 @@ __version__ = versions["version"]
 __git_revision__ = versions["full-revisionid"]
 del get_versions, versions
 
-__all__ = [
+__all__: List[str] = [
     "Interchange",
 ]
+
+_objects: Dict[str, str] = {
+    "Interchange": "openff.interchange.components.interchange",
+}
+
+
+def __getattr__(name) -> ModuleType:
+    """
+    Lazily import objects from submodules.
+
+    Taken from openff/toolkit/__init__.py
+    """
+    module = _objects.get(name)
+    if module is not None:
+        return importlib.import_module(module).__dict__[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """Add _objects to dir()."""
+    keys = (*globals().keys(), *_objects.keys())
+    return sorted(keys)

--- a/openff/interchange/tests/unit_tests/test_lazy_import.py
+++ b/openff/interchange/tests/unit_tests/test_lazy_import.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_lazy_load():
+    from openff.interchange import Interchange as I1
+    from openff.interchange.components.interchange import Interchange as I2
+
+    assert I1 == I2
+
+
+def test_lazy_load_top_level_module():
+    import openff.interchange
+
+    assert "Interchange" in dir(openff.interchange)
+
+
+def test_lazy_load_error():
+    with pytest.raises(
+        ImportError, match="cannot import name 'Blah' from 'openff.interchange"
+    ):
+        from openff.interchange import Blah  # noqa


### PR DESCRIPTION
### Description
```shell
$ git checkout upstream/main && time python -c "from openff.interchange import __version__" && git checkout top-level-lazy-import && time python -c "from openff.interchange import __version__"
HEAD is now at 6222adc Merge pull request #566 from openforcefield/refactor-report
python -c "from openff.interchange import __version__"  1.79s user 0.76s system 88% cpu 2.899 total
Previous HEAD position was 6222adc Merge pull request #566 from openforcefield/refactor-report
Switched to branch 'top-level-lazy-import'
python -c "from openff.interchange import __version__"  0.04s user 0.04s system 83% cpu 0.096 total
```
### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
