### PR TITLE
Raise exception when writing Amber files with virtual sites

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,12 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## Current development
+
+### Behavior changes
+
+* #845 Adds an exception when unimplemented virtual sites are present while writing to Amber files. Previously this was a silent error producing invalid files.
+
 ## 0.3.17 - 2023-11-02
 
 ### New Features

--- a/openff/interchange/_tests/unit_tests/interop/amber/export/test_export.py
+++ b/openff/interchange/_tests/unit_tests/interop/amber/export/test_export.py
@@ -5,6 +5,7 @@ from openff.utilities import has_package
 
 from openff.interchange import Interchange
 from openff.interchange._tests import get_test_file_path, requires_openeye
+from openff.interchange.exceptions import UnsupportedExportError
 
 if has_package("openmm"):
     import openmm
@@ -60,3 +61,11 @@ def exclusions_in_rings(molecule):
     for force in loaded_system.getForces():
         if isinstance(force, openmm.NonbondedForce):
             assert force.getNumExceptions() == reference
+
+
+def test_virtual_site_error(tip4p, water):
+    with pytest.raises(
+        UnsupportedExportError,
+        match="not yet supported in Amber writers",
+    ):
+        tip4p.create_interchange(water.to_topology()).to_prmtop("foo")

--- a/openff/interchange/interop/amber/export/_export.py
+++ b/openff/interchange/interop/amber/export/_export.py
@@ -317,6 +317,13 @@ def to_prmtop(interchange: "Interchange", file_path: Union[Path, str]):
     if interchange["vdW"].mixing_rule != "lorentz-berthelot":
         raise UnsupportedMixingRuleError(interchange["vdW"].mixing_rule)
 
+    if "VirtualSites" in interchange.collections:
+        if len(interchange["VirtualSites"].key_map) > 0:
+            raise UnsupportedExportError(
+                "Virtual sites are not yet supported in Amber writers. See issues labeled "
+                "'amber' or 'virtual sites' for status and updates of this feature.",
+            )
+
     if interchange.box is None:
         if interchange["Electrostatics"].periodic_potential != _PME:
             raise UnsupportedExportError(


### PR DESCRIPTION

Related #783 #843 

### Description

Previously this silently produced garbage files; these will be implemented in the future, but explicitly erroring out is an improvement in the current state.

### Checklist

- [x] Add tests
- [x] Lint
- [x] Update docstrings
