### PR TITLE
Add methods for adding and removing GROMACS molecules

### DIFF
--- a/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
@@ -90,6 +90,7 @@ class TestAddRemoveMoleculeType(_BaseTest):
                 1,
             )
 
+    @needs_gmx
     def test_different_force_field_different_energies(
         self,
         combined_system,

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
@@ -1,0 +1,145 @@
+import numpy
+import pytest
+from openff.toolkit import Molecule, Topology
+from openff.units import unit
+
+from openff.interchange import Interchange
+from openff.interchange._tests import _BaseTest
+from openff.interchange.components.mdconfig import get_intermol_defaults
+from openff.interchange.drivers.gromacs import _process, _run_gmx_energy
+from openff.interchange.interop.gromacs.export._export import GROMACSWriter
+from openff.interchange.smirnoff._gromacs import _convert
+
+
+class TestAddRemoveMoleculeType(_BaseTest):
+    @pytest.fixture()
+    def molecule1(self):
+        molecule = Molecule.from_smiles(
+            "[H][O][c]1[c]([H])[c]([O][H])[c]([H])[c]([O][H])[c]1[H]",
+        )
+        molecule.generate_conformers(n_conformers=1)
+        molecule.name = "MOL1"
+
+        return molecule
+
+    @pytest.fixture()
+    def molecule2(self):
+        molecule = Molecule.from_smiles("C1=C(C=C(C=C1C(=O)O)C(=O)O)C(=O)O")
+        molecule.generate_conformers(n_conformers=1)
+        molecule.name = "MOL2"
+
+        molecule.conformers[0] += numpy.array([5, 0, 0]) * unit.angstrom
+
+        return molecule
+
+    @pytest.fixture()
+    def system1(self, molecule1, sage):
+        box = 5 * numpy.eye(3) * unit.nanometer
+
+        return _convert(Interchange.from_smirnoff(sage, [molecule1], box=box))
+
+    @pytest.fixture()
+    def system2(self, molecule2, sage):
+        box = 5 * numpy.eye(3) * unit.nanometer
+
+        return _convert(Interchange.from_smirnoff(sage, [molecule2], box=box))
+
+    @pytest.fixture()
+    def combined_system(self, sage, molecule1, molecule2):
+        box = 5 * numpy.eye(3) * unit.nanometer
+
+        return _convert(
+            Interchange.from_smirnoff(
+                sage,
+                Topology.from_molecules([molecule1, molecule2]),
+                box=box,
+            ),
+        )
+
+    @pytest.mark.parametrize("molecule_name", ["MOL1", "MOL2"])
+    def test_remove_basic(self, combined_system, molecule_name):
+        combined_system.remove_molecule_type(molecule_name)
+
+        # Just a sanity check
+        writer = GROMACSWriter(
+            system=combined_system,
+            top_file=f"{molecule_name}.top",
+            gro_file=f"{molecule_name}.gro",
+        )
+
+        writer.to_top()
+        writer.to_gro(decimal=8)
+
+        get_intermol_defaults(periodic=True).write_mdp_file("tmp.mdp")
+
+        _process(
+            _run_gmx_energy(f"{molecule_name}.top", f"{molecule_name}.gro", "tmp.mdp"),
+        )
+
+    @pytest.mark.parametrize("molecule_name", ["MOL1", "MOL2"])
+    def test_add_existing_molecule_type(self, combined_system, molecule_name):
+        with pytest.raises(
+            ValueError,
+            match=f"The molecule type {molecule_name} is already present in this system.",
+        ):
+            combined_system.add_molecule_type(
+                combined_system.molecule_types[molecule_name],
+                1,
+            )
+
+    def test_molecule_order_independent(self, system1, system2):
+        positions1 = numpy.vstack([system1.positions, system2.positions])
+        positions2 = numpy.vstack([system2.positions, system1.positions])
+
+        system1.add_molecule_type(system2.molecule_types["MOL2"], 1)
+        system1.positions = positions1
+
+        system2.add_molecule_type(system1.molecule_types["MOL1"], 1)
+        system2.positions = positions2
+
+        writer1 = GROMACSWriter(
+            system=system1,
+            top_file="order1.top",
+            gro_file="order1.gro",
+        )
+
+        writer2 = GROMACSWriter(
+            system=system2,
+            top_file="order2.top",
+            gro_file="order2.gro",
+        )
+
+        for writer in [writer1, writer2]:
+            writer.to_top()
+            writer.to_gro(decimal=8)
+
+        get_intermol_defaults(periodic=True).write_mdp_file("tmp.mdp")
+
+        _process(_run_gmx_energy("order1.top", "order1.gro", "tmp.mdp")).compare(
+            _process(_run_gmx_energy("order2.top", "order2.gro", "tmp.mdp")),
+        )
+
+    def test_clashing_atom_types(self, combined_system, system1, system2):
+        with pytest.raises(
+            ValueError,
+            match="The molecule type MOL1 is already present in this system.",
+        ):
+            combined_system.add_molecule_type(system1.molecule_types["MOL1"], 1)
+
+        with pytest.raises(
+            ValueError,
+            match="The molecule type MOL2 is already present in this system.",
+        ):
+            combined_system.add_molecule_type(system2.molecule_types["MOL2"], 1)
+
+        with pytest.raises(
+            ValueError,
+            match="The molecule type MOL1 is already present in this system.",
+        ):
+            system1.add_molecule_type(system1.molecule_types["MOL1"], 1)
+
+        with pytest.raises(
+            ValueError,
+            match="The molecule type MOL2 is already present in this system.",
+        ):
+            system2.add_molecule_type(system2.molecule_types["MOL2"], 1)

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/models/test_models.py
@@ -4,7 +4,7 @@ from openff.toolkit import Molecule, Topology
 from openff.units import unit
 
 from openff.interchange import Interchange
-from openff.interchange._tests import _BaseTest
+from openff.interchange._tests import _BaseTest, needs_gmx
 from openff.interchange.components.mdconfig import get_intermol_defaults
 from openff.interchange.drivers.gromacs import _process, _run_gmx_energy
 from openff.interchange.interop.gromacs.export._export import GROMACSWriter
@@ -56,6 +56,7 @@ class TestAddRemoveMoleculeType(_BaseTest):
             ),
         )
 
