### PR TITLE
Fix sensitivity to atom ordering in charge caching

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,12 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## 0.3.18 - 2023-11-16
+
+### Bugfixes
+
+* #844 Fixes a bug in which charge assignment caching incorrect charges between similar molecules with different atom orderings.
+
 ## 0.3.17 - 2023-11-02
 
 ### New Features

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -456,7 +456,12 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
 
     @classmethod
     @functools.lru_cache(None)
-    def _compute_partial_charges(cls, molecule: Molecule, method: str) -> "Quantity":
+    def _compute_partial_charges(
+        cls,
+        molecule: Molecule,
+        mapped_smiles: str,
+        method: str,
+    ) -> "Quantity":
         """Call out to the toolkit's toolkit wrappers to generate partial charges."""
         molecule = copy.deepcopy(molecule)
         molecule.assign_partial_charges(method)
@@ -646,6 +651,11 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
 
         partial_charges = cls._compute_partial_charges(
             unique_molecule,
+            unique_molecule.to_smiles(
+                isomeric=True,
+                explicit_hydrogens=True,
+                mapped=True,
+            ),
             method=partial_charge_method,
         )
 


### PR DESCRIPTION
### Description

Iterating on #842; this is the simplest solution we've come up with so far, I'm not sure it's necessarily the best.

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
