### PR TITLE
Improve minimization with virtual sites

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,16 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## Current development
+
+### New Features
+
+* #848 Raises a more useful error when `Interchange.minimize` is called while positions are not present.
+
+### Bugfixes
+
+* #848 Fixes a bug in which `Interchange.minimize` erroneously appended virtual site positions to the `positions` attribute.
+
 ## 0.3.18 - 2023-11-16
 
 ### Bugfixes

--- a/openff/interchange/_tests/unit_tests/operations/minimize/test_openmm.py
+++ b/openff/interchange/_tests/unit_tests/operations/minimize/test_openmm.py
@@ -2,9 +2,12 @@ from openff.utilities import has_package, skip_if_missing
 
 if has_package("openmm"):
     import numpy
+    import pytest
+    from openff.toolkit import Molecule
 
     from openff.interchange._tests import MoleculeWithConformer
     from openff.interchange.drivers import get_openmm_energies
+    from openff.interchange.exceptions import MissingPositionsError
     from openff.interchange.operations.minimize import (
         _DEFAULT_ENERGY_MINIMIZATION_TOLERANCE,
     )
@@ -32,3 +35,7 @@ class TestOpenMMMinimization:
         minimied_energy = get_openmm_energies(system).total_energy
 
         assert minimied_energy < original_energy
+
+    def test_missing_positions_error(self, tip3p):
+        with pytest.raises(MissingPositionsError, match="positions=None"):
+            tip3p.create_interchange(Molecule.from_smiles("O").to_topology()).minimize()

--- a/openff/interchange/_tests/unit_tests/operations/minimize/test_openmm.py
+++ b/openff/interchange/_tests/unit_tests/operations/minimize/test_openmm.py
@@ -39,3 +39,12 @@ class TestOpenMMMinimization:
     def test_missing_positions_error(self, tip3p):
         with pytest.raises(MissingPositionsError, match="positions=None"):
             tip3p.create_interchange(Molecule.from_smiles("O").to_topology()).minimize()
+
+    def test_minimization_does_not_add_virtual_sites_as_atoms(self, tip4p, water_tip4p):
+        system = tip4p.create_interchange(water_tip4p.to_topology())
+
+        original_positions = system.positions
+
+        system.minimize()
+
+        assert system.positions.shape == original_positions.shape

--- a/openff/interchange/exceptions.py
+++ b/openff/interchange/exceptions.py
@@ -346,5 +346,9 @@ class PACKMOLValueError(InterchangeException):
     """Exception raised when a bad input is passed to a PACKMOL wrapper."""
 
 
+class MinimizationError(InterchangeException):
+    """Exception raised when an energy minimization fails to converge."""
+
+
 class ExperimentalFeatureException(InterchangeException):
     """Exception raised when an experimental feature is used without opt-in."""

--- a/openff/interchange/operations/minimize/openmm.py
+++ b/openff/interchange/operations/minimize/openmm.py
@@ -45,4 +45,11 @@ def minimize_openmm(
         else:
             raise MinimizationError("OpenMM Minimization failed.") from error
 
-    return from_openmm(simulation.context.getState(getPositions=True).getPositions())
+    # Assume that all virtual sites are placed at the _end_, so the 0th through
+    # (number of atoms)th positions are the massive particles
+    return from_openmm(
+        simulation.context.getState(getPositions=True).getPositions(asNumpy=True)[
+            : interchange.positions.shape[0],
+            :,
+        ],
+    )


### PR DESCRIPTION
### Checklist

- [x] Raise error when `Interchange.minimize` is called without virtual sites present
- [x] Add #846 as a test
- [x] Only set atomic positions from `Interchange.minimize`
- [x] Add #847 as a test
- [x] Lint
- [x] Update docstrings
