### PR TITLE
Bring installation guide in line with ecosystem docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,10 @@ intersphinx_mapping = {
         None,
     ),
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
+    "openff.docs": (
+        "https://docs.openforcefield.org/",
+        None,
+    ),
 }
 
 mermaid_init_js = """mermaid.initialize({

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ intersphinx_mapping = {
     ),
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
     "openff.docs": (
-        "https://docs.openforcefield.org/",
+        "https://docs.openforcefield.org/en/latest/",
         None,
     ),
     "setuptools": ("https://setuptools.pypa.io/en/latest/", None),

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,20 +1,20 @@
 # Installation
 
-These instructions assume that the `conda` package manager is installed. It can be obtained either from the [Anaconda](https://www.anaconda.com/products/individual#Downloads) Python distribution or a lightweight stand-in such as [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Miniforge](https://github.com/conda-forge/miniforge#readme).
+These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [ecosystem installation documentation](openff.docs:installation).
 
 ## Quick Installation
 
-Install the latest release from `conda-forge`:
+Install the latest release of the `openff-interchange` package from `conda-forge`:
 
 ```shell
-conda install openff-interchange -c conda-forge
+conda install -c conda-forge openff-interchange
 ```
 
 ## Optional dependencies
 
 Some libraries or tools are only used for development, testing, or optional features. If portions of the API that require optional dependencies are called while those package(s) are not available, an informative error message should be provided. If one is not provided or is insufficiently informative, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
 
-It is assumed that all packages are updated to their latest minor versions. Compatibility with old releases is not guaranteed and likely to not work. For example, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.8.3 and older) and OpenMM (7.5.1 and older) are not guaranteed. If there are a compelling reasons to add compatibiility with old versions of dependencies, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
+It is assumed that all packages are updated to their latest minor versions. Compatibility with old releases is not guaranteed and likely to not work. For example, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.8.3 and older) and OpenMM (7.5.1 and older) are not guaranteed. If there are a compelling reasons to add compatibility with old versions of dependencies, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
 
 All packages (with the exception of OpenEye toolkits) are understood to be open source and free to use. Some operations within the OpenFF Toolkit can be faster if OpenEye toolkits are available, but free alternatives (using RDKit, AmberTools) are available for all methods. For more see [here](https://open-forcefield-toolkit.readthedocs.io/en/stable/installation.html#optional-dependencies).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [ecosystem installation documentation](openff.docs:installation).
+These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [ecosystem installation documentation](openff.docs:install).
 
 ## Quick Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [ecosystem installation documentation](openff.docs:install).
+These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [OpenFF installation documentation](openff.docs:install).
 
 ## Quick Installation
 

--- a/docs/using/plugins.md
+++ b/docs/using/plugins.md
@@ -66,7 +66,7 @@ A `SMIRNOFFCollection` is a subclass of [`Collection`] specific to SMIRNOFF forc
   * define a field [`expression: str`], a mathematical formula defining how it contributes to the overall potential energy
   * define a class method [`allowed_parameter_handlers`] that returns an iterable of the `ParameterHandler` subclasses that it can process
   * define a class method [`supported_parameters`] that returns an iterable of parameters that it expects to store (i.e. `"smirks"`, `"k"`, `"length"`, etc.)
-  * override other methods of [`SMIRNOFFCollection`] and  [`Collection`] ([`store_matches`], [`store_potentials`], [`create`]) as needed
+  * override other methods of [`SMIRNOFFCollection`] and  [`Collection`] ([`store_matches`], [`create`]) as needed
     * The argument `parameter_handler` to `create` can either be of type `ParameterHandler` or `List[ParameterHandler]`. If the collection can take multiple handlers (a case probably associated with `allowed_parameter_handlers` returning an iterable longer than 1) then `create` should assume the argument is a list containing multiple handlers. Otherwise, it will be passed a single handler.
 
 * The class _may_
@@ -81,7 +81,6 @@ A `SMIRNOFFCollection` is a subclass of [`Collection`] specific to SMIRNOFF forc
 [`supported_parameters`]:openff.interchange.plugins.SMIRNOFFCollection.supported_parameters
 [`Collection`]: openff.interchange.components.potentials.Collection
 [`store_matches`]: openff.interchange.plugins.SMIRNOFFCollection.store_matches
-[`store_potentials`]: openff.interchange.components.potentials.Collection.store_potentials
 [`create`]: openff.interchange.plugins.SMIRNOFFCollection.create
 
 ## Examples


### PR DESCRIPTION
### Description

This PR links the installation guide to the new [ecosystem docs](https://docs.openforcefield.org/en/latest/install.html).

### Checklist

- [x] Lint