+    @needs_gmx
     @pytest.mark.parametrize("molecule_name", ["MOL1", "MOL2"])
     def test_remove_basic(self, combined_system, molecule_name):
         combined_system.remove_molecule_type(molecule_name)
@@ -87,6 +88,7 @@ class TestAddRemoveMoleculeType(_BaseTest):
                 1,
             )
 
+    @needs_gmx
     def test_molecule_order_independent(self, system1, system2):
         positions1 = numpy.vstack([system1.positions, system2.positions])
         positions2 = numpy.vstack([system2.positions, system1.positions])

--- a/openff/interchange/interop/gromacs/_import/_import.py
+++ b/openff/interchange/interop/gromacs/_import/_import.py
@@ -118,6 +118,16 @@ def from_files(top_file, gro_file, cls=GROMACSSystem):
             else:
                 raise ValueError(f"Invalid directive {current_directive}")
 
+    for molecule_type in system.molecule_types.values():
+        this_molecule_atom_type_names = tuple(
+            atom.atom_type for atom in molecule_type.atoms
+        )
+
+        molecule_type._contained_atom_types = {
+            atom_type_name: system.atom_types[atom_type_name]
+            for atom_type_name in this_molecule_atom_type_names
+        }
+
     system.positions = _read_coordinates(gro_file)
     system.box = _read_box(gro_file)
 

--- a/openff/interchange/interop/gromacs/export/_export.py
+++ b/openff/interchange/interop/gromacs/export/_export.py
@@ -282,7 +282,10 @@ class GROMACSWriter(DefaultModel):
             for molecule_name, molecule_type in self.system.molecule_types.items()
         )
 
-        assert n_particles == self.system.positions.shape[0]
+        assert n_particles == self.system.positions.shape[0], (
+            n_particles,
+            self.system.positions.shape[0],
+        )
 
         # Explicitly round here to avoid ambiguous things in string formatting
         positions = numpy.round(self.system.positions, decimal).m_as(unit.nanometer)
@@ -305,7 +308,7 @@ class GROMACSWriter(DefaultModel):
                             atom.residue_index,  # This needs to be looked up from a different data structure
                             atom.residue_name,
                             atom.name,
