### PR TITLE
Support multiple `ParameterHandlers` in one `SMIRNOFFCollection`

### DIFF
--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -58,7 +58,7 @@ for collection_plugin in load_smirnoff_plugins():
 
     # if len(parameter_handlers) != 1:
     #     raise RuntimeError
-    
+
     for parameter_handler in parameter_handlers:
         if parameter_handler in load_handler_plugins():
             _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handler._TAGNAME)
@@ -352,11 +352,12 @@ def _plugins(
         # Perhaps need to exit if there is a handler that is not in the collection
         # but I will leave this to developers.
 
-
     # In case where multiple handlers co-exist in a collection
     # Assuming only one collection gets to be loaded at a time
-    handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
-
+    handlers = [
+        force_field[handler_class._TAGNAME]
+        for handler_class in _PLUGIN_CLASS_MAPPING.keys()
+    ]
 
     # Protect cases that are one handler per collection
     # Probably would not be necessary if `Collection.create` always take in List
@@ -364,7 +365,6 @@ def _plugins(
     if len(handlers) == 1:
         handlers = handlers[0]
 
-    
     collection = collection_class.create(
         parameter_handler=handlers,
         topology=topology,
@@ -373,6 +373,6 @@ def _plugins(
     interchange.collections.update(
         {
             # handler_class._TAGNAME: collection,
-            collection.type: collection, # Since handlers have different tagnames, I would match collection type instead of handler
+            collection.type: collection,  # Since handlers have different tagnames, I would match collection type instead of handler
         },
     )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,13 +349,18 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-        collection = collection_class.create(
-            parameter_handler=force_field[handler_class._TAGNAME],
-            topology=topology,
-        )
+    # In case where multiple handles co-exists in a collection (MPID)
+    handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
-        interchange.collections.update(
-            {
-                handler_class._TAGNAME: collection,
-            },
-        )
+
+    collection = collection_class.create(
+        parameter_handler=handlers,
+        topology=topology,
+    )
+
+    interchange.collections.update(
+        {
+            # handler_class._TAGNAME: collection,
+            collection.type: collection, # match collection instead of handler
+        },
+    )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -56,12 +56,13 @@ for collection_plugin in load_smirnoff_plugins():
         Type["ParameterHandler"]
     ] = collection_plugin.allowed_parameter_handlers()
 
-    if len(parameter_handlers) != 1:
-        raise RuntimeError
-
-    if parameter_handlers[0] in load_handler_plugins():
-        _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handlers[0]._TAGNAME)
-        _PLUGIN_CLASS_MAPPING[parameter_handlers[0]] = collection_plugin
+    # if len(parameter_handlers) != 1:
+    #     raise RuntimeError
+    
+    for parameter_handler in parameter_handlers:
+        if parameter_handler in load_handler_plugins():
+            _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handler._TAGNAME)
+            _PLUGIN_CLASS_MAPPING[parameter_handler] = collection_plugin
 
 
 def _check_supported_handlers(force_field: ForceField):

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,10 +349,22 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-    # In case where multiple handlers co-exist in a collection (MPID)
+        # Perhaps need to exit if there is a handler that is not in the collection
+        # but I will leave this to developers.
+
+
+    # In case where multiple handlers co-exist in a collection
+    # Assuming only one collection gets to be loaded at a time
     handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
 
+    # Protect cases that are one handler per collection
+    # Probably would not be necessary if `Collection.create` always take in List
+    # see file _base.py#L219
+    if len(handlers) == 1:
+        handlers = handlers[0]
+
+    
     collection = collection_class.create(
         parameter_handler=handlers,
         topology=topology,
@@ -361,6 +373,6 @@ def _plugins(
     interchange.collections.update(
         {
             # handler_class._TAGNAME: collection,
-            collection.type: collection, # match collection instead of handler
+            collection.type: collection, # Since handlers have different tagnames, I would match collection type instead of handler
         },
     )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,7 +349,7 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-    # In case where multiple handles co-exists in a collection (MPID)
+    # In case where multiple handlers co-exist in a collection (MPID)
     handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
 


### PR DESCRIPTION
### Description

Responds to [Issue#647](https://github.com/openforcefield/openff-interchange/issues/647)

I have left comments in the code block regarding:
1. If more than one collection is loaded by the plugin.
2. If there is only one handler in the collection.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
