### PR TITLE
fixed the zenodo links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Documentation for Interchange, including examples, a brief user guide, release h
 
 ## How to cite
 
-Please cite Interchange using the [Zenodo record](https://zenodo.org/record/8147765) of the [latest release](https://zenodo.org/record/8147765) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/8147765/export/hx).
+Please cite Interchange using the [Zenodo record](https://doi.org/10.5281/zenodo.10068101) of the [latest release](https://zenodo.org/doi/10.5281/zenodo.8147764) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/8147765/export/hx).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Documentation for Interchange, including examples, a brief user guide, release h
 
 ## How to cite
 
-Please cite Interchange using the [Zenodo record](https://doi.org/10.5281/zenodo.10068101) of the [latest release](https://zenodo.org/doi/10.5281/zenodo.8147764) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/8147765/export/hx).
+Please cite Interchange using the [Zenodo record](https://doi.org/10.5281/zenodo.10068101) of the [latest release](https://zenodo.org/doi/10.5281/zenodo.8147764) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/8147764/export/hx).
 
 ## Installation
 


### PR DESCRIPTION
...to refer to 0.3.17 and the all-versions doi, respectively.

### Description

The zenodo links in the readme were linking to an old release. This PR fixes them, so that the first one links the current (Nov 3, 2023) release and the second one links the evergreen latest release.