### PR TITLE
FIX: Do not assume vdW handler exists

### DIFF
--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -55,3 +55,5 @@ dependencies:
   - flake8
   - snakeviz
   - tuna
+  - pip:
+    - git+https://github.com/jthorton/de-forcefields


### PR DESCRIPTION
### Description

This PR fixes an assumption in the OpenMM export logic that a vdW collection exists with that name as a non-plugin.

### Checklist

- [ ] Test in Evaluator test environment
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
