### PR TITLE
Updates to match toolkit behaviors

### DIFF
--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -162,7 +162,7 @@ class MissingBondOrdersError(BaseException):
     """
 
 
-class NonUniqueMoleculesError(ValueError):
+class DuplicateMoleculeError(ValueError):
     """
     Exception for when molecules are not unique.
     """

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -97,7 +97,12 @@ def _create_interchange(
     interchange.box = _topology.box_vectors if box is None else box
 
     _bonds(interchange, force_field, _topology, partial_bond_orders_from_molecules)
-    _constraints(interchange, force_field, _topology)
+    _constraints(
+        interchange,
+        force_field,
+        _topology,
+        bonds=interchange.collections.get("Bonds", None),  # type: ignore[arg-type]
+    )
     _angles(interchange, force_field, _topology)
     _propers(interchange, force_field, _topology, partial_bond_orders_from_molecules)
     _impropers(interchange, force_field, _topology)
@@ -144,7 +149,12 @@ def _bonds(
     )
 
 
-def _constraints(interchange: Interchange, force_field: ForceField, topology: Topology):
+def _constraints(
+    interchange: Interchange,
+    force_field: ForceField,
+    topology: Topology,
+    bonds: Optional[SMIRNOFFBondCollection] = None,
+):
     interchange.collections.update(
         {
             "Constraints": SMIRNOFFConstraintCollection.create(
@@ -157,6 +167,7 @@ def _constraints(interchange: Interchange, force_field: ForceField, topology: To
                     if handler is not None
                 ],
                 topology=topology,
+                bonds=bonds,
             ),
         },
     )

--- a/openff/interchange/smirnoff/_valence.py
+++ b/openff/interchange/smirnoff/_valence.py
@@ -232,7 +232,7 @@ class SMIRNOFFBondCollection(SMIRNOFFCollection):
         cls: Type[T],
         parameter_handler: BondHandler,
         topology: Topology,
-        partial_bond_orders_from_molecules=None,
+        partial_bond_orders_from_molecules: Optional[List[Molecule]] = None,
     ) -> T:
         """
         Create a SMIRNOFFBondCollection from toolkit data.
@@ -255,7 +255,8 @@ class SMIRNOFFBondCollection(SMIRNOFFCollection):
         if handler._get_uses_interpolation(parameter_handler):
             _check_molecule_uniqueness(partial_bond_orders_from_molecules)
 
-            for molecule in topology.unique_molecules:
+            for molecule in topology.molecules:
+                # TODO: This loop could be sped up by iterating over `unique_molecules` and later copy the
                 if _molecule_is_in_list(molecule, partial_bond_orders_from_molecules):
                     continue
 
@@ -301,6 +302,7 @@ class SMIRNOFFConstraintCollection(SMIRNOFFCollection):
         cls: Type[T],
         parameter_handler: List,
         topology: Topology,
