### PR TITLE
Fix docs environment and tidy up pack_box docstring

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -7,14 +7,30 @@ dependencies:
   # Base depends
   - python
   - pip
-  - pydantic
-  - pint
-  - openff-toolkit-base >=0.11.3
-  - openff-models >=0.0.4
+  - numpy >=1.21
+  - pydantic <2.0.0a0
   - openmm >=7.6
+  - openff-toolkit >=0.11.3
+  - openff-models >=0.0.4
+  - openff-nagl
+  - unyt
+  - mbuild
+  - foyer >=0.11.3
   - mdtraj
   - intermol
   - jax
+  - nbval
+  - nglview
+  - ipywidgets >7,<8  # https://github.com/nglviewer/nglview/issues/1032
+  - mdanalysis
+  - gromacs >=2021=nompi*
+  - lammps
+  # https://github.com/conda-forge/quippy-feedstock/issues/15
+  - panedr
+  - mypy =1.2
+  - typing-extensions
+  - types-setuptools
+  - pandas-stubs >=1.2.0.56
   # readthedocs dependencies
   - myst-parser
   - numpydoc
@@ -23,4 +39,5 @@ dependencies:
   - sphinxcontrib-mermaid
   - sphinx-notfound-page
   - pip:
+    - git+https://github.com/jthorton/de-forcefields
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -10,9 +10,8 @@ dependencies:
   - numpy >=1.21
   - pydantic <2.0.0a0
   - openmm >=7.6
-  - openff-toolkit >=0.11.3
+  - openff-toolkit >=0.13
   - openff-models >=0.0.4
-  - openff-nagl
   - unyt
   - mbuild
   - foyer >=0.11.3

--- a/docs/using/plugins.md
+++ b/docs/using/plugins.md
@@ -45,7 +45,7 @@ The high-level objectives of a parameter handler are to:
   * define its own properties, class methods, etc. as needed
   * define optional attributes such as `id`
 