-                            count,
+                            count + 1,
                             positions[count, 0],
                             positions[count, 1],
                             positions[count, 2],

--- a/openff/interchange/interop/gromacs/models/models.py
+++ b/openff/interchange/interop/gromacs/models/models.py
@@ -276,18 +276,19 @@ class GROMACSSystem(DefaultModel):
             for name in molecules_before
         )
 
-        row_indices_to_delete = [
-            *range(
-                n_atoms_before,
-                n_atoms_before + len(self.molecule_types[molecule_name].atoms),
-            ),
-        ]
+        if self.positions is not None:
+            row_indices_to_delete = [
+                *range(
+                    n_atoms_before,
+                    n_atoms_before + len(self.molecule_types[molecule_name].atoms),
+                ),
+            ]
 
-        # Pint lacks __array_function__ needed here, so strip and then tag units
-        self.positions = unit.Quantity(
-            numpy.delete(self.positions.m, row_indices_to_delete, axis=0),
-            self.positions.units,
-        )
+            # Pint lacks __array_function__ needed here, so strip and then tag units
+            self.positions = unit.Quantity(
+                numpy.delete(self.positions.m, row_indices_to_delete, axis=0),
+                self.positions.units,
+            )
 
         self.molecule_types.pop(molecule_name)
         self.molecules[molecule_name] -= n_copies

--- a/openff/interchange/interop/gromacs/models/models.py
+++ b/openff/interchange/interop/gromacs/models/models.py
@@ -272,8 +272,8 @@ class GROMACSSystem(DefaultModel):
         molecule_names = [*self.molecules.keys()]
         molecules_before = molecule_names[: molecule_names.index(molecule_name)]
         n_atoms_before = sum(
-            self.molecule_types[molecule_name].n_atoms * self.molecules[molecule_name]
-            for molecule_name in molecules_before
+            len(self.molecule_types[name].atoms) * self.molecules[name]
+            for name in molecules_before
         )
 
         row_indices_to_delete = [

--- a/openff/interchange/interop/gromacs/models/models.py
+++ b/openff/interchange/interop/gromacs/models/models.py
@@ -11,7 +11,7 @@ class GROMACSAtomType(DefaultModel):
     """Base class for GROMACS atom types."""
 
     name: str
-    bonding_type: str
+    bonding_type: Optional[str] = None
     atomic_number: Optional[PositiveInt]
     mass: unit.Quantity
     charge: unit.Quantity

--- a/openff/interchange/interop/gromacs/models/models.py
+++ b/openff/interchange/interop/gromacs/models/models.py
@@ -4,7 +4,7 @@ from typing import Optional
 from openff.models.models import DefaultModel
 from openff.models.types import ArrayQuantity, FloatQuantity
 from openff.units import unit
-from pydantic import Field, PositiveInt
+from pydantic import Field, PositiveInt, PrivateAttr
 
 
 class GROMACSAtomType(DefaultModel):
@@ -191,6 +191,11 @@ class GROMACSMolecule(DefaultModel):
         description="The exclusions in this molecule.",
     )
 
+    # TODO: This can desync between system- and molecule-level data, it might be better
+    #       to not store atom types at the system level, instead storing them at the
+    #       molecule and grouping up to system level at write time
+    _contained_atom_types: dict[str, GROMACSAtomType] = PrivateAttr()
+
 
 class GROMACSSystem(DefaultModel):
     """A GROMACS system. Adapted from Intermol."""
@@ -245,3 +250,45 @@ class GROMACSSystem(DefaultModel):
         from openff.interchange.interop.gromacs.export._export import to_top
 
         return to_top(self, file)
