### PR TITLE
Internally use vdW section 0.4

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pydantic
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.14
+  - openff-toolkit >=0.14.2
   - openff-models
   - openff-nagl
   - openff-nagl-models

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -55,4 +55,5 @@ dependencies:
   - snakeviz
   - tuna
   - pip:
-    - git+https://github.com/jthorton/de-forcefields
+    - git+https://github.com/mattwthompson/de-forcefields.git@periodic-nonperiodic-methods
+    - git+https://github.com/openforcefield/smirnoff-plugins.git@vdw-0.4

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pydantic
   - openmm
   # OpenFF stack
-  - openff-toolkit >=0.14
+  - openff-toolkit >=0.14.2
   - openff-models
   - openff-nagl
   - openff-nagl-models

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pip
   - numpy >=1.21
   - pydantic >=1.10.8,<2.0.0a0
-  - openff-toolkit-base >=0.14
+  - openff-toolkit-base >=0.14.2
   - openff-models
   - openmm >=7.6
   - mbuild

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -11,8 +11,7 @@ dependencies:
   - pydantic
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.14
-  - openff-forcefields >=2023.05
+  - openff-toolkit >=0.14.2
   # Optional features
   - unyt
   - mbuild

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -6,7 +6,6 @@ channels:
 dependencies:
   # Core
   - python
-  - pip
   - numpy >=1.21
   - pydantic
   - openmm >=7.6

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -3,12 +3,5 @@ channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  # Core
-  - python
-  - pip
-  - pydantic
-  # OpenFF stack
   - openff-toolkit >=0.14.2
-  # Testing
-  - pytest
   - pytest-xdist

--- a/devtools/conda-envs/minimal_env.yaml
+++ b/devtools/conda-envs/minimal_env.yaml
@@ -8,8 +8,7 @@ dependencies:
   - pip
   - pydantic
   # OpenFF stack
-  - openff-toolkit >=0.14
-  - openff-models
+  - openff-toolkit >=0.14.2
   # Testing
   - pytest
   - pytest-xdist

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,8 +1,6 @@
 name: openff-interchange-env
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
-  - conda-forge/label/openff-models_rc
-  - conda-forge/label/openff-interchange_rc
   - conda-forge
 dependencies:
   # Core

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   - pydantic
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.14
+  - openff-toolkit >=0.14.2
   - openff-units
   - openff-models
   # Optional features

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -41,4 +41,5 @@ dependencies:
   - types-setuptools
   - pandas-stubs >=1.2.0.56
   - pip:
-    - git+https://github.com/jthorton/de-forcefields
+    - git+https://github.com/mattwthompson/de-forcefields.git@periodic-nonperiodic-methods
+    - git+https://github.com/openforcefield/smirnoff-plugins.git@vdw-0.4

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -9,16 +9,18 @@ Releases follow versioning as described in
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
-## 0.3.10 - 2023-08-02
+## 0.3.10 - 2023-08-09
 
 ### New features
 
 * #781 Adds support for version 0.4 of the SMIRNOFF vdW section.
+* #789 Internally use vdWHandler 0.4 when storing SMIRNOFF data and creating OpenMM forces.
 * #780 Adds compatibility with Pydantic v2, using the existing v1 API.
 
 ### Behavior changes
 
 * #778 `Interchange.from_foyer` now infers positions from the input topology, matching the behavior of `Interchange.from_smirnoff`.
+* #789 Using plugins that create `openmm.NonbondedForce` now results in `openmm.NonbondedForce.NoCutoff` when the topology is non-periodic and `vdWHandler.nonperiodic_method == "no-cutoff"`
 
 ### Documentation improvements
 

--- a/openff/interchange/_tests/data/buckingham.offxml
+++ b/openff/interchange/_tests/data/buckingham.offxml
@@ -4,7 +4,7 @@
         <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c-tip3p-H-O" distance="0.9572 * angstrom"></Constraint>
         <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c-tip3p-H-O-H" distance="1.5139006545247014 * angstrom"></Constraint>
     </Constraints>
-    <Buckingham version="0.3" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom ** 1" switch_width="1.0 * angstrom ** 1" method="cutoff" combining_rules="Lorentz-Berthelot">
+    <Buckingham version="0.3" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom ** 1" switch_width="1.0 * angstrom ** 1" periodic_method="cutoff" nonperiodic_method="no-cutoff" combining_rules="Lorentz-Berthelot">
         <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" a="0.0 * kilojoule_per_mole ** 1" b="0.0 * nanometer ** -1" c="0.0 * kilojoule_per_mole ** 1 * nanometer ** 6"></Atom>
         <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" a="1600000.0 * kilojoule_per_mole ** 1" b="42.0 * nanometer ** -1" c="0.003 * kilojoule_per_mole ** 1 * nanometer ** 6"></Atom>
     </Buckingham>

