### PR TITLE
Packmol improvements

### DIFF
--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -615,11 +615,13 @@ def pack_box(
     # Set the positions, skipping the positions from topology_to_solvate
     n_solute_atoms = len(positions) - topology.n_atoms
     topology.set_positions(positions[n_solute_atoms:] * unit.angstrom)
-    topology.box_vectors = box_vectors
 
     # Add topology_to_solvate back in with the original, unwrapped positions
     if topology_to_solvate is not None:
         topology = topology_to_solvate + topology
+
+    # Set the box vectors
+    topology.box_vectors = box_vectors
 
     return topology
 

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -187,6 +187,7 @@ def _compute_brick_from_box_vectors(box_vectors: Quantity) -> Quantity:
 
 
 def _range_neg_pos(stop):
+    """Yield 0, 1, -1, 2, -2... ``stop - 1``, ``-(stop - 1)``."""
     yield 0
     for i in range(1, stop):
         yield i
@@ -194,6 +195,7 @@ def _range_neg_pos(stop):
 
 
 def _iter_lattice_vecs(box, max_order):
+    """Yield linear combinations of box vectors until max_order is reached."""
     a, b, c = box
     for i in _range_neg_pos(max_order + 1):
         for j in _range_neg_pos(max_order + 1):

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -316,7 +316,7 @@ def _box_from_density(
     volume = total_mass / mass_density
 
     # Scale the box shape so that it has unit volume
-    box_shape_volume = box_shape[0].dot(box_shape[1].cross(box_shape[2]))
+    box_shape_volume = np.linalg.det(box_shape)
     box_vectors = volume * box_shape / box_shape_volume
 
     return box_vectors
@@ -589,8 +589,6 @@ def pack_box(
             packmol_succeeded = result.find("Success!") > 0
 
         if not packmol_succeeded:
-            if temporary_directory and not retain_working_files:
-                shutil.rmtree(".")
             raise PACKMOLRuntimeError(result)
 
         # Load the coordinates from the PDB file with RDKit (because its already
@@ -604,7 +602,7 @@ def pack_box(
         positions = rdmol.GetConformers()[0].GetPositions()
 
     # TODO: This currently does not run if we encountered an error in the
-    # context manager (except the one we raise if packmol failed)
+    # context manager
     if temporary_directory and not retain_working_files:
         shutil.rmtree(working_directory)
 


### PR DESCRIPTION
### Description

This PR adds a bunch of features to the packmol wrapper. I probably shouldn't have spent time on it at this stage but it seems to work and it's much easier to use than the old wrapper. Up to you @mattwthompson if you want to merge this now, or after the meeting, or put it in the vignettes repo, or throw it away or whatever - just putting it here so you have the option!

I may have gone a bit overboard but I've tried to stage commits so you can just take the ones you like and leave the later ones off. I've tested manually on a lipid-water system and solvating a protein, but haven't written or changed any unit tests - I can if you decide you want to merge this. Here's what the PR does:

- pack_box now returns an OpenFF Topology instead of an MDTraj Trajectory
- The box size buffers to support PBCs have been overhauled; they're now tied to tolerance and the volume is not scaled automatically by the 1.1 fudge factor. This is a bit more principled and less surprising (to me). It also means that the generated simulation box actually has the requested density/size, but packing still converges and it still energy minimizes and simulates.
- the `structure_to_solvate` argument is now `topology_to_solvate` and takes a topology instead of a PDB file. I've removed a lot of now-unnecessary code that handles residue names and the like; there was no obvious, principled way to port them and I figure we should dogfood the Toolkit's handling of this
- MDTraj is no longer a dependency
- We can now pack triclinic boxes (like rhombic dodecahedra) - packmol only supports rectangular prisms so this works by computing the rectangular brick representation of the box and packing that. The `topology_to_solvate` is wrapped into the brick for packing so that packmol sees all of it, but the original coordinates are later restored so that all molecules are whole in the output. 
- The arguments to specify box vectors have been overhauled. It now takes a `box_shape` argument instead of `box_aspect_ratio`, and a `box_vectors` argument instead of `box_size`. They do what you expect.
- If `box_vectors` and `mass_density` are not specified, box vectors are now taken from `topology_to_solvate`
- The code has been generally streamlined and simplified
- a `solvate_topology` method has been added that takes a topology and adds saline and a box with customizable salt concentration, buffer distance, and shape. You can just call this on a protein topology and get solvated, salted, neutralised starting coordinates that actually work with reasonable defaults in a rhombic dodecahedron. This could be extended to support other solvent mixtures or ions if desired.
- unit image distance arrays specifying the shape of the major box types (cube, rhombic dodecahedron with a square in the XY plane, rhombic dodecahedron with a hexagon in the XY plane) have been added to make it easy to generate box vectors (just multiply by the desired image distance)

Headlines:
- Inputs and outputs `openff.toolkit.Topology` instead of `mdtraj.Trajectory` and PDB files
- Less surprising box sizes
- No more MDTraj
- Triclinic boxes that just work
- `solvate_topology` with reasonable defaults
- Net reduction in LoC

Demo notebook (I can put this in examples if desired): [pack_mol_demo.zip](https://github.com/openforcefield/openff-interchange/files/11392068/pack_mol_demo.zip)

![solvate_topology](https://user-images.githubusercontent.com/28590748/236078271-fbb5f9fa-f16b-40df-b4e9-73cad8972530.png)

### Checklist

- [ ] Add tests
- [x] Lint
- [x] Update docstrings
