### PR TITLE
Fix protein_ligand example's call to pack_box

### DIFF
--- a/examples/protein_ligand/protein_ligand.ipynb
+++ b/examples/protein_ligand/protein_ligand.ipynb
@@ -55,7 +55,7 @@
     "from openff.units import unit\n",
     "\n",
     "from openff.interchange import Interchange\n",
-    "from openff.interchange.components._packmol import pack_box\n",
+    "from openff.interchange.components._packmol import UNIT_CUBE, pack_box\n",
     "from openff.interchange.drivers import (\n",
     "    get_amber_energies,\n",
     "    get_gromacs_energies,\n",
@@ -389,7 +389,7 @@
     "xyz = protein.conformers[0]\n",
     "centroid = xyz.sum(axis=0) / xyz.shape[0]\n",
     "protein_radius = np.sqrt(((xyz - centroid) ** 2).sum(axis=-1).max())\n",
-    "box_size = np.ones(3) * protein_radius * 2 + 2 * unit.nanometer\n",
+    "box_vectors = UNIT_CUBE * (protein_radius * 2 + 2 * unit.nanometer)\n",
     "\n",
     "# Pack the box with an arbitrary number of water\n",
     "n_water = 1000\n",
@@ -397,8 +397,8 @@
     "packed_topology = pack_box(\n",
     "    molecules=[water],\n",
     "    number_of_copies=[n_water],\n",
-    "    structure_to_solvate=docked_intrcg.topology,\n",
-    "    box_size=box_size,\n",
+    "    solute=docked_intrcg.topology,\n",
+    "    box_vectors=box_vectors,\n",
     ")"
    ]
   },
@@ -739,7 +739,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
### Description

The `protein_ligand` example is broken on 0.3.6 - it uses the old argument names for `pack_box`.

This PR gets everything to run without errors, but at least for me the summary data tables were not displaying.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
