### PR TITLE
Consistently strip units when passing parameters to `openmm.CustomNonbondedForce`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,7 @@ jobs:
         # https://github.com/openforcefield/openff-interchange/pull/578#issuecomment-1369979875
         micromamba remove jax -yq
         mypy --show-error-codes --namespace-packages -p "openff.interchange"
+        mypy --show-error-codes plugins/nonbonded_plugins/
 
     - name: Codecov
       uses: codecov/codecov-action@v3

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -651,7 +651,7 @@ def _create_multiple_nonbonded_forces(
             for global_parameter in vdw.global_parameters():
                 vdw_14_force.addGlobalParameter(
                     global_parameter,
-                    getattr(vdw, global_parameter),
+                    getattr(vdw, global_parameter).m,
                 )
 
             for term, value in data["vdw_collection"].pre_computed_terms().items():
@@ -925,15 +925,15 @@ def _set_particle_parameters(
                 pot_key = vdw.key_map[top_key]
 
                 if vdw.is_plugin:
-                    potential_parameters = vdw.potentials[pot_key].parameters
-
-                    parameters: Dict[str, unit.Quantity] = {
-                        key: val.to_openmm()
-                        for key, val in potential_parameters.items()
-                    }
+                    parameters = vdw.potentials[pot_key].parameters
 
                     if hasattr(vdw, "modify_parameters"):
+                        # This method strips units ..
                         parameters = vdw.modify_parameters(parameters)
+                    else:
+                        # so manually strip them if the method is not present
+                        parameters = {key: val.m for key, val in parameters.items()}
+
                 else:
                     sigma, epsilon = _lj_params_from_potential(
                         vdw.potentials[pot_key],

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -772,7 +772,7 @@ def _create_vdw_force(
         for global_parameter in vdw_collection.global_parameters():
             vdw_force.addGlobalParameter(
                 global_parameter,
-                getattr(vdw_collection, global_parameter),
+                getattr(vdw_collection, global_parameter).m,
             )
 
         for term, value in vdw_collection.pre_computed_terms().items():

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -761,7 +761,9 @@ def _create_vdw_force(
     mixing_rule_expression: str = data["mixing_rule_expression"]  # type: ignore[assignment]
 
     vdw_force = openmm.CustomNonbondedForce(
-        f"{vdw_expression}; {mixing_rule_expression}",
+        f"{vdw_expression}"
+        if mixing_rule_expression in (None, "")
+        else f"{vdw_expression}; {mixing_rule_expression}",
     )
 
     for potential_parameter in vdw_collection.potential_parameters():

--- a/plugins/nonbonded_plugins/nonbonded.py
+++ b/plugins/nonbonded_plugins/nonbonded.py
@@ -281,13 +281,16 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
     def modify_parameters(
         self,
         original_parameters: Dict[str, unit.Quantity],
-    ) -> Dict[str, unit.Quantity]:
+    ) -> Dict[str, float]:
         """Optionally modify parameters prior to their being stored in a force."""
         # It's important that these keys are in the order of self.potential_parameters(),
         # consider adding a check somewhere that this is the case.
+        _units = {"r_min": unit.nanometer, "epsilon": unit.kilojoule_per_mole}
         return {
-            "r_min": original_parameters["r_min"] * 0.5,
-            "epsilon": original_parameters["epsilon"] ** 0.5,
+            "r_min": original_parameters["r_min"].m_as(_units["r_min"]) * 0.5,
+            "epsilon": math.sqrt(
+                original_parameters["epsilon"].m_as(_units["epsilon"]),
+            ),
         }
 
     @classmethod

--- a/plugins/nonbonded_plugins/nonbonded.py
+++ b/plugins/nonbonded_plugins/nonbonded.py
@@ -1,6 +1,6 @@
 """Custom classes exposed as plugins."""
 import math
-from typing import Dict, Iterable, List, Literal, Type
+from typing import Dict, Iterable, Literal, Type
 
 from openff.models.types import FloatQuantity
 from openff.toolkit import Topology
@@ -114,29 +114,29 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
     switch_width: FloatQuantity["angstrom"] = unit.Quantity(1.0, unit.angstrom)  # noqa
 
     @classmethod
-    def allowed_parameter_handlers(cls) -> List[Type[ParameterHandler]]:
+    def allowed_parameter_handlers(cls) -> Iterable[Type[ParameterHandler]]:
         """Return a list of allowed types of ParameterHandler classes."""
-        return [BuckinghamHandler]
+        return (BuckinghamHandler,)
 
     @classmethod
     def supported_parameters(cls) -> Iterable[str]:
         """Return a list of supported parameter attributes."""
-        return ["smirks", "id", "a", "b", "c"]
+        return "smirks", "id", "a", "b", "c"
 
     @classmethod
     def default_parameter_values(cls) -> Iterable[float]:
         """Per-particle parameter values passed to Force.addParticle()."""
-        return [0.0, 0.0, 0.0]
+        return 0.0, 0.0, 0.0
 
     @classmethod
     def potential_parameters(cls) -> Iterable[str]:
         """Return a subset of `supported_parameters` that are meant to be included in potentials."""
-        return ["a", "b", "c"]
+        return "a", "b", "c"
 
     @classmethod
     def global_parameters(cls) -> Iterable[str]:
         """Return a list of global parameters, i.e. not per-potential parameters."""
-        return list()
+        return tuple()
 
     def pre_computed_terms(self) -> Dict[str, float]:
         """Return a dictionary of pre-computed terms for use in the expression."""
@@ -171,7 +171,7 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
             self.potentials[potential_key] = potential
 
     @classmethod
-    def create(  # type: ignore[override]
+    def create(
         cls: Type[T],
         parameter_handler: BuckinghamHandler,
         topology: Topology,
@@ -201,11 +201,11 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
         return handler
 
     @classmethod
-    def parameter_handler_precedence(cls) -> List[str]:
+    def parameter_handler_precedence(cls) -> Iterable[str]:
         """
         Return the order in which parameter handlers take precedence when computing charges.
         """
-        return ["vdw", "VirtualSites"]
+        return "vdw", "VirtualSites"
 
     def create_virtual_sites(
         self,
@@ -246,27 +246,27 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
     @classmethod
     def allowed_parameter_handlers(cls) -> Iterable[Type[ParameterHandler]]:
         """Return a list of allowed types of ParameterHandler classes."""
-        return [DoubleExponentialHandler]
+        return (DoubleExponentialHandler,)
 
     @classmethod
     def supported_parameters(cls) -> Iterable[str]:
         """Return a list of supported parameter attributes."""
-        return ["smirks", "id", "r_min", "epsilon"]
+        return "smirks", "id", "r_min", "epsilon"
 
     @classmethod
     def default_parameter_values(cls) -> Iterable[float]:
         """Per-particle parameter values passed to Force.addParticle()."""
-        return [0.0, 0.0]
+        return 0.0, 0.0
 
     @classmethod
     def potential_parameters(cls) -> Iterable[str]:
         """Return a subset of `supported_parameters` that are meant to be included in potentials."""
-        return ["r_min", "epsilon"]
+        return "r_min", "epsilon"
 
     @classmethod
     def global_parameters(cls) -> Iterable[str]:
         """Return a list of global parameters, i.e. not per-potential parameters."""
-        return ["alpha", "beta"]
+        return "alpha", "beta"
 
     def pre_computed_terms(self) -> Dict[str, float]:
         """Return a dictionary of pre-computed terms for use in the expression."""
@@ -322,7 +322,7 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
             self.potentials[potential_key] = potential
 
     @classmethod
-    def create(  # type: ignore[override]
+    def create(
         cls: Type[T],
         parameter_handler: DoubleExponentialHandler,
         topology: Topology,
@@ -354,11 +354,11 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
         return handler
 
     @classmethod
-    def parameter_handler_precedence(cls) -> List[str]:
+    def parameter_handler_precedence(cls) -> Iterable[str]:
         """
         Return the order in which parameter handlers take precedence when computing charges.
         """
-        return ["vdw", "VirtualSites"]
+        return "vdw", "VirtualSites"
 
     def create_virtual_sites(
         self,


### PR DESCRIPTION
### Description
This is an inconsistency that caused me trouble working on https://github.com/openforcefield/smirnoff-plugins/pull/53. It's somewhat tricky because
* `openmm.NonbondedForce` will gladly take in `openmm.unit.Quantity`s but `openmm.CustomNonbondedForce` wants floats.
* Some functional forms have global parameters, which may or may not have units.
* Some functional forms have  pre-compute parameters, which could strip units

So, by the time parameters are [given](https://github.com/openforcefield/openff-interchange/blob/5ceba6c78bf3ebeecdb7b96355b8424bafc3ab19/openff/interchange/interop/openmm/_nonbonded.py#L949) to OpenMM's C++ layer, it's not clear if their units were stripped or not, and which units they were in. This remains a potent footgun but I'm not going to be able to put in all of the potential safeguards today. The signature

```
def pre_computed_terms(self) -> Dict[str, float]:
```

indicates that units are to be stripped and therefore the control is with the user to i.e. ensure distance units are consistently in nanometers or Angstroms. Elsewhere the units are naively stripped (will reference where in a comment); if this becomes an issue to users we can add another method that marries units to parameters.

### Checklist
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