+
+    def remove_molecule_type(self, molecule_name: str, n_copies: int):
+        """Remove a molecule type from the system."""
+        if molecule_name not in self.molecule_types:
+            raise ValueError(
+                f"The molecule type {molecule_name} is not present in this system.",
+            )
+
+        if n_copies > self.molecules[molecule_name]:
+            raise ValueError(
+                f"Cannot remove {n_copies} copies of {molecule_name} from this system "
+                f"because only {self.molecules[molecule_name]} are present.",
+            )
+
+        self.molecule_types.pop(molecule_name)
+        self.molecules[molecule_name] -= n_copies
+
+        if self.molecules[molecule_name] == 0:
+            self.molecules.pop(molecule_name)
+
+    def add_molecule_type(self, molecule: GROMACSMolecule, n_copies: int):
+        """Add a molecule type to the system."""
+        if molecule.name in self.molecule_types:
+            raise ValueError(
+                f"The molecule type {molecule.name} is already present in this system.",
+            )
+
+        if len(molecule._contained_atom_types) == 0:
+            raise ValueError(
+                f"The molecule type {molecule.name} does not contain any atom types.",
+            )
+
+        for atom_type_name, atom_type in molecule._contained_atom_types.items():
+            if atom_type_name in self.atom_types:
+                raise ValueError(
+                    f"An atom type {atom_type_name} is already present in this system.",
+                )
+
+            self.atom_types[atom_type_name] = atom_type
+
+        self.molecule_types[molecule.name] = molecule
+        self.molecules[molecule.name] = n_copies

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -87,7 +87,9 @@ def _convert(interchange: Interchange) -> GROMACSSystem:
             unique_molecule.name = "MOL" + str(unique_molecule_index)
 
         for atom in unique_molecule.atoms:
-            atom_type_name = f"{unique_molecule.name}{unique_molecule.atom_index(atom)}"
+            atom_type_name = (
+                f"{unique_molecule.name}_{unique_molecule.atom_index(atom)}"
+            )
             _atom_atom_type_map[atom] = atom_type_name
 
             topology_index = interchange.topology.atom_index(atom)

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -157,6 +157,15 @@ def _convert(interchange: Interchange) -> GROMACSSystem:
                 ),
             )
 
+            this_molecule_atom_type_names = tuple(
+                atom.atom_type for atom in molecule.atoms
+            )
+
+            molecule._contained_atom_types = {
+                atom_type_name: system.atom_types[atom_type_name]
+                for atom_type_name in this_molecule_atom_type_names
+            }
+
         # Use a set to de-duplicate
         pairs: set[tuple] = {*_get_14_pairs(unique_molecule)}
 

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -131,8 +131,9 @@ def _convert(interchange: Interchange) -> GROMACSSystem:
                         "If some atoms have residue names, all atoms must have residue names.",
                     )
                 else:
-                    for atom in unique_molecule.atoms:
-                        atom.metadata["residue_name"] = unique_molecule.name
+                    # Use dummy since we're already iterating over this molecule's atoms
+                    for _atom in unique_molecule.atoms:
+                        _atom.metadata["residue_name"] = unique_molecule.name
 
             name = SYMBOLS[atom.atomic_number] if atom.name == "" else atom.name
             charge = (


### PR DESCRIPTION
### Description

This PR introduces two methods for adding and removing molecules from `GROMACSSystem`s. This can be useful for a handful of operations, a flashy one being re-parametrizing a ligand in a protein-ligand (+ water and ions) complex with a different force field without needing to re-parametrize or do anything in particular to the protein.

### Checklist

- [ ] ~~Store atomic coordinates on each `GROMACSAtom`~~ This can't be done in a straightforward way in the general case because of how GROMACS de-duplicates atoms, each `GROMACSAtom` would need to contain a list of coordinates for each duplicate of it and there'd be a lot of bookkeeping associated with system-level atom indexing on the fly.
- [x] Add `GROMACSSystem.add_molecule_type`
- [x] Add `GROMACSSystem.remove_molecule_type`
- [x] Allow each `GROMACSMolecule` to track which atom types it contains
- [ ] Trim un-used atom types after removing a molecule
- [x] Fix double-iteration bug that produced bogus atom indices in some cases
- [ ] Add tests
  - [x] Remove a molecule from a system without adverse effects
  - [x] Add a molecule from a system without adverse effects
  - [x] Swap in the same (defined as the same molecule + force field) and reproduce energies
  - [x] Swap the same molecule with a different force field and ensure energies differ
  - [ ] Swap in a chemically different molecule and ensure coordinates are not botched
  - [x] Error out when atom type collisions are detected
- [x] Lint
- [ ] Update docstrings