-[`ParameterType`]: openff.toolkit.typing.engines.smirnoff.ParameterType
+[`ParameterType`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterType
 [entry point group]: setuptools:userguide/entry_point
 [`check_handler_compatibility`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.check_handler_compatibility
 

--- a/openff/interchange/components/packmol.py
+++ b/openff/interchange/components/packmol.py
@@ -629,34 +629,34 @@ def pack_box(
         The molecules in the system.
     number_of_copies : list of int
         A list of the number of copies of each molecule type, of length
-        equal to the length of `molecules`.
+        equal to the length of ``molecules``.
     structure_to_solvate: str, optional
         A file path to the PDB coordinates of the structure to be solvated.
     center_solute: bool
-        If `True`, the structure to solvate will be centered in the
-        simulation box. This option is only applied when `structure_to_solvate`
-        is set.
+        If ``True``, the structure to solvate will be placed in the center of
+        thesimulation box. This option is only applied when
+        ``structure_to_solvate`` is set.
     tolerance : openff.units.Quantity
-        The minimum spacing between molecules during packing in units
-         compatible with angstroms.
+        The minimum spacing between molecules during packing in units of
+        distance.
     box_size : openff.units.Quantity, optional
         The size of the box to generate in units compatible with angstroms.
-        If `None`, `mass_density` must be provided.
+        If ``None``, ``mass_density`` must be provided.
     mass_density : openff.units.Quantity, optional
         Target mass density for final system with units compatible with g / mL.
-         If `None`, `box_size` must be provided.
+        If ``None``, ``box_size`` must be provided.
     box_aspect_ratio: list of float, optional
         The aspect ratio of the simulation box, used in conjunction with
-        the `mass_density` parameter. If none, an isotropic ratio (i.e.
-        [1.0, 1.0, 1.0]) is used.
+        the ``mass_density`` parameter. If none, an isotropic ratio (i.e.
+        ``[1.0, 1.0, 1.0]``) is used.
     verbose : bool
-        If True, verbose output is written.
+        If ``True``, verbose output is written.
     working_directory: str, optional
-        The directory in which to generate the temporary working files. If `None`,
-        a temporary one will be created.
+        The directory in which to generate the temporary working files. If
+        ``None``, a temporary one will be created.
     retain_working_files: bool
-        If True all of the working files, such as individual molecule coordinate
-        files, will be retained.
+        If ``True`` all of the working files, such as individual molecule
+        coordinate files, will be retained.
 
     Returns
     -------

--- a/openff/interchange/components/packmol.py
+++ b/openff/interchange/components/packmol.py
@@ -612,6 +612,7 @@ def pack_box(
     box_aspect_ratio: Optional[list[float]] = None,
     working_directory: Optional[str] = None,
     retain_working_files: bool = False,
+    add_box_buffers: bool = True,
 ) -> tuple[mdtraj.Trajectory, list[str]]:
     """
     Run packmol to generate a box containing a mixture of molecules.
@@ -650,6 +651,9 @@ def pack_box(
     retain_working_files: bool
         If ``True`` all of the working files, such as individual molecule
         coordinate files, will be retained.
+    add_box_buffers: bool
+        If ``True`` (the default), buffers will be added to the box size to
+        help reduce clashes.
 
     Returns
     -------
@@ -691,6 +695,7 @@ def pack_box(
             number_of_copies,
             mass_density,
             box_aspect_ratio,  # type: ignore[arg-type]
+            box_scaleup_factor=1.1 if add_box_buffers else 1.0,
         )
 
     # Set up the directory to create the working files in.
@@ -773,9 +778,10 @@ def pack_box(
             raise PACKMOLRuntimeError(result)
 
         # Add a 2 angstrom buffer to help alleviate PBC issues.
-        box_size = [
-            (x + 2.0 * unit.angstrom).to(unit.nanometer).magnitude for x in box_size
-        ]
+        if add_box_buffers:
+            box_size = [
+                (x + 2.0 * unit.angstrom).to(unit.nanometer).magnitude for x in box_size
+            ]
 
         # Append missing connect statements to the end of the
         # output file.

--- a/openff/interchange/components/packmol.py
+++ b/openff/interchange/components/packmol.py
@@ -10,7 +10,6 @@ import tempfile
 import warnings
 from collections import defaultdict
 from distutils.spawn import find_executable
-from functools import reduce
 from typing import Optional
 
 import mdtraj
@@ -131,17 +130,11 @@ def _approximate_box_size_by_density(
         A list of the three box lengths in units compatible with angstroms.
 
     """
-    volume = 0.0 * unit.angstrom**3
-
+    total_mass = 0.0 * unit.dalton
     for molecule, number in zip(molecules, n_copies):
-        # The toolkit reports masses as daltons
-        molecule_mass = reduce(
-            (lambda x, y: x + y),
-            [atom.mass for atom in molecule.atoms],
-        )
-
-        molecule_volume = molecule_mass / mass_density
-        volume += molecule_volume * number
+        for atom in molecule.atoms:
+            total_mass += number * atom.mass
+    volume = total_mass / mass_density
 
     box_length = volume ** (1.0 / 3.0) * box_scaleup_factor
     box_length_angstrom = box_length.to(unit.angstrom).magnitude

--- a/openff/interchange/components/packmol.py
+++ b/openff/interchange/components/packmol.py
@@ -628,7 +628,7 @@ def pack_box(
         A file path to the PDB coordinates of the structure to be solvated.
     center_solute: bool
         If ``True``, the structure to solvate will be placed in the center of
-        thesimulation box. This option is only applied when
+        the simulation box. This option is only applied when
         ``structure_to_solvate`` is set.
     tolerance : openff.units.Quantity
         The minimum spacing between molecules during packing in units of


### PR DESCRIPTION
### Description

Toolkit 0.13.0 broke the docs environment - it would solve but then `from openff.toolkit import Molecule, ForceField, Topology` would raise an ImportError. I just copied over the deps from the test environment and it seems to work, so hopefully this is some change in a dependency that is already reflected in the forge recipe. Also tidied up the pack_box docstring.

### Checklist

- [x] Lint
- [x] Update docstrings