+        bonds: Optional[SMIRNOFFBondCollection] = None,
     ) -> T:
         """
         Create a SMIRNOFFCollection from toolkit data.
@@ -319,6 +321,7 @@ class SMIRNOFFConstraintCollection(SMIRNOFFCollection):
         handler.store_constraints(
             parameter_handlers=parameter_handlers,
             topology=topology,
+            bonds=bonds,
         )
 
         return handler
@@ -327,6 +330,7 @@ class SMIRNOFFConstraintCollection(SMIRNOFFCollection):
         self,
         parameter_handlers: List,
         topology: Topology,
+        bonds: Optional[SMIRNOFFBondCollection] = None,
     ) -> None:
         """Store constraints."""
         if self.key_map:
@@ -343,10 +347,8 @@ class SMIRNOFFConstraintCollection(SMIRNOFFCollection):
 
         if any([type(p) == BondHandler for p in parameter_handlers]):
             bond_handler = [p for p in parameter_handlers if type(p) == BondHandler][0]
-            bonds = SMIRNOFFBondCollection.create(
-                parameter_handler=bond_handler,
-                topology=topology,
-            )
+            # This should be passed in as a parameter
+            assert bonds is not None
         else:
             bond_handler = None
             bonds = None
@@ -570,7 +572,7 @@ class SMIRNOFFProperTorsionCollection(SMIRNOFFCollection):
         ):
             _check_molecule_uniqueness(partial_bond_orders_from_molecules)
 
-            for molecule in topology.unique_molecules:
+            for molecule in topology.molecules:
                 if _molecule_is_in_list(molecule, partial_bond_orders_from_molecules):
                     continue
 

--- a/openff/interchange/tests/energy_tests/test_energies.py
+++ b/openff/interchange/tests/energy_tests/test_energies.py
@@ -218,7 +218,7 @@ class TestEnergies(_BaseTest):
         mol.generate_conformers(n_conformers=1)
 
         forcefield = ForceField(
-            "test_forcefields/test_forcefield.offxml",
+            "openff-2.0.0.offxml",
             xml_ff_bo_all_heavy_bonds,
         )
 

--- a/openff/interchange/tests/unit_tests/interop/test_openmm.py
+++ b/openff/interchange/tests/unit_tests/interop/test_openmm.py
@@ -48,9 +48,10 @@ class TestOpenMM(_BaseTest):
         # Ported from the toolkit after #1276
         top = Molecule.from_smiles("CCCC").to_topology()
 
-        ff_no_electrostatics = ForceField("test_forcefields/test_forcefield.offxml")
+        ff_no_electrostatics = ForceField("openff-2.0.0.offxml")
         ff_no_electrostatics.deregister_parameter_handler("Electrostatics")
         ff_no_electrostatics.deregister_parameter_handler("ToolkitAM1BCC")
+        ff_no_electrostatics.deregister_parameter_handler("LibraryCharges")
 
         out = Interchange.from_smirnoff(
             ff_no_electrostatics,
@@ -67,7 +68,7 @@ class TestOpenMM(_BaseTest):
         # Ported from the toolkit after #1276
         top = Molecule.from_smiles("CCCC").to_topology()
 
-        ff_no_vdw = ForceField("test_forcefields/test_forcefield.offxml")
+        ff_no_vdw = ForceField("openff-2.0.0.offxml")
         ff_no_vdw.deregister_parameter_handler("vdW")
 
         out = Interchange.from_smirnoff(

--- a/openff/interchange/tests/unit_tests/smirnoff/test_create.py
+++ b/openff/interchange/tests/unit_tests/smirnoff/test_create.py
@@ -239,7 +239,10 @@ class TestPartialBondOrdersFromMolecules(_BaseTest):
 
         from openff.toolkit.tests.test_forcefield import xml_ff_bo
 
-        forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
+        forcefield = ForceField(
+            "openff-2.0.0.offxml",
+            xml_ff_bo,
+        )
         topology = Topology.from_molecules(mol)
 
         out = Interchange.from_smirnoff(
@@ -274,7 +277,10 @@ class TestPartialBondOrdersFromMolecules(_BaseTest):
     def test_partial_bond_order_from_molecules_empty(self, ethanol):
         from openff.toolkit.tests.test_forcefield import xml_ff_bo
 
-        forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
+        forcefield = ForceField(
+            "openff-2.0.0.offxml",
+            xml_ff_bo,
+        )
 
         default = Interchange.from_smirnoff(forcefield, ethanol.to_topology())
         empty = Interchange.from_smirnoff(
@@ -290,7 +296,10 @@ class TestPartialBondOrdersFromMolecules(_BaseTest):
     def test_partial_bond_order_from_molecules_no_matches(self, ethanol):
         from openff.toolkit.tests.test_forcefield import xml_ff_bo
 
-        forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
+        forcefield = ForceField(
+            "openff-2.0.0.offxml",
+            xml_ff_bo,
+        )
 
         decoy = Molecule.from_smiles("C#N")
         decoy.assign_fractional_bond_orders(bond_order_model="am1-wiberg")

--- a/openff/interchange/tests/unit_tests/smirnoff/test_valence.py
+++ b/openff/interchange/tests/unit_tests/smirnoff/test_valence.py
@@ -6,8 +6,9 @@ from openff.toolkit.tests.test_forcefield import (
     create_cyclohexane,
     create_ethanol,
     create_reversed_ethanol,
+    create_water,
 )
-from openff.toolkit.tests.utils import get_data_file_path, requires_openeye
+from openff.toolkit.tests.utils import requires_openeye
 from openff.toolkit.typing.engines.smirnoff.parameters import (
     AngleHandler,
     BondHandler,
@@ -198,7 +199,6 @@ class TestBondOrderInterpolation(_BaseTest):
     def test_input_bond_orders_ignored(self):
         """Test that conformers existing in the topology are not considered in the bond order interpolation
         part of the parametrization process"""
-        from openff.toolkit.tests.test_forcefield import create_ethanol
 
         mol = create_ethanol()
         mol.assign_fractional_bond_orders(bond_order_model="am1-wiberg")
@@ -210,7 +210,7 @@ class TestBondOrderInterpolation(_BaseTest):
         mod_top = Topology.from_molecules(mod_mol)
 
         forcefield = ForceField(
-            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            "openff-2.0.0.offxml",
             self.xml_ff_bo_bonds,
         )
 
@@ -248,7 +248,7 @@ class TestBondOrderInterpolation(_BaseTest):
         mod_top = Topology.from_molecules(mod_mol)
 
         forcefield = ForceField(
-            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            "openff-2.0.0.offxml",
             self.xml_ff_bo_bonds,
         )
 
@@ -272,7 +272,7 @@ class TestBondOrderInterpolation(_BaseTest):
         FractionalBondOrderInterpolationMethodUnsupportedError
         """
         forcefield = ForceField(
-            get_data_file_path("test_forcefields/test_forcefield.offxml"),
+            "openff-2.0.0.offxml",
             self.xml_ff_bo_bonds,
         )
         forcefield["Bonds"]._fractional_bondorder_interpolation = "invalid method name"
