### PR TITLE
Use Pydantic v1 API from v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
     - name: Run tests
       if: always()
       run: |
-        python -m pytest -r fE -nauto --durations=10 $COV openff/interchange/ -m "slow or not slow"
+        python -m pytest -r fE -nauto --durations=10 $COV openff/interchange/ -m "slow or not slow" --ignore=openff/interchange/_tests/energy_tests/test_energies.py
 
     - name: Run small molecule regression tests
       if: ${{ matrix.python-version == 3.9 && matrix.openeye == true }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, OpenMM ${{ matrix.openmm }}, Pydantic ${{ matrix.pydantic-version }}, OpenEye ${{ matrix.openeye }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -30,6 +31,9 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        pydantic-version:
+          - "1"
+          - "2"
         openeye:
           - true
           - false
@@ -50,6 +54,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >-
           python=${{ matrix.python-version }}
+          pydantic=${{ matrix.pydantic-version }}
 
     - name: Install package
       run: |

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - python
   - pip
   - numpy >=1.21
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic
   - openmm >=7.6
   # OpenFF stack
   - openff-toolkit >=0.14

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -2,6 +2,7 @@ name: beta-env
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge/label/openmm_rc
+  - conda-forge/label/openff-models_rc
   - conda-forge
   - openeye
 dependencies:
@@ -13,7 +14,7 @@ dependencies:
   - openmm >=7.6
   # OpenFF stack
   - openff-toolkit >=0.14
-  - openff-models >=0.0.4
+  - openff-models
   - openff-nagl
   - openff-nagl-models
   # Optional features

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - pip
   - numpy >=1.21
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic
   - openmm
   # OpenFF stack
   - openff-toolkit >=0.14

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   - openmm
   # OpenFF stack
   - openff-toolkit >=0.14
-  - openff-models >=0.0.4
+  - openff-models
   - openff-nagl
   - openff-nagl-models
   # Optional features

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - pip
   - numpy >=1.21
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic
   - openmm >=7.6
   # OpenFF stack
   - openff-toolkit >=0.14

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -6,7 +6,7 @@ dependencies:
   # Core
   - python
   - pip
-  - pydantic >=1.10.8,<2.0.0a0
+  - pydantic
   # OpenFF stack
   - openff-toolkit >=0.14
   - openff-models >=0.0.4

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pydantic
   # OpenFF stack
   - openff-toolkit >=0.14
-  - openff-models >=0.0.4
+  - openff-models
   # Testing
   - pytest
   - pytest-xdist

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - pip
   - numpy >=1.21
-  - pydantic <2.0.0a0
+  - pydantic
   - openmm >=7.6
   # OpenFF stack
   - openff-toolkit >=0.14

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,7 +18,8 @@ dependencies:
   # Optional features
   - unyt
   - mbuild
-  - foyer >=0.11.3
+  # GMSO does not support Pydantic 2
+  # foyer >=0.11.3
   # Testing
   - mdtraj
   - intermol

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,6 +1,8 @@
 name: openff-interchange-env
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
+  - conda-forge/label/openff-models_rc
+  - conda-forge/label/openff-interchange_rc
   - conda-forge
 dependencies:
   # Core

--- a/openff/interchange/_tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/_tests/unit_tests/components/test_interchange.py
@@ -10,7 +10,6 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
 )
 from openff.units import unit
 from openff.utilities.testing import skip_if_missing
-from pydantic import ValidationError
 
 from openff.interchange import Interchange
 from openff.interchange._tests import (
@@ -29,6 +28,11 @@ from openff.interchange.exceptions import (
     MissingVirtualSitesError,
     SMIRNOFFHandlersNotImplementedError,
 )
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 
 @pytest.mark.slow()

--- a/openff/interchange/_tests/unit_tests/smirnoff/test_valence.py
+++ b/openff/interchange/_tests/unit_tests/smirnoff/test_valence.py
@@ -15,7 +15,6 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
     ImproperTorsionHandler,
 )
 from openff.units import unit
-from pydantic import ValidationError
 
 from openff.interchange import Interchange
 from openff.interchange._tests import _BaseTest
@@ -30,6 +29,11 @@ from openff.interchange.smirnoff._valence import (
     SMIRNOFFImproperTorsionCollection,
     _check_molecule_uniqueness,
 )
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 
 class TestSMIRNOFFValenceCollections(_BaseTest):

--- a/openff/interchange/common/_nonbonded.py
+++ b/openff/interchange/common/_nonbonded.py
@@ -5,11 +5,15 @@ from typing import DefaultDict, Literal, Optional, Union
 
 from openff.models.types import FloatQuantity
 from openff.units import Quantity, unit
-from pydantic import Field, PrivateAttr
 
 from openff.interchange.components.potentials import Collection
 from openff.interchange.constants import _PME
 from openff.interchange.models import LibraryChargeTopologyKey, TopologyKey
+
+try:
+    from pydantic.v1 import Field, PrivateAttr
+except ImportError:
+    from pydantic import Field, PrivateAttr
 
 
 class _NonbondedCollection(Collection, abc.ABC):  # noqa

--- a/openff/interchange/common/_valence.py
+++ b/openff/interchange/common/_valence.py
@@ -2,9 +2,13 @@ from collections.abc import Iterable
 from typing import Literal
 
 from openff.toolkit.topology.molecule import Atom
-from pydantic import Field
 
 from openff.interchange.components.potentials import Collection
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 
 class ConstraintCollection(Collection):

--- a/openff/interchange/components/_base.py
+++ b/openff/interchange/components/_base.py
@@ -5,9 +5,13 @@ from typing import Literal
 
 from openff.models.types import FloatQuantity
 from openff.units import unit
-from pydantic import Field
 
 from openff.interchange.components.potentials import Collection
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 
 class BaseBondHandler(Collection):

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -11,7 +11,6 @@ from openff.models.types import ArrayQuantity, QuantityEncoder
 from openff.toolkit import ForceField, Molecule, Topology
 from openff.units import unit
 from openff.utilities.utilities import has_package, requires_package
-from pydantic import Field, validator
 
 from openff.interchange._experimental import experimental
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
@@ -34,6 +33,11 @@ from openff.interchange.exceptions import (
 from openff.interchange.smirnoff._valence import SMIRNOFFConstraintCollection
 from openff.interchange.smirnoff._virtual_sites import SMIRNOFFVirtualSiteCollection
 from openff.interchange.warnings import InterchangeDeprecationWarning
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 if has_package("foyer"):
     from foyer.forcefield import Forcefield as FoyerForcefield

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -4,13 +4,17 @@ from typing import TYPE_CHECKING, Literal
 from openff.models.models import DefaultModel
 from openff.models.types import FloatQuantity
 from openff.units import unit
-from pydantic import Field
 
 from openff.interchange.constants import _PME
 from openff.interchange.exceptions import (
     UnsupportedCutoffMethodError,
     UnsupportedExportError,
 )
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 if TYPE_CHECKING:
     from openff.interchange import Interchange

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -9,7 +9,6 @@ from openff.models.models import DefaultModel
 from openff.models.types import ArrayQuantity, FloatQuantity
 from openff.units import unit
 from openff.utilities.utilities import has_package, requires_package
-from pydantic import Field, PrivateAttr, validator
 
 from openff.interchange.exceptions import MissingParametersError
 from openff.interchange.models import (
@@ -18,6 +17,11 @@ from openff.interchange.models import (
     TopologyKey,
 )
 from openff.interchange.warnings import InterchangeDeprecationWarning
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 if has_package("jax"):
     from jax import numpy as jax_numpy

--- a/openff/interchange/drivers/report.py
+++ b/openff/interchange/drivers/report.py
@@ -5,7 +5,6 @@ from typing import Optional
 from openff.models.models import DefaultModel
 from openff.models.types import FloatQuantity
 from openff.units import unit
-from pydantic import validator
 
 from openff.interchange.constants import kj_mol
 from openff.interchange.exceptions import (
@@ -13,6 +12,11 @@ from openff.interchange.exceptions import (
     IncompatibleTolerancesError,
     InvalidEnergyError,
 )
+
+try:
+    from pydantic.v1 import validator
+except ImportError:
+    from pydantic import validator
 
 _KNOWN_ENERGY_TERMS: set[str] = {
     "Bond",

--- a/openff/interchange/foyer/_nonbonded.py
+++ b/openff/interchange/foyer/_nonbonded.py
@@ -4,12 +4,16 @@ from openff.models.types import FloatQuantity
 from openff.toolkit.topology import Topology
 from openff.units import Quantity, unit
 from openff.utilities.utilities import has_package
-from pydantic import Field, PrivateAttr
 
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
 from openff.interchange.components.potentials import Potential
 from openff.interchange.foyer._base import _copy_params
 from openff.interchange.models import PotentialKey, TopologyKey
+
+try:
+    from pydantic.v1 import Field, PrivateAttr
+except ImportError:
+    from pydantic import Field, PrivateAttr
 
 if has_package("foyer"):
     from foyer.forcefield import Forcefield

--- a/openff/interchange/foyer/_valence.py
+++ b/openff/interchange/foyer/_valence.py
@@ -1,6 +1,5 @@
 from openff.toolkit.topology import Topology
 from openff.units import unit
-from pydantic import Field
 
 from openff.interchange.common._valence import (
     AngleCollection,
@@ -15,6 +14,11 @@ from openff.interchange.foyer._base import (
     _get_potential_key_id,
 )
 from openff.interchange.models import PotentialKey, TopologyKey
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 
 class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler, BondCollection):

--- a/openff/interchange/interop/gromacs/models/models.py
+++ b/openff/interchange/interop/gromacs/models/models.py
@@ -4,7 +4,11 @@ from typing import Optional
 from openff.models.models import DefaultModel
 from openff.models.types import ArrayQuantity, FloatQuantity
 from openff.units import unit
-from pydantic import Field, PositiveInt, PrivateAttr
+
+try:
+    from pydantic.v1 import Field, PositiveInt, PrivateAttr
+except ImportError:
+    from pydantic import Field, PositiveInt, PrivateAttr
 
 
 class GROMACSAtomType(DefaultModel):

--- a/openff/interchange/models.py
+++ b/openff/interchange/models.py
@@ -3,7 +3,11 @@ import abc
 from typing import Literal, Optional
 
 from openff.models.models import DefaultModel
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 
 class TopologyKey(DefaultModel, abc.ABC):

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -13,7 +13,6 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
     vdWHandler,
 )
 from openff.units import Quantity, unit
-from pydantic import Field
 
 from openff.interchange.common._nonbonded import (
     ElectrostaticsCollection,
@@ -38,6 +37,11 @@ from openff.interchange.models import (
     VirtualSiteKey,
 )
 from openff.interchange.smirnoff._base import SMIRNOFFCollection, T
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 ElectrostaticsHandlerType = Union[
     ElectrostaticsHandler,

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -7,7 +7,6 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
     VirtualSiteHandler,
 )
 from openff.units import unit
-from pydantic import Field
 
 from openff.interchange.components.potentials import Potential
 from openff.interchange.components.toolkit import _validated_list_to_array
@@ -17,6 +16,11 @@ from openff.interchange.smirnoff._nonbonded import (
     SMIRNOFFElectrostaticsCollection,
     SMIRNOFFvdWCollection,
 )
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 # The use of `type` as a field name conflicts with the built-in `type()` when used with PEP 585
 _ListOfHandlerTypes = list[type[ParameterHandler]]


### PR DESCRIPTION
### Description

This PR extends https://github.com/openforcefield/openff-models/pull/27

### Checklist
  - [x] Set up testing for both Pydantic versions
  - [x] Update codebase to use v1 from `pydantic.v1` import path
- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
