### PR TITLE
Support multiple `ParameterHandler`s in one `SMIRNOFFCollection` plugin

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -21,6 +21,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 * #635 Adds a dedicated class `GROMACSSystem` to represent GROMACS state.
 * #635 Adds parsing and exporting between GROMACS files and `GROMACSSystem` objects.
+* #651 Adds support for `SMIRNOFFCollection` plugins that depend on multiple `ParameterHandler`s.
 
 ## 0.3.0 - 2023-04-10
 

--- a/docs/using/plugins.md
+++ b/docs/using/plugins.md
@@ -1,8 +1,8 @@
 # Creating custom interactions via plugins
 
-Custom interactions (i.e., interactions other than 12-6 Lennard-Jones, harmonic bonds, or harmonic angles) can be introduced into the OpenFF stack via plugin interfaces. To create a plugin, create a subclass of both [`ParameterHandler`] and [`SMIRNOFFCollection`] for each new type of physical interaction in the model, then expose them to Interchange via the `openff.toolkit.plugins.handlers` and `openff.interchange.plugins.collections` [SetupTools entry points], respectively.
+Custom interactions (i.e., interactions other than 12-6 Lennard-Jones, harmonic bonds, or harmonic angles) can be introduced into the OpenFF stack via plugin interfaces. To create a plugin, create a subclass(s) of both [`ParameterHandler`] and [`SMIRNOFFCollection`] for each new type of physical interaction in the model, then expose them to Interchange via the `openff.toolkit.plugins.handlers` and `openff.interchange.plugins.collections` [SetupTools entry points], respectively.
 
-Parameter handlers are responsible for the system- and engine-independent aspects of parametrization; in other words, they define the force field itself. By contrast, a SMIRNOFF collection handles the parametrization of a particular system and the preparation of that system for simulation with an external MD engine. The base classes for parameter handlers are defined in the OpenFF Toolkit, while collections are defined in Interchange.
+Parameter handlers are responsible for the system- and engine-independent aspects of parametrization; in other words, they define the force field itself. By contrast, a SMIRNOFF collection handles the parametrization of a particular system and the preparation of that system for simulation with an external MD engine. The base classes for parameter handlers are defined in the OpenFF Toolkit, while collections are defined in Interchange. Most use cases involve one parameter handler and one collection, though a collection can process multiple parameter handlers.
 
 Currently, systems using custom interactions can only be exported to OpenMM. There are two routes for this export: one using existing Interchange machinery and another that allows for completely custom behavior.
 
@@ -67,6 +67,7 @@ A `SMIRNOFFCollection` is a subclass of [`Collection`] specific to SMIRNOFF forc
   * define a class method [`allowed_parameter_handlers`] that returns an iterable of the `ParameterHandler` subclasses that it can process
   * define a class method [`supported_parameters`] that returns an iterable of parameters that it expects to store (i.e. `"smirks"`, `"k"`, `"length"`, etc.)
   * override other methods of [`SMIRNOFFCollection`] and  [`Collection`] ([`store_matches`], [`store_potentials`], [`create`]) as needed
+    * The argument `parameter_handler` to `create` can either be of type `ParameterHandler` or `List[ParameterHandler]`. If the collection can take multiple handlers (a case probably associated with `allowed_parameter_handlers` returning an iterable longer than 1) then `create` should assume the argument is a list containing multiple handlers. Otherwise, it will be passed a single handler.
 
 * The class _may_
   * define other optional fields, similar to optional attributes on its corresponding parameter handler
@@ -246,7 +247,7 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
         self.method = parameter_handler.method.lower()
         self.cutoff = parameter_handler.cutoff
 
-        for potential_key in self.slot_map.values():
+        for potential_key in self.key_map.values():
             smirks = potential_key.id
             parameter = parameter_handler.parameters[smirks]
 

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -58,7 +58,7 @@ for collection_plugin in load_smirnoff_plugins():
 
     # if len(parameter_handlers) != 1:
     #     raise RuntimeError
-    
+
     for parameter_handler in parameter_handlers:
         if parameter_handler in load_handler_plugins():
             _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handler._TAGNAME)
