### PR TITLE
Update installation instructions

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -39,7 +39,7 @@ The configuration file (`.pre-commit-config.yaml`) is commited to the repo. This
 First, install `pre-commit`
 
 ```console
-$ conda install pre-commit -c conda-forge
+$ mamba install pre-commit -c conda-forge
 ...
 ```
 
@@ -95,9 +95,9 @@ Dependencies for building the documentation can be found in `docs/environment.ym
 
 ```shell
 # Create the environment
-conda env create --file devtools/conda-envs/docs_env.yaml
+mamba env create --file devtools/conda-envs/docs_env.yaml
 # Prepare the current shell session
-conda activate interchange-docs
+mamba activate interchange-docs
 cd docs
 # Build the docs
 make html

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,21 +1,23 @@
 # Installation
 
-These instructions assume that the `conda` package manager is installed. If you do not have Conda installed, see the [OpenFF installation documentation](openff.docs:install).
+These instructions assume that the `mamba` package manager is installed. If you do not have Conda/Mamba or a drop-in replacement installed, see the [OpenFF installation documentation](openff.docs:install).
 
 ## Quick Installation
 
 Install the latest release of the `openff-interchange` package from `conda-forge`:
 
 ```shell
-conda install -c conda-forge openff-interchange
+mamba create -n interchange-env -c conda-forge openff-interchange
 ```
+
+Note that Interchange is [a dependency of the OpenFF Toolkit](https://docs.openforcefield.org/projects/toolkit/en/stable/installation.html#installation); if you have the toolkit installed, Interchange is likely already installed.
 
 ## Optional dependencies
 
 Some libraries or tools are only used for development, testing, or optional features. If portions of the API that require optional dependencies are called while those package(s) are not available, an informative error message should be provided. If one is not provided or is insufficiently informative, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
 
-It is assumed that all packages are updated to their latest minor versions. Compatibility with old releases is not guaranteed and likely to not work. For example, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.8.3 and older) and OpenMM (7.5.1 and older) are not guaranteed. If there are a compelling reasons to add compatibility with old versions of dependencies, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
+It is assumed that all upstream packages are updated to their latest minor versions. Compatibility with old releases is not guaranteed and likely to not work. For example, compatibility with older versions of the OpenFF Toolkit (i.e. versions 0.10.6 and older) and OpenMM (7.5.1 and older) are not guaranteed. If there are a compelling reasons to add compatibility with old versions of dependencies, please [raise an issue](https://github.com/openforcefield/openff-interchange/issues).
 
-All packages (with the exception of OpenEye toolkits) are understood to be open source and free to use. Some operations within the OpenFF Toolkit can be faster if OpenEye toolkits are available, but free alternatives (using RDKit, AmberTools) are available for all methods. For more see [here](https://open-forcefield-toolkit.readthedocs.io/en/stable/installation.html#optional-dependencies).
+All packages (with the exception of those packaged within OpenEye Toolkits) are understood to be open source and free to use. Some operations within the OpenFF Toolkit can be faster if OpenEye Toolkits are available, but free alternatives (OpenFF NAGL, RDKit, AmberTools, etc.) are available for all methods. For more see [here](https://open-forcefield-toolkit.readthedocs.io/en/stable/installation.html#optional-dependencies).
 
-All packages used in core functionality are available on `conda-forge` and it assumed that `conda` is used to install them. Most are also available on [PyPI](https://pypi.org) via `pip`; while this method of installation is likely to work, it is not currently tested and no guarantees are made.
+All packages used in core functionality are available on `conda-forge` and it assumed that `mamba` is used to install them. Most are also available on [PyPI](https://pypi.org) via `pip`; while this method of installation is likely to work, it is not tested and no guarantees are made.


### PR DESCRIPTION
### Description

Resolves #862

The docs default to the `stable` branch so these won't be highly visible until a release is made in early January.

### Checklist

- [x] Update installation instructions
- [x] Recommend Mamba
- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
