### PR TITLE
Tag some features as opt-in experimental

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -31,6 +31,7 @@ jobs:
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+      INTERCHANGE_EXPERIMENTAL: "1"
 
     steps:
     - uses: actions/checkout@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
+    # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
     python: "mambaforge-4.10"
 
 sphinx:

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -5,7 +5,8 @@ channels:
   - conda-forge
 dependencies:
   # Base depends
-  - python
+  # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
+  - python =3.10
   - pip
   - numpy >=1.21
   - pydantic <2.0.0a0

--- a/openff/interchange/_experimental.py
+++ b/openff/interchange/_experimental.py
@@ -1,6 +1,6 @@
+import os
 from functools import wraps
 from inspect import cleandoc
-import os
 
 from openff.interchange.exceptions import ExperimentalFeatureException
 

--- a/openff/interchange/_experimental.py
+++ b/openff/interchange/_experimental.py
@@ -10,15 +10,15 @@ def experimental(func):
     Decorate a function as experimental, requiring environment variable opt-in.
 
     To use the wrapped function, set the environment variable INTERCHANGE_EXPERIMENTAL=1.
-    """
 
+    """
     firstline, _, remainder = cleandoc(func.__doc__).partition("\n")
 
     func.__doc__ = (
         "🧪 "
-        + firstline
-        + "\n\n.. admonition:: Experimental\n\n    This object is experimental and should not be used in production.\n"
-        + remainder
+        f"{firstline}"
+        "\n\n.. admonition:: Experimental\n\n    This object is experimental and should not be used in production.\n"
+        f"{remainder}"
     )
 
     @wraps(func)

--- a/openff/interchange/_experimental.py
+++ b/openff/interchange/_experimental.py
@@ -1,3 +1,5 @@
+from functools import wraps
+from inspect import cleandoc
 import os
 
 from openff.interchange.exceptions import ExperimentalFeatureException
@@ -10,6 +12,16 @@ def experimental(func):
     To use the wrapped function, set the environment variable INTERCHANGE_EXPERIMENTAL=1.
     """
 
+    firstline, _, remainder = cleandoc(func.__doc__).partition("\n")
+
+    func.__doc__ = (
+        "🧪 "
+        + firstline
+        + "\n\n.. admonition:: Experimental\n\n    This object is experimental and should not be used in production.\n"
+        + remainder
+    )
+
+    @wraps(func)
     def wrapper(*args, **kwargs):
         if os.environ.get("INTERCHANGE_EXPERIMENTAL", "0") != "1":
             raise ExperimentalFeatureException(

--- a/openff/interchange/_experimental.py
+++ b/openff/interchange/_experimental.py
@@ -1,0 +1,25 @@
+import os
+
+from openff.interchange.exceptions import ExperimentalFeatureException
+
+
+def experimental(func):
+    """
+    Decorate a function as experimental, requiring environment variable opt-in.
+
+    To use the wrapped function, set the environment variable INTERCHANGE_EXPERIMENTAL=1.
+    """
+
+    def wrapper(*args, **kwargs):
+        if os.environ.get("INTERCHANGE_EXPERIMENTAL", "0") != "1":
+            raise ExperimentalFeatureException(
+                f"\n\tFunction or method {func.__name__} is experimental. This feature is not "
+                "complete, not yet reliable, and/or needs more testing to be considered suitable "
+                "for production.\n"
+                "\tTo use this feature on a provisional basis, set the environment variable "
+                "INTERCHANGE_EXPERIMENTAL=1.",
+            )
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/_import/test_from_files.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/_import/test_from_files.py
@@ -3,7 +3,9 @@ from openff.interchange.interop.gromacs._import._import import from_files
 from openff.interchange.interop.gromacs.models.models import RyckaertBellemansDihedral
 
 
-def test_load_rb_torsions():
+def test_load_rb_torsions(monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
     system = from_files(
         get_test_file_path("ethanol_rb_torsions.top"),
         get_test_file_path("ethanol_rb_torsions.gro"),

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/_import/test_topology.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/_import/test_topology.py
@@ -5,7 +5,9 @@ from openff.interchange.interop.gromacs._import._topology import (
 )
 
 
-def test_complex():
+def test_complex(monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
     topology = _create_topology_from_system(
         GROMACSSystem.from_files(
             get_test_file_path("complex.top"),

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/test_interchange.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/test_interchange.py
@@ -38,7 +38,9 @@ class TestToInterchange(_BaseTest):
 
         return sage_unconstrained.create_interchange(topology)
 
-    def test_convert_basic_system(self, simple_interchange):
+    def test_convert_basic_system(self, monkeypatch, simple_interchange):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
         converted = to_interchange(_convert(simple_interchange))
 
         assert numpy.allclose(converted.positions, simple_interchange.positions)
@@ -76,7 +78,8 @@ class TestConvertTopology(_BaseTest):
 
         return _convert(sage_unconstrained.create_interchange(topology))
 
-    def test_convert_basic_system(self, simple_system):
+    def test_convert_basic_system(self, monkeypatch, simple_system):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
         converted = _convert_topology(simple_system)
 
         assert converted.n_molecules == 1

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
@@ -15,7 +15,9 @@ from openff.interchange.interop.openmm._import._import import _convert_nonbonded
 
 
 class TestFromOpenMM(_BaseTest):
-    def test_simple_roundtrip(self, sage_unconstrained):
+    def test_simple_roundtrip(self, monkeypatch, sage_unconstrained):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
         molecule = create_ethanol()
         molecule.generate_conformers(n_conformers=1)
 

--- a/openff/interchange/_tests/unit_tests/test_experimental.py
+++ b/openff/interchange/_tests/unit_tests/test_experimental.py
@@ -7,6 +7,7 @@ from openff.interchange.exceptions import ExperimentalFeatureException
 def test_default():
     @experimental
     def f():
+        """Docstring of f."""
         pass
 
     with pytest.raises(ExperimentalFeatureException):
@@ -18,6 +19,7 @@ def test_experimental_opted_in(monkeypatch):
 
     @experimental
     def g():
+        """Docstring of g."""
         pass
 
     g()
@@ -28,6 +30,7 @@ def test_experimental_opted_in_bad_value(monkeypatch):
 
     @experimental
     def h():
+        """Docstring of h."""
         pass
 
     with pytest.raises(ExperimentalFeatureException):

--- a/openff/interchange/_tests/unit_tests/test_experimental.py
+++ b/openff/interchange/_tests/unit_tests/test_experimental.py
@@ -1,0 +1,34 @@
+import pytest
+
+from openff.interchange._experimental import experimental
+from openff.interchange.exceptions import ExperimentalFeatureException
+
+
+def test_default():
+    @experimental
+    def f():
+        pass
+
+    with pytest.raises(ExperimentalFeatureException):
+        f()
+
+
+def test_experimental_opted_in(monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+    @experimental
+    def g():
+        pass
+
+    g()
+
+
+def test_experimental_opted_in_bad_value(monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "True")
+
+    @experimental
+    def h():
+        pass
+
+    with pytest.raises(ExperimentalFeatureException):
+        h()

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -334,3 +334,7 @@ class PACKMOLRuntimeError(Exception):
 
 class PACKMOLValueError(Exception):
     """Exception raised when a bad input is passed to a PACKMOL wrapper."""
+
+
+class ExperimentalFeatureException(Exception):
+    """Exception raised when an experimental feature is used without opt-in."""

--- a/openff/interchange/interop/gromacs/_import/_import.py
+++ b/openff/interchange/interop/gromacs/_import/_import.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy
 from openff.units import unit
 
+from openff.interchange._experimental import experimental
 from openff.interchange.interop.gromacs.models.models import (
     GROMACSAngle,
     GROMACSAtom,
@@ -21,6 +22,7 @@ from openff.interchange.interop.gromacs.models.models import (
 )
 
 
+@experimental
 def from_files(top_file, gro_file, cls=GROMACSSystem):
     """
     Parse a GROMACS topology file. Adapted from Intermol.

