### PR TITLE
Do not perform SHAKE in Amber driver

### DIFF
--- a/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
+++ b/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
@@ -195,7 +195,7 @@ class TestWriteSanderInput(_BaseTest):
 
         # Unclear what's "supposed" to be the value here
         assert options["cntrl"]["ntf"] in ("2", "4")
-        assert options["cntrl"]["ntc"] == "2"
+        assert options["cntrl"]["ntc"] == "1"
 
     def test_constrained_ligand_rigid_water_box(
         self,
@@ -210,7 +210,7 @@ class TestWriteSanderInput(_BaseTest):
         # Amber does not support this case (constrain all h-bonds and water angles, but no other angles),
         # this option seems to be the best one
         assert options["cntrl"]["ntf"] == "2"
-        assert options["cntrl"]["ntc"] == "2"
+        assert options["cntrl"]["ntc"] == "1"
 
     def test_unconstrained_ligand_rigid_water_box(
         self,
@@ -225,4 +225,4 @@ class TestWriteSanderInput(_BaseTest):
         # Amber does not support this case (constrain wtaer bonds and water angles, but no other bonds or angles),
         # this option seems to be the best one
         assert options["cntrl"]["ntf"] == "2"
-        assert options["cntrl"]["ntc"] == "2"
+        assert options["cntrl"]["ntc"] == "1"

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -14,6 +14,7 @@ from openff.interchange.exceptions import (
 
 if TYPE_CHECKING:
     from openff.interchange import Interchange
+
 MDP_HEADER = """
 nsteps                   = 0
 nstenergy                = 1000
@@ -271,7 +272,10 @@ class MDConfig(DefaultModel):
             #       Amber cannot ignore H-O-H angle energy without ignoring all H-X-X angles,
             #       See 21.7.1. in Amber22 manual
             elif self.constraints in ("h-bonds", "all-bonds", "all-angles"):
-                sander.write("ntc=2,\nntf=2,\n")
+                sander.write(
+                    "ntc=1,\n"  # do NOT perform shake, since it will modify positions, but ...
+                    "ntf=2,\n",  # ... ignore interactions of bonds including hydrogen atoms
+                )
             # TODO: Cover other cases, though hard to reach with mainline OpenFF force fields
             else:
                 raise UnsupportedExportError(


### PR DESCRIPTION
### Description

For purposes of energy evaluation of systems prepared with a constrained force field, we want to ignore constrained interactions but **NOT** apply a constraint algorithm like SHAKE; when comparing energies to other engines, it is important that the input coordinates are used, **NOT** coordinates that have been adjusted to satisfy constraints. This breaks a soft convention of `ntc=ntf=2` in sander input files, but is justified by the use case not being production.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