--- a/openff/interchange/_tests/data/buckingham_virtual_sites.offxml
+++ b/openff/interchange/_tests/data/buckingham_virtual_sites.offxml
@@ -4,7 +4,7 @@
         <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c-tip3p-H-O" distance="0.9572 * angstrom"></Constraint>
         <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c-tip3p-H-O-H" distance="1.5139006545247014 * angstrom"></Constraint>
     </Constraints>
-    <Buckingham version="0.3" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom ** 1" switch_width="1.0 * angstrom ** 1" method="cutoff" combining_rules="Lorentz-Berthelot">
+    <Buckingham version="0.3" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom ** 1" switch_width="1.0 * angstrom ** 1" periodic_method="cutoff" nonperiodic_method="no-cutoff" combining_rules="Lorentz-Berthelot">
         <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" a="0.0 * kilojoule_per_mole ** 1" b="0.0 * nanometer ** -1" c="0.0 * kilojoule_per_mole ** 1 * nanometer ** 6"></Atom>
         <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" a="1600000.0 * kilojoule_per_mole ** 1" b="42.0 * nanometer ** -1" c="0.003 * kilojoule_per_mole ** 1 * nanometer ** 6"></Atom>
     </Buckingham>

--- a/openff/interchange/_tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/_tests/interoperability_tests/test_openmm.py
@@ -37,13 +37,15 @@ from openff.interchange.interop.openmm import (
 
 nonbonded_methods = [
     {
-        "vdw_method": "cutoff",
+        "vdw_periodic": "cutoff",
+        "vdw_nonperiodic": "no-cutoff",
         "electrostatics_periodic": "PME",
         "periodic": True,
         "result": openmm.NonbondedForce.PME,
     },
     {
-        "vdw_method": "cutoff",
+        "vdw_periodic": "cutoff",
+        "vdw_nonperiodic": "no-cutoff",
         "electrostatics_periodic": "PME",
         "periodic": False,
         "result": openmm.NonbondedForce.NoCutoff,
@@ -75,7 +77,6 @@ class TestOpenMM(_BaseTest):
     @pytest.mark.parametrize("inputs", nonbonded_methods)
     def test_openmm_nonbonded_methods(self, inputs, sage):
         """See test_nonbonded_method_resolution in openff.toolkit._tests/test_forcefield.py"""
-        vdw_method = inputs["vdw_method"]
         electrostatics_method = inputs["electrostatics_periodic"]
         periodic = inputs["periodic"]
         result = inputs["result"]
@@ -90,7 +91,15 @@ class TestOpenMM(_BaseTest):
         if not periodic:
             topology.box_vectors = None
 
-        sage.get_parameter_handler("vdW", {}).method = vdw_method
+        if inputs["periodic"]:
+            sage.get_parameter_handler("vdW", {}).periodic_method = inputs[
+                "vdw_periodic"
+            ]
+        else:
+            sage.get_parameter_handler("vdW", {}).nonperiodic_method = inputs[
+                "vdw_nonperiodic"
+            ]
+
         sage.get_parameter_handler(
             "Electrostatics",
             {},
@@ -102,7 +111,15 @@ class TestOpenMM(_BaseTest):
         if type(result) is int:
             nonbonded_method = result
             # The method is validated and may raise an exception if it's not supported.
-            sage.get_parameter_handler("vdW", {}).method = vdw_method
+            if inputs["periodic"]:
+                sage.get_parameter_handler("vdW", {}).periodic_method = inputs[
+                    "vdw_periodic"
+                ]
+            else:
+                sage.get_parameter_handler("vdW", {}).nonperiodic_method = inputs[
+                    "vdw_nonperiodic"
+                ]
+
             sage.get_parameter_handler(
                 "Electrostatics",
                 {},

--- a/openff/interchange/_tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/_tests/interoperability_tests/test_openmm.py
@@ -446,6 +446,19 @@ class TestOpenMMWithPlugins(TestDoubleExponential):
 
         assert isinstance(exception.value.__cause__, AssertionError)
 
+    def test_nocutoff_when_nonperiodic(self, de_force_field):
+        system = Interchange.from_smirnoff(
+            de_force_field,
+            MoleculeWithConformer.from_smiles("CCO").to_topology(),
+        ).to_openmm(combine_nonbonded_forces=False)
+
+        for force in system.getForces():
+            if type(force) in (
+                openmm.NonbondedForce,
+                openmm.CustomNonbondedForce,
+            ):
+                assert force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff
+
     def test_double_exponential_create_simulation(self, de_force_field):
         from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
 

--- a/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
+++ b/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
@@ -128,7 +128,8 @@ class TestSMIRNOFFDefaults(_BaseTest):
                 unit.nanometer,
             ) == pytest.approx(value)
 
-        assert interchange["vdW"].method == "cutoff"
+        assert interchange["vdW"].periodic_method == "cutoff"
+        assert interchange["vdW"].nonperiodic_method == "no-cutoff"
 
         if periodic:
             assert interchange["Electrostatics"].periodic_potential == _PME

--- a/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
+++ b/openff/interchange/_tests/unit_tests/components/test_mdconfig.py
@@ -93,14 +93,23 @@ def parse_sander(file: str) -> dict[str, Union[dict, str]]:
 
 
 class TestMDConfigFromInterchange(_BaseTest):
+    @pytest.mark.parametrize("periodic", [True, False])
     @pytest.mark.parametrize("switch", [True, False])
-    def test_from_interchange(self, sage, basic_top, switch):
+    def test_from_interchange(self, sage, basic_top, switch, periodic):
         from openff.units import unit
+        from packaging.version import Version
 
         from openff.interchange import Interchange
 
+        # After openff-toolkit 0.14.2, this should mean
+        # periodic_method="cutoff", nonperiodic-method="no-cutoff"
+        assert sage["vdW"].version >= Version("0.3.0")
+
         if not switch:
             sage["vdW"].switch_width = 0.0 * unit.nanometer
+
+        if not periodic:
+            basic_top.box_vectors = None
 
         interchange = Interchange.from_smirnoff(sage, basic_top)
         config = MDConfig.from_interchange(interchange)
@@ -111,6 +120,11 @@ class TestMDConfigFromInterchange(_BaseTest):
         else:
             assert not config.switching_function
             # No need to check the value of `switching_distance` ... right?
+
+        if periodic:
+            assert config.vdw_method == "cutoff"
+        else:
+            assert config.vdw_method == "no-cutoff"
 
 
 class TestSMIRNOFFDefaults(_BaseTest):

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_nonbonded.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_nonbonded.py
@@ -10,7 +10,7 @@ class TestUnsupportedCases(_BaseTest):
     def test_ljpme_nonperiodic(self, sage):
         interchange = sage.create_interchange(Molecule.from_smiles("CC").to_topology())
 
-        interchange["vdW"].periodic_method = "pme"
+        interchange["vdW"].nonperiodic_method = "pme"
 
         with pytest.raises(
             UnsupportedCutoffMethodError,

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_nonbonded.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_nonbonded.py
@@ -10,7 +10,7 @@ class TestUnsupportedCases(_BaseTest):
     def test_ljpme_nonperiodic(self, sage):
         interchange = sage.create_interchange(Molecule.from_smiles("CC").to_topology())
 
-        interchange["vdW"].method = "pme"
+        interchange["vdW"].periodic_method = "pme"
 
         with pytest.raises(
             UnsupportedCutoffMethodError,

--- a/openff/interchange/_tests/unit_tests/smirnoff/test_create.py
+++ b/openff/interchange/_tests/unit_tests/smirnoff/test_create.py
@@ -15,7 +15,7 @@ from openff.interchange.exceptions import (
 from openff.interchange.models import BondKey
 from openff.interchange.smirnoff._nonbonded import (
     SMIRNOFFvdWCollection,
-    _downconvert_vdw_handler,
+    _upconvert_vdw_handler,
     library_charge_from_molecule,
 )
 from openff.interchange.smirnoff._valence import (
@@ -374,7 +374,7 @@ class TestMatrixRepresentations(_BaseTest):
             )
         elif handler_name == "vdW":
             # Ensure this is 0.3 until everything assumes 0.4
-            _downconvert_vdw_handler(sage[handler_name])
+            _upconvert_vdw_handler(sage[handler_name])
 
             handler = SMIRNOFFvdWCollection.create(
                 parameter_handler=sage[handler_name],

--- a/openff/interchange/common/_nonbonded.py
+++ b/openff/interchange/common/_nonbonded.py
@@ -57,7 +57,8 @@ class vdWCollection(_NonbondedCollection):
         description="The width over which the switching function is applied",
     )
 
-    method: Literal["cutoff", "no-cutoff", "pme"] = Field("cutoff")
+    periodic_method: Literal["cutoff", "no-cutoff", "pme"] = Field("cutoff")
+    nonperiodic_method: Literal["cutoff", "no-cutoff", "pme"] = Field("no-cutoff")
 
     @classmethod
     def default_parameter_values(cls) -> Iterable[float]:

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -82,8 +82,13 @@ class MDConfig(DefaultModel):
         )
         if "vdW" in interchange.collections:
             vdw_collection = interchange["vdW"]
-            mdconfig.vdw_cutoff = vdw_collection.cutoff
-            mdconfig.vdw_method = vdw_collection.method
+
+            if interchange.box is None:
+                mdconfig.vdw_method = vdw_collection.nonperiodic_method
+            else:
+                mdconfig.vdw_method = vdw_collection.periodic_method
+                mdconfig.vdw_cutoff = vdw_collection.cutoff
+
             mdconfig.mixing_rule = vdw_collection.mixing_rule
 
             if vdw_collection.switch_width is not None:
@@ -116,8 +121,13 @@ class MDConfig(DefaultModel):
 
         if "vdW" in interchange.collections:
             vdw_collection = interchange["vdW"]
+
+            if interchange.box is None:
+                vdw_collection.nonperiodic_method = self.vdw_method
+            else:
+                vdw_collection.periodic_method = self.vdw_method
+
             vdw_collection.cutoff = self.vdw_cutoff
-            vdw_collection.method = self.vdw_method
             vdw_collection.mixing_rule = self.mixing_rule
 
             if self.switching_function:

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -280,7 +280,7 @@ def _create_single_nonbonded_force(
     system.addForce(non_bonded_force)
 
     if interchange.box is None:
-        if (data.vdw_method in ("cutoff", None)) and (
+        if (data.vdw_method in ("no-cutoff", None)) and (
             data.electrostatics_method in ("Coulomb", None)
         ):
             non_bonded_force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -803,7 +803,7 @@ def _create_vdw_force(
                 "LJ-PME with split non-bonded forces is not supported due to openmm.CustomNonbondedForce "
                 "not supporting PME. If also using PME electrostatics, try `combine_nonbonded_forces=True`,  "
                 "which should produce a single force with NonbondedForce.LJPME, which uses PME for both "
-                "electrostatics and LJ forces tersm. If your use case would benenfit from split non-bonded "
+                "electrostatics and LJ forces terms. If your use case would benefit from split non-bonded "
                 "forces with LJPME, please file an feature request.",
             )
 

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -210,7 +210,12 @@ def _prepare_input_data(interchange: "Interchange") -> _NonbondedData:
 
     if vdw:
         vdw_cutoff: Optional[unit.Quanaity] = vdw.cutoff
-        vdw_method: Optional[str] = getattr(vdw, "method", "cutoff").lower()
+
+        if interchange.box is None:
+            vdw_method: Optional[str] = vdw.nonperiodic_method.lower()
+        else:
+            vdw_method: Optional[str] = vdw.periodic_method.lower()
+
         mixing_rule: Optional[str] = getattr(vdw, "mixing_rule", None)
         vdw_expression: Optional[str] = vdw.expression.replace("**", "^")
     else:
@@ -730,7 +735,7 @@ def _create_multiple_nonbonded_forces(
         ):
             raise UnsupportedCutoffMethodError(
                 "When using `openmm.CustomNonbondedForce`, vdW and electrostatics cutoff methods "
-                "must agree on whether or not periodic boundary conditions should be used."
+                "must agree on whether or not periodic boundary conditions should be used. "
                 f"OpenMM will throw an error. Found vdw method {vdw_force.getNonbondedMethod()}, "
                 f"and electrostatics method {electrostatics_force.getNonbondedMethod()}, ",
             )
@@ -793,6 +798,14 @@ def _create_vdw_force(
 
         _apply_switching_function(vdw_collection, vdw_force)
 
+    elif data.vdw_method == "no-cutoff":
+        if interchange.box is None:
+            vdw_force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+        else:
+            raise UnsupportedCutoffMethodError(
+                "vdW method 'no-cutoff' is not valid for periodic systems.",
+            )
+
     elif data.vdw_method == "pme":
         if interchange.box is None:
             raise UnsupportedCutoffMethodError(
@@ -804,8 +817,13 @@ def _create_vdw_force(
                 "not supporting PME. If also using PME electrostatics, try `combine_nonbonded_forces=True`,  "
                 "which should produce a single force with NonbondedForce.LJPME, which uses PME for both "
                 "electrostatics and LJ forces terms. If your use case would benefit from split non-bonded "
-                "forces with LJPME, please file an feature request.",
+                "forces with LJPME, please open a feature request.",
             )
+
+    else:
+        raise UnsupportedCutoffMethodError(
+            f"Unsupported vdW method: {data.vdw_method}",
+        )
 
     return vdw_force
 

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -228,13 +228,15 @@ def _impropers(interchange, force_field, _topology):
 
 
 def _vdw(interchange: Interchange, force_field: ForceField, topology: Topology):
+    from openff.interchange.smirnoff._nonbonded import _upconvert_vdw_handler
+
     if "vdW" not in force_field.registered_parameter_handlers:
         return
 
-    if force_field["vdW"].version == Version("0.4"):
-        from openff.interchange.smirnoff._nonbonded import _downconvert_vdw_handler
+    # TODO: This modifies a user-supplied argument in-place, might consider
+    # deepcopying it somewhere around `Interchange.from_x`
 
-        _downconvert_vdw_handler(force_field["vdW"])
+    _upconvert_vdw_handler(force_field["vdW"])
 
     interchange.collections.update(
         {

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -69,7 +69,7 @@ def _add_charges(
 
 
 def _upconvert_vdw_handler(vdw_handler: vdWHandler):
-    """Given a vdW with version 0.3, up-convert to 0.4."""
+    """Given a vdW with version 0.3 or 0.4, up-convert to 0.4 or short-circuit if already 0.4."""
     from packaging.version import Version
 
     if vdw_handler.version >= Version("0.4"):
@@ -176,7 +176,8 @@ class SMIRNOFFvdWCollection(vdWCollection, SMIRNOFFCollection):
         Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
-        self.method = parameter_handler.method.lower()
+        self.periodic_method = parameter_handler.periodic_method.lower()
+        self.nonperiodic_method = parameter_handler.nonperiodic_method.lower()
         self.cutoff = parameter_handler.cutoff
 
         for potential_key in self.key_map.values():
@@ -220,7 +221,8 @@ class SMIRNOFFvdWCollection(vdWCollection, SMIRNOFFCollection):
             scale_15=parameter_handler.scale15,
             cutoff=parameter_handler.cutoff,
             mixing_rule=parameter_handler.combining_rules.lower(),
-            method=parameter_handler.method.lower(),
+            periodic_method=parameter_handler.periodic_method.lower(),
+            nonperiodic_method=parameter_handler.nonperiodic_method.lower(),
             switch_width=parameter_handler.switch_width,
         )
         handler.store_matches(parameter_handler=parameter_handler, topology=topology)

--- a/plugins/nonbonded_plugins/nonbonded.py
+++ b/plugins/nonbonded_plugins/nonbonded.py
@@ -76,7 +76,9 @@ class DoubleExponentialHandler(ParameterHandler):
         r_min = ParameterAttribute(default=None, unit=unit.nanometers)
         epsilon = ParameterAttribute(default=None, unit=unit.kilojoule_per_mole)
 
-    _TAGNAME = "DoubleExponential"
+    # Give this a different name than the class provided in smirnoff-plugins
+    # since the toolkit forbids two handlers from sharing a _TAGNAME
+    _TAGNAME = "OtherDoubleExponential"
     _INFOTYPE = DoubleExponentialType
 
     scale12 = ParameterAttribute(default=0.0, converter=float)

--- a/plugins/nonbonded_plugins/nonbonded.py
+++ b/plugins/nonbonded_plugins/nonbonded.py
@@ -48,9 +48,14 @@ class BuckinghamHandler(ParameterHandler):
 
     cutoff = ParameterAttribute(default=9.0 * unit.angstroms, unit=unit.angstrom)
     switch_width = ParameterAttribute(default=1.0 * unit.angstroms, unit=unit.angstrom)
-    method = ParameterAttribute(
+
+    periodic_method = ParameterAttribute(
         default="cutoff",
-        converter=_allow_only(["cutoff", "PME"]),
+        converter=_allow_only(["cutoff"]),
+    )
+    nonperiodic_method = ParameterAttribute(
+        default="no-cutoff",
+        converter=_allow_only(["no-cutoff"]),
     )
 
     combining_rules = ParameterAttribute(
@@ -86,9 +91,14 @@ class DoubleExponentialHandler(ParameterHandler):
 
     cutoff = ParameterAttribute(default=9.0 * unit.angstroms, unit=unit.angstrom)
     switch_width = ParameterAttribute(default=1.0 * unit.angstroms, unit=unit.angstrom)
-    method = ParameterAttribute(
+
+    periodic_method = ParameterAttribute(
         default="cutoff",
-        converter=_allow_only(["cutoff", "PME"]),
+        converter=_allow_only(["cutoff"]),
+    )
+    nonperiodic_method = ParameterAttribute(
+        default="no-cutoff",
+        converter=_allow_only(["no-cutoff"]),
     )
 
     combining_rules = ParameterAttribute(
@@ -128,7 +138,8 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
         "a*exp(-b*r)-c*r^-6;" "a=sqrt(a1*a2);" "b=2/(1/b1+1/b2);" "c=sqrt(c1*c2);"
     )
 
-    method: str = "cutoff"
+    periodic_method: str = "cutoff"
+    nonperiodic_method: str = "no-cutoff"
 
     mixing_rule: str = "Buckingham"
 
@@ -175,7 +186,8 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
         Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
-        self.method = parameter_handler.method.lower()
+        self.periodic_method = parameter_handler.periodic_method.lower()
+        self.nonperiodic_method = parameter_handler.nonperiodic_method.lower()
         self.cutoff = parameter_handler.cutoff
 
         for potential_key in self.slot_map.values():
@@ -213,7 +225,8 @@ class SMIRNOFFBuckinghamCollection(_SMIRNOFFNonbondedCollection):
             scale_15=parameter_handler.scale15,
             cutoff=parameter_handler.cutoff,
             mixing_rule=parameter_handler.combining_rules.lower(),
-            method=parameter_handler.method.lower(),
+            periodic_method=parameter_handler.periodic_method.lower(),
+            nonperiodic_method=parameter_handler.nonperiodic_method.lower(),
             switch_width=parameter_handler.switch_width,
         )
         handler.store_matches(parameter_handler=parameter_handler, topology=topology)
@@ -255,7 +268,8 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
         "CombinedR=r_min1+r_min2;"
     )
 
-    method: str = "cutoff"
+    periodic_method: str = "cutoff"
+    nonperiodic_method: str = "no-cutoff"
 
     mixing_rule: str = ""
 
@@ -326,7 +340,8 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
         Populate self.potentials with key-val pairs of [TopologyKey, PotentialKey].
 
         """
-        self.method = parameter_handler.method.lower()
+        self.periodic_method = parameter_handler.periodic_method.lower()
+        self.nonperiodic_method = parameter_handler.nonperiodic_method.lower()
         self.cutoff = parameter_handler.cutoff
 
         for potential_key in self.slot_map.values():
@@ -366,7 +381,8 @@ class SMIRNOFFDoubleExponentialCollection(_SMIRNOFFNonbondedCollection):
             scale_15=parameter_handler.scale15,
             cutoff=parameter_handler.cutoff,
             mixing_rule=parameter_handler.combining_rules.lower(),
-            method=parameter_handler.method.lower(),
+            periodic_method=parameter_handler.periodic_method.lower(),
+            nonperiodic_method=parameter_handler.nonperiodic_method.lower(),
             switch_width=parameter_handler.switch_width,
         )
         handler.store_matches(parameter_handler=parameter_handler, topology=topology)
@@ -398,6 +414,9 @@ class SMIRNOFFC4IonCollection(_SMIRNOFFNonbondedCollection):
     is_plugin: bool = True
 
     expression: str = "c*r^-4;c=sqrt(c1*c2);"
+
+    periodic_method: str = "cutoff"
+    nonperiodic_method: str = "no-cutoff"
 
     @classmethod
     def allowed_parameter_handlers(cls) -> _HandlerIterable:


### PR DESCRIPTION
### Description

Resolves #786

* `MDConfig`, `SMIRNOFFvdWCollection`, and similar classes now separately track vdW methods following [`OFF-EP-0008`](https://github.com/openforcefield/standards/blob/b3e17f72c7a906e0700f5d9605ffa9683a1ef32d/docs/enhancement-proposals/off-ep-0008.md).
* Only versions of the toolkit supporting vdW 0.4 (0.14.2+) are compatible
* Using plugins that create `openmm.NonbondedForce` now results in `openmm.NonbondedForce.NoCutoff` when the topology is non-periodic and `vdWHandler.nonperiodic_method == "no-cutoff"
* Some OFFXML files used in tests are updated manually in leiu of wiring up auto-converters.

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