@@ -352,11 +352,12 @@ def _plugins(
         # Perhaps need to exit if there is a handler that is not in the collection
         # but I will leave this to developers.
 
-
     # In case where multiple handlers co-exist in a collection
     # Assuming only one collection gets to be loaded at a time
-    handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
-
+    handlers = [
+        force_field[handler_class._TAGNAME]
+        for handler_class in _PLUGIN_CLASS_MAPPING.keys()
+    ]
 
     # Protect cases that are one handler per collection
     # Probably would not be necessary if `Collection.create` always take in List
@@ -364,7 +365,6 @@ def _plugins(
     if len(handlers) == 1:
         handlers = handlers[0]
 
-    
     collection = collection_class.create(
         parameter_handler=handlers,
         topology=topology,
@@ -373,6 +373,6 @@ def _plugins(
     interchange.collections.update(
         {
             # handler_class._TAGNAME: collection,
-            collection.type: collection, # Since handlers have different tagnames, I would match collection type instead of handler
+            collection.type: collection,  # Since handlers have different tagnames, I would match collection type instead of handler
         },
     )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,13 +349,18 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-        collection = collection_class.create(
-            parameter_handler=force_field[handler_class._TAGNAME],
-            topology=topology,
-        )
+    # In case where multiple handles co-exists in a collection (MPID)
+    handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
-        interchange.collections.update(
-            {
-                handler_class._TAGNAME: collection,
-            },
-        )
+
+    collection = collection_class.create(
+        parameter_handler=handlers,
+        topology=topology,
+    )
+
+    interchange.collections.update(
+        {
+            # handler_class._TAGNAME: collection,
+            collection.type: collection, # match collection instead of handler
+        },
+    )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -56,12 +56,13 @@ for collection_plugin in load_smirnoff_plugins():
         Type["ParameterHandler"]
     ] = collection_plugin.allowed_parameter_handlers()
 
-    if len(parameter_handlers) != 1:
-        raise RuntimeError
-
-    if parameter_handlers[0] in load_handler_plugins():
-        _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handlers[0]._TAGNAME)
-        _PLUGIN_CLASS_MAPPING[parameter_handlers[0]] = collection_plugin
+    # if len(parameter_handlers) != 1:
+    #     raise RuntimeError
+    
+    for parameter_handler in parameter_handlers:
+        if parameter_handler in load_handler_plugins():
+            _SUPPORTED_PARAMETER_HANDLERS.add(parameter_handler._TAGNAME)
+            _PLUGIN_CLASS_MAPPING[parameter_handler] = collection_plugin
 
 
 def _check_supported_handlers(force_field: ForceField):

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,10 +349,22 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-    # In case where multiple handlers co-exist in a collection (MPID)
+        # Perhaps need to exit if there is a handler that is not in the collection
+        # but I will leave this to developers.
+
+
+    # In case where multiple handlers co-exist in a collection
+    # Assuming only one collection gets to be loaded at a time
     handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
 
+    # Protect cases that are one handler per collection
+    # Probably would not be necessary if `Collection.create` always take in List
+    # see file _base.py#L219
+    if len(handlers) == 1:
+        handlers = handlers[0]
+
+    
     collection = collection_class.create(
         parameter_handler=handlers,
         topology=topology,
@@ -361,6 +373,6 @@ def _plugins(
     interchange.collections.update(
         {
             # handler_class._TAGNAME: collection,
-            collection.type: collection, # match collection instead of handler
+            collection.type: collection, # Since handlers have different tagnames, I would match collection type instead of handler
         },
     )

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -349,7 +349,7 @@ def _plugins(
         if handler_class._TAGNAME not in force_field.registered_parameter_handlers:
             continue
 
-    # In case where multiple handles co-exists in a collection (MPID)
+    # In case where multiple handlers co-exist in a collection (MPID)
     handlers = [force_field[handler_class._TAGNAME] for handler_class in _PLUGIN_CLASS_MAPPING.keys()] 
 
 


### PR DESCRIPTION
### Description

This is #648 moved onto a new branch.

### Checklist

- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
- [x] Update plugin guide
  - [ ] Document `ParameterHandler` vs. `List[ParameterHandler]`
  - [ ] List assumptions about handler-collection relationships