@@ -308,7 +308,7 @@ class TestParameterInterpolation(_BaseTest):
     @pytest.mark.xfail(reason="Not yet implemented using input bond orders")
     def test_bond_order_interpolation(self, ethanol):
         forcefield = ForceField(
-            "test_forcefields/test_forcefield.offxml",
+            "openff-2.0.0.offxml",
             self.xml_ff_bo,
         )
 
@@ -334,7 +334,7 @@ class TestParameterInterpolation(_BaseTest):
         """Test that key mappings do not get confused when two bonds having similar SMIRKS matches
         have different bond orders"""
         forcefield = ForceField(
-            "test_forcefields/test_forcefield.offxml",
+            "openff-2.0.0.offxml",
             self.xml_ff_bo,
         )
 
@@ -417,7 +417,7 @@ class TestParameterInterpolation(_BaseTest):
         """
         mol = get_molecule()
         forcefield = ForceField(
-            "test_forcefields/test_forcefield.offxml",
+            "openff-2.0.0.offxml",
             self.xml_ff_bo,
         )
         topology = Topology.from_molecules(mol)
@@ -534,10 +534,14 @@ def test_get_uses_interpolation():
 
 
 def test_check_molecule_uniqueness():
-    ethanol = create_ethanol()
-    _check_molecule_uniqueness(ethanol, None)
-    _check_molecule_uniqueness(ethanol, list())
-    _check_molecule_uniqueness(ethanol, [create_cyclohexane()])
+    _check_molecule_uniqueness(None)
+    _check_molecule_uniqueness(list())
+    _check_molecule_uniqueness([create_ethanol()])
+    _check_molecule_uniqueness([create_cyclohexane()])
+    _check_molecule_uniqueness([create_ethanol(), create_cyclohexane(), create_water()])
 
     with pytest.raises(DuplicateMoleculeError, match="Duplicate molecules"):
-        _check_molecule_uniqueness(ethanol, 2 * [create_ethanol()])
+        _check_molecule_uniqueness(2 * [create_ethanol()])
+
+    with pytest.raises(DuplicateMoleculeError, match="Duplicate molecules"):
+        _check_molecule_uniqueness([create_ethanol(), create_reversed_ethanol()])

--- a/openff/interchange/tests/unit_tests/smirnoff/test_valence.py
+++ b/openff/interchange/tests/unit_tests/smirnoff/test_valence.py
@@ -173,10 +173,9 @@ class TestConstraintCollection(_BaseTest):
         topology = Molecule.from_smiles(mol).to_topology()
 
         constraints = SMIRNOFFConstraintCollection.create(
-            parameter_handler=[
-                val for val in [bond_handler, constraint_handler] if val is not None
-            ],
+            parameter_handler=[bond_handler, constraint_handler],
             topology=topology,
+            bonds=SMIRNOFFBondCollection.create(bond_handler, topology),
         )
 
         assert len(constraints.key_map) == n_constraints


### PR DESCRIPTION
* Raise `ValueError` if `partial_bond_orders_from_molecules` contains isomorphic duplicates
* Do not look in `test_forcefields/`