### PR TITLE
Fix a strange bug with Python 3.9

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -40,6 +40,6 @@ dependencies:
   - nbval
   # Typing
   - mypy =1.2
-  - typing-extensions
+  - typing-extensions !=4.6.0
   - types-setuptools
   - pandas-stubs >=1.2.0.56

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -38,7 +38,7 @@ dependencies:
   - panedr
   # Typing
   - mypy =1.2
-  - typing-extensions
+  - typing-extensions !=4.6.0
   - types-setuptools
   - pandas-stubs >=1.2.0.56
   # Development tools

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - foyer >=0.11.3
   - nglview
   - panedr
-  - typing-extensions
+  - typing-extensions !=4.6.0
   - pandas-stubs >=1.2.0.56
   # readthedocs dependencies
   - myst-parser

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -35,7 +35,7 @@ dependencies:
   - panedr
   # Typing
   - mypy =1.2
-  - typing-extensions
+  - typing-extensions !=4.6.0
   - types-setuptools
   - pandas-stubs >=1.2.0.56
   - pip:


### PR DESCRIPTION
### Description

I have no idea why this is happening
```python
(openff-interchange-env) [openff-interchange] python                                                 13:27:24  ☁  5d6f4aec ☂
Python 3.9.16 | packaged by conda-forge | (main, Feb  1 2023, 21:42:20)
[Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openff.interchange.models import PotentialKey, TopologyKey
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/software/openff-interchange/openff/interchange/models.py", line 200, in <module>
    class VirtualSiteKey(TopologyKey):
  File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 552, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 668, in pydantic.fields.ModelField._type_analysis
  File "/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/typing.py", line 852, in __subclasscheck__
    return issubclass(cls, self.__origin__)
TypeError: issubclass() arg 1 must be a class
```

This bubbles up from this check
```python
In [2]: from typing import Literal

In [3]: issubclass(Literal, object)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 issubclass(Literal, object)

TypeError: issubclass() arg 1 must be a class
```
which didn't happen a couple of weeks ago. There doesn't seem to be a new release of Python or Pydantic, which are the only things that should be interacting here.