--- a/openff/interchange/interop/gromacs/_interchange.py
+++ b/openff/interchange/interop/gromacs/_interchange.py
@@ -3,6 +3,7 @@ from openff.toolkit import Topology
 from openff.units import unit
 
 from openff.interchange import Interchange
+from openff.interchange._experimental import experimental
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
 from openff.interchange.common._valence import (
     AngleCollection,
@@ -29,6 +30,7 @@ from openff.interchange.models import (
 )
 
 
+@experimental
 def to_interchange(
     system: GROMACSSystem,
 ) -> Interchange:

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 import openmm
 import openmm.app
 
+from openff.interchange._experimental import experimental
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
 from openff.interchange.common._valence import (
     AngleCollection,
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     from openff.interchange import Interchange
 
 
+@experimental
 def from_openmm(
     topology: Optional["openmm.app.Topology"] = None,
     system: Optional[openmm.System] = None,


### PR DESCRIPTION
### Description

This is an idea I've considered for a while but never tried. The problem is that many features need extensive testing to be considered complete yet need to exist in the package for a long time in order for that testing to be feasible. Throwing warnings around is not ideal as they can easily be ignored by users. Me personally and repeatedly communicating the nature of these features scales poorly and guarantees that some people aren't informed what is and is not currently trustworthy. Hiding things behind "private" import paths implies a lack of API stability but does not communicate whether or not something is trustworthy and leaves us more or less in the same position as before.

With this changeset, features tagged with an `@experimental` decorator require an environment variable `INTERCHANGE_EXPERIMENTAL=1` to be set. This requires users to explicitly opt-in with a non-negligible hurdle if using one of these features. Power users and heavy testers can set this in their shell profile without their work being interrupted.

Here's what it looks like to use:

```python3
In [1]: from openff.interchange._experimental import experimental
   ...:
   ...:
   ...: @experimental
   ...: def f():
   ...:     pass
   ...:
   ...:
   ...: f()

---------------------------------------------------------------------------
ExperimentalFeatureException              Traceback (most recent call last)
Cell In[1], line 9
      4 @experimental
      5 def f():
      6     pass
----> 9 f()

File ~/software/openff-interchange/openff/interchange/_experimental.py:15, in experimental.<locals>.wrapper(*args, **kwargs)
     13 def wrapper(*args, **kwargs):
     14     if os.environ.get("INTERCHANGE_EXPERIMENTAL", "0") != "1":
---> 15         raise ExperimentalFeatureException(
     16             f"\n\tFunction or method {func.__name__} is experimental. This feature is not "
     17             "complete, not yet reliable, and/or needs more testing to be considered suitable "
     18             "for production.\n"
     19             "\tTo use this feature on a provisional basis, set the environment variable "
     20             "INTERCHANGE_EXPERIMENTAL=1.",
     21         )
     23     return func(*args, **kwargs)

ExperimentalFeatureException:
	Function or method f is experimental. This feature is not complete, not yet reliable, and/or needs more testing to be considered suitable for production.
	To use this feature on a provisional basis, set the environment variable INTERCHANGE_EXPERIMENTAL=1.
```
Thoughts @j-wags @Yoshanuikabundi?

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
