### PR TITLE
Wrap GROMACS atom indices at 100,000

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -14,6 +14,8 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 ### Bugfixes
 
 * #724 Fixes #723 in which some parameters in GROMACS files were incorrectly written.
+* #728 Fixes #719 in which GROMACS coordinate files were written incorrectly when containing more
+  than 100,000 atoms.
 
 ## 0.3.4 - 2023-05-14
 

--- a/openff/interchange/interop/gromacs/export/_export.py
+++ b/openff/interchange/interop/gromacs/export/_export.py
@@ -308,7 +308,7 @@ class GROMACSWriter(DefaultModel):
                             atom.residue_index,  # This needs to be looked up from a different data structure
                             atom.residue_name,
                             atom.name,
-                            count + 1,
+                            (count + 1) % 100000,
                             positions[count, 0],
                             positions[count, 1],
                             positions[count, 2],


### PR DESCRIPTION
### Description

#719 

I used this code to reproduce the issue and verify the fix, but it takes about 4 minutes to run so I can't include it in the test suite.

```python
#### import time
from rdkit import Chem
from openmm.app import PDBFile
from openff.toolkit.topology import Molecule, Topology
from openff.toolkit.typing.engines.smirnoff import ForceField
from openff.interchange.components._packmol import pack_box
from openff.units import unit
from openff.interchange.components.mdconfig import MDConfig
from openff.interchange.drivers import get_gromacs_energies, get_openmm_energies

t0 = time.time()

molecules = [Molecule.from_smiles(smiles) for smiles in ['CCO', 'CCCO']]
n_molecules = [3030, 6600]
system_name = f'ethanol_propanol_{n_molecules[0]}_{n_molecules[1]}'

topology = pack_box(
    molecules = molecules,
    number_of_copies=n_molecules,
    structure_to_solvate=None,
    mass_density=0.8 * unit.grams / unit.milliliters,
)
print(f"Packing took {time.time() - t0}")

t0 = time.time()

forcefield = ForceField("openff-2.0.0.offxml")

interchange = forcefield.create_interchange(topology)

print(f"Creating took {time.time() - t0}")

t0 = time.time()

get_gromacs_energies(interchange)

print(f"GROMACS took {time.time() - t0}")

t0 = time.time()

get_openmm_energies(interchange)

print(f"OpenMM took {time.time() - t0}")

t0 = time.time()
```
```
Packing took 66.13208389282227
Creating took 95.53923773765564
GROMACS took 9.437824964523315
OpenMM took 67.45472693443298
```
### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
