### PR TITLE
Interoperability trunk

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -71,5 +71,6 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         fail_ci_if_error: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,5 +144,6 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         fail_ci_if_error: false

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -12,8 +12,8 @@ dependencies:
   - pydantic =1
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.14.5
-  - openff-models
+  - openff-toolkit >=0.15
+  - openff-models >=0.1.2
   - openff-nagl
   - openff-nagl-models
   # Optional features

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -12,8 +12,8 @@ dependencies:
   - pydantic =1
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.15
-  - openff-models >=0.1.2
+  - openff-toolkit >=0.15.2
+  - openff-models
   - openff-nagl
   - openff-nagl-models
   # Optional features
@@ -43,5 +43,3 @@ dependencies:
   - typing-extensions
   - types-setuptools
   - pandas-stubs >=1.2.0.56
-  - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -43,3 +43,5 @@ dependencies:
   - typing-extensions
   - types-setuptools
   - pandas-stubs >=1.2.0.56
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -11,9 +11,9 @@ dependencies:
   - pydantic
   - openmm
   # OpenFF stack
-  - openff-toolkit ==0.14.5
+  - openff-toolkit >=0.15
   - openff-interchange-base
-  - openff-models
+  - openff-models >=0.1.2
   - smirnoff-plugins =2023
   # openff-nagl
   # openff-nagl-models

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -52,3 +52,5 @@ dependencies:
   - flake8
   - snakeviz
   - tuna
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -11,9 +11,9 @@ dependencies:
   - pydantic
   - openmm
   # OpenFF stack
-  - openff-toolkit >=0.15
+  - openff-toolkit =0.15.2
   - openff-interchange-base
-  - openff-models >=0.1.2
+  - openff-models
   - smirnoff-plugins =2023
   # openff-nagl
   # openff-nagl-models
@@ -52,5 +52,3 @@ dependencies:
   - flake8
   - snakeviz
   - tuna
-  - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,8 +9,8 @@ dependencies:
   - pip
   - numpy =1
   - pydantic =1
-  - openff-toolkit-base =0.14.5
-  - openff-models
+  - openff-toolkit-base =0.15
+  - openff-models =0.1.2
   - openmm >=7.6
   - mbuild
   - foyer >=0.12.1

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -27,3 +27,4 @@ dependencies:
   - sphinx-notfound-page
   - pip:
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
+    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,8 +9,8 @@ dependencies:
   - pip
   - numpy =1
   - pydantic =1
-  - openff-toolkit-base =0.15
-  - openff-models =0.1.2
+  - openff-toolkit-base =0.15.2
+  - openff-models
   - openmm >=7.6
   - mbuild
   - foyer >=0.12.1
@@ -27,4 +27,3 @@ dependencies:
   - sphinx-notfound-page
   - pip:
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
-    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -10,7 +10,8 @@ dependencies:
   - pydantic =1
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit =0.14.5
+  - openff-toolkit =0.15
+  - openff-models =0.1.2
   - openff-nagl ==0.3.1
   - openff-nagl-models ==0.1
   # Optional features

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -31,3 +31,5 @@ dependencies:
   # Drivers
   - gromacs =2023.3=nompi_*_103
   - lammps
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -10,8 +10,8 @@ dependencies:
   - pydantic =1
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit =0.15
-  - openff-models =0.1.2
+  - openff-toolkit =0.15.2
+  - openff-models
   - openff-nagl ==0.3.1
   - openff-nagl-models ==0.1
   # Optional features
@@ -32,5 +32,3 @@ dependencies:
   # Drivers
   - gromacs =2023.3=nompi_*_103
   - lammps
-  - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,9 +8,9 @@ dependencies:
   - numpy
   - pydantic
   # OpenFF stack
-  - openff-toolkit-base =0.15
+  - openff-toolkit-base =0.15.2
   - openff-units
-  - openff-models =0.1.2
+  - openff-models
   # Needs to be explicitly listed to not be dropped when AmberTools is removed
   - rdkit
   # Optional features
@@ -37,5 +37,3 @@ dependencies:
   - typing-extensions
   - types-setuptools
   - pandas-stubs
-  - pip:
-    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,9 +8,9 @@ dependencies:
   - numpy
   - pydantic
   # OpenFF stack
-  - openff-toolkit-base =0.14.5
+  - openff-toolkit-base =0.15
   - openff-units
-  - openff-models
+  - openff-models =0.1.2
   # Needs to be explicitly listed to not be dropped when AmberTools is removed
   - rdkit
   # Optional features

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -37,3 +37,5 @@ dependencies:
   - typing-extensions
   - types-setuptools
   - pandas-stubs
+  - pip:
+    - git+https://github.com/openforcefield/openff-toolkit.git@interop

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,15 +13,26 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## Current development
 
-### New Features
+### 0.3.19 - 2023-02-05
 
 * #867 Tags `PotentialKey.virtual_site_type` with the associated type provided by SMIRNOFF parameters.
+* #857 Tags `PotentialKey.associated_handler` when importing data from OpenMM.
 * #848 Raises a more useful error when `Interchange.minimize` is called while positions are not present.
 * #852 Support LJPME in OpenMM export.
+* #871 Re-introduces Foyer compatibility with version 0.12.1.
+* #883 Improve topology interoperability after importing data from OpenMM, using OpenFF Toolkit 0.15.2.
+* #883 Falls back to `Topology.visualize` in most cases.
 
 ### Bugfixes
 
 * #848 Fixes a bug in which `Interchange.minimize` erroneously appended virtual site positions to the `positions` attribute.
+* #883 Using `openff-models` 0.1.2, fixes parsing box information from OpenMM data.
+* #883 Skips writing unnecessary PDB file during visualization.
+* #883 Preserves atom metadata when roundtripping topologies with OpenMM.
+
+### Documentation improvements
+
+* #864 Updates installation instructions.
 
 ## 0.3.18 - 2023-11-16
 

--- a/openff/interchange/_tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/_tests/interoperability_tests/test_openmm.py
@@ -264,38 +264,6 @@ class TestOpenMM(_BaseTest):
             get_openmm_energies(converted, combine_nonbonded_forces=True),
         )
 
-    def test_openmm_roundtrip_metadata(self):
-        # Make an example OpenMM Topology with metadata.
-        # Here we use OFFTK to make the OpenMM Topology, but this could just as easily come from another source
-        ethanol = Molecule.from_smiles("CCO")
-        benzene = Molecule.from_smiles("c1ccccc1")
-        for atom in ethanol.atoms:
-            atom.metadata["chain_id"] = "1"
-            atom.metadata["residue_number"] = "1"
-            atom.metadata["insertion_code"] = ""
-            atom.metadata["residue_name"] = "ETH"
-        for atom in benzene.atoms:
-            atom.metadata["chain_id"] = "1"
-            atom.metadata["residue_number"] = "2"
-            atom.metadata["insertion_code"] = "A"
-            atom.metadata["residue_name"] = "BNZ"
-        top = Topology.from_molecules([ethanol, benzene])
-
-        # Roundtrip the topology with metadata through openmm
-        interchange = Interchange.from_openmm(topology=top.to_openmm())
-
-        # Ensure that the metadata is the same
-        for atom in interchange.topology.molecule(0).atoms:
-            assert atom.metadata["chain_id"] == "1"
-            assert atom.metadata["residue_number"] == "1"
-            assert atom.metadata["insertion_code"] == ""
-            assert atom.metadata["residue_name"] == "ETH"
-        for atom in interchange.topology.molecule(1).atoms:
-            assert atom.metadata["chain_id"] == "1"
-            assert atom.metadata["residue_number"] == "2"
-            assert atom.metadata["insertion_code"] == "A"
-            assert atom.metadata["residue_name"] == "BNZ"
-
     @pytest.mark.xfail(reason="Broken because of splitting non-bonded forces")
     @pytest.mark.slow()
     def test_combine_nonbonded_forces(self, sage):

--- a/openff/interchange/_tests/interoperability_tests/test_openmm.py
+++ b/openff/interchange/_tests/interoperability_tests/test_openmm.py
@@ -264,6 +264,38 @@ class TestOpenMM(_BaseTest):
             get_openmm_energies(converted, combine_nonbonded_forces=True),
         )
 
+    def test_openmm_roundtrip_metadata(self):
+        # Make an example OpenMM Topology with metadata.
+        # Here we use OFFTK to make the OpenMM Topology, but this could just as easily come from another source
+        ethanol = Molecule.from_smiles("CCO")
+        benzene = Molecule.from_smiles("c1ccccc1")
+        for atom in ethanol.atoms:
+            atom.metadata["chain_id"] = "1"
+            atom.metadata["residue_number"] = "1"
+            atom.metadata["insertion_code"] = ""
+            atom.metadata["residue_name"] = "ETH"
+        for atom in benzene.atoms:
+            atom.metadata["chain_id"] = "1"
+            atom.metadata["residue_number"] = "2"
+            atom.metadata["insertion_code"] = "A"
+            atom.metadata["residue_name"] = "BNZ"
+        top = Topology.from_molecules([ethanol, benzene])
+
+        # Roundtrip the topology with metadata through openmm
+        interchange = Interchange.from_openmm(topology=top.to_openmm())
+
+        # Ensure that the metadata is the same
+        for atom in interchange.topology.molecule(0).atoms:
+            assert atom.metadata["chain_id"] == "1"
+            assert atom.metadata["residue_number"] == "1"
+            assert atom.metadata["insertion_code"] == ""
+            assert atom.metadata["residue_name"] == "ETH"
+        for atom in interchange.topology.molecule(1).atoms:
+            assert atom.metadata["chain_id"] == "1"
+            assert atom.metadata["residue_number"] == "2"
+            assert atom.metadata["insertion_code"] == "A"
+            assert atom.metadata["residue_name"] == "BNZ"
+
     @pytest.mark.xfail(reason="Broken because of splitting non-bonded forces")
     @pytest.mark.slow()
     def test_combine_nonbonded_forces(self, sage):

--- a/openff/interchange/_tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/_tests/unit_tests/components/test_interchange.py
@@ -305,13 +305,14 @@ class TestInterchange(_BaseTest):
 
     @skip_if_missing("nglview")
     @skip_if_missing("openmm")
-    def test_visualize(self, sage):
+    @pytest.mark.parametrize("include_virtual_sites", [True, False])
+    def test_visualize(self, include_virtual_sites, tip4p, sage):
         import nglview
 
-        molecule = Molecule.from_smiles("CCO")
+        molecule = Molecule.from_smiles("O")
 
         out = Interchange.from_smirnoff(
-            force_field=sage,
+            force_field=tip4p if include_virtual_sites else sage,
             topology=molecule.to_topology(),
         )
 
@@ -324,7 +325,10 @@ class TestInterchange(_BaseTest):
         molecule.generate_conformers(n_conformers=1)
         out.positions = molecule.conformers[0]
 
-        assert isinstance(out.visualize(), nglview.NGLWidget)
+        assert isinstance(
+            out.visualize(include_virtual_sites=include_virtual_sites),
+            nglview.NGLWidget,
+        )
 
 
 @skip_if_missing("openmm")

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
@@ -96,11 +96,11 @@ class TestFromOpenMM(_BaseTest):
         """
         monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
         pdb = openmm.app.PDBFile(
-            get_data_file_path("ALA_GLY/ALA_GLY.pdb", "openff.interchange._tests.data")
+            get_data_file_path("ALA_GLY/ALA_GLY.pdb", "openff.interchange._tests.data"),
         )
         interchange = Interchange.from_openmm(topology=pdb.topology)
         off_top = Topology.from_pdb(
-            get_data_file_path("ALA_GLY/ALA_GLY.pdb", "openff.interchange._tests.data")
+            get_data_file_path("ALA_GLY/ALA_GLY.pdb", "openff.interchange._tests.data"),
         )
         for roundtrip_atom, off_atom in zip(interchange.topology.atoms, off_top.atoms):
             # off_atom's metadata also includes a little info about how the chemistry was

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
@@ -1,6 +1,6 @@
-import numpy
 import random
 
+import numpy
 import pytest
 from openff.units import unit
 from openff.utilities import has_package, skip_if_missing
@@ -52,6 +52,7 @@ class TestFromOpenMM(_BaseTest):
 
         assert isinstance(converted.box.m, numpy.ndarray)
         assert converted.box.m.dtype is float
+
 
 @skip_if_missing("openmm")
 class TestConvertNonbondedForce:

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
@@ -1,3 +1,4 @@
+import numpy
 import random
 
 import pytest
@@ -49,6 +50,8 @@ class TestFromOpenMM(_BaseTest):
             },
         )
 
+        assert isinstance(converted.box.m, numpy.ndarray)
+        assert converted.box.m.dtype is float
 
 @skip_if_missing("openmm")
 class TestConvertNonbondedForce:

--- a/openff/interchange/components/_viz.py
+++ b/openff/interchange/components/_viz.py
@@ -1,0 +1,27 @@
+import uuid
+from io import StringIO
+
+from openff.toolkit.utils._viz import TopologyNGLViewStructure
+
+from openff.interchange import Interchange
+
+
+class InterchangeNGLViewStructure(TopologyNGLViewStructure):
+    """Subclass of the toolkit's NGLView interface."""
+
+    def __init__(
+        self,
+        interchange: Interchange,
+        ext: str = "PDB",
+    ):
+        self.interchange = interchange
+        self.ext = ext.lower()
+        self.params: dict = dict()
+        self.id = str(uuid.uuid4())
+
+    def get_structure_string(self) -> str:
+        """Get structure as a string."""
+        with StringIO() as f:
+            self.interchange.to_pdb(f, include_virtual_sites=True)
+            structure_string = f.getvalue()
+        return structure_string

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -327,7 +327,7 @@ class Interchange(DefaultModel):
 
                 # but don't modify them long-term
                 # work around https://github.com/openforcefield/openff-toolkit/issues/1820
-                if original_positions:
+                if original_positions is not None:
                     self.topology.set_positions(original_positions)
                 else:
                     for molecule in self.topology.molecules:

--- a/openff/interchange/components/toolkit.py
+++ b/openff/interchange/components/toolkit.py
@@ -113,11 +113,20 @@ def _simple_topology_from_openmm(openmm_topology: "openmm.app.Topology") -> Topo
     # TODO: Residue metadata
     # TODO: Splice in fully-defined OpenFF `Molecule`s?
     graph = nx.Graph()
-
+    # TODO: This is nearly identical to Topology._openmm_topology_to_networkx.
+    #  Should this method be replaced with a direct call to that?
     for atom in openmm_topology.atoms():
         graph.add_node(
             atom.index,
             atomic_number=atom.element.atomic_number,
+            name=atom.name,
+            residue_name=atom.residue.name,
+            # Note that residue number is mapped to residue.id here. The use of id vs. number varies in other packages
+            # and the convention for the OpenFF-OpenMM interconversion is recorded at
+            # https://docs.openforcefield.org/projects/toolkit/en/0.15.1/users/molecule_conversion.html
+            residue_number=atom.residue.id,
+            insertion_code=atom.residue.insertionCode,
+            chain_id=atom.residue.chain.id,
         )
 
     for bond in openmm_topology.bonds():

--- a/openff/interchange/components/toolkit.py
+++ b/openff/interchange/components/toolkit.py
@@ -2,13 +2,11 @@
 
 from typing import TYPE_CHECKING, Union
 
-import networkx as nx
-import numpy as np
-from openff.toolkit import Molecule, Topology
+import networkx
+import numpy
+from openff.toolkit import ForceField, Molecule, Quantity, Topology
 from openff.toolkit.topology._mm_molecule import _SimpleMolecule
-from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.toolkit.utils.collections import ValidatedList
-from openff.units import Quantity
 from openff.utilities.utilities import has_package
 
 if has_package("openmm") or TYPE_CHECKING:
@@ -66,7 +64,7 @@ def _validated_list_to_array(validated_list: "ValidatedList") -> "Quantity":
     from openff.units import unit
 
     unit_ = validated_list[0].units
-    return unit.Quantity(np.asarray([val.m for val in validated_list]), unit_)
+    return unit.Quantity(numpy.asarray([val.m for val in validated_list]), unit_)
 
 
 def _combine_topologies(topology1: Topology, topology2: Topology) -> Topology:
@@ -110,9 +108,10 @@ def _check_electrostatics_handlers(force_field: "ForceField") -> bool:
 
 def _simple_topology_from_openmm(openmm_topology: "openmm.app.Topology") -> Topology:
     """Convert an OpenMM Topology into an OpenFF Topology consisting **only** of so-called `_SimpleMolecule`s."""
-    # TODO: Residue metadata
     # TODO: Splice in fully-defined OpenFF `Molecule`s?
-    graph = nx.Graph()
+
+    graph = networkx.Graph()
+
     # TODO: This is nearly identical to Topology._openmm_topology_to_networkx.
     #  Should this method be replaced with a direct call to that?
     for atom in openmm_topology.atoms():
@@ -138,10 +137,11 @@ def _simple_topology_from_openmm(openmm_topology: "openmm.app.Topology") -> Topo
     return _simple_topology_from_graph(graph)
 
 
-def _simple_topology_from_graph(graph: nx.Graph) -> Topology:
+def _simple_topology_from_graph(graph: networkx.Graph) -> Topology:
+    """Convert a networkx Graph into an OpenFF Topology consisting only of `_SimpleMolecule`s."""
     topology = Topology()
 
-    for component in nx.connected_components(graph):
+    for component in networkx.connected_components(graph):
         subgraph = graph.subgraph(component)
         topology.add_molecule(_SimpleMolecule._from_subgraph(subgraph))
 

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -163,7 +163,9 @@ def _convert_nonbonded_force(
         vdw.key_map.update({top_key: pot_key})
         vdw.potentials.update({pot_key: pot})
 
-        pot_key = PotentialKey(id=f"{idx}", associated_handler="Electrostatics")
+        # This quacks like it's from a library charge, but tracks that it's
+        # not actually coming from a source
+        pot_key = PotentialKey(id=f"{idx}", associated_handler="ExternalSource")
         electrostatics.key_map.update({top_key: pot_key})
         electrostatics.potentials.update(
             {pot_key: Potential(parameters={"charge": from_openmm_quantity(charge)})},

--- a/openff/interchange/interop/openmm/_topology.py
+++ b/openff/interchange/interop/openmm/_topology.py
@@ -24,8 +24,8 @@ def to_openmm_topology(
     from collections import defaultdict
 
     from openff.toolkit.topology import Topology
-    from openff.toolkit.topology.molecule import Bond
     from openff.toolkit.topology._mm_molecule import _SimpleBond
+    from openff.toolkit.topology.molecule import Bond
 
     from openff.interchange.interop._virtual_sites import (
         _virtual_site_parent_molecule_mapping,

--- a/openff/interchange/interop/openmm/_topology.py
+++ b/openff/interchange/interop/openmm/_topology.py
@@ -25,6 +25,7 @@ def to_openmm_topology(
 
     from openff.toolkit.topology import Topology
     from openff.toolkit.topology.molecule import Bond
+    from openff.toolkit.topology._mm_molecule import _SimpleBond
 
     from openff.interchange.interop._virtual_sites import (
         _virtual_site_parent_molecule_mapping,
@@ -155,6 +156,9 @@ def to_openmm_topology(
                 else:
                     bond_type = bond_types[bond.bond_order]
                 bond_order = bond.bond_order
+            elif isinstance(bond, _SimpleBond):
+                bond_type = None
+                bond_order = None
             else:
                 raise RuntimeError(
                     "Unexpected bond type found while iterating over Topology.bonds."

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -350,6 +350,7 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
                         "LibraryCharges",
                         "ToolkitAM1BCCHandler",
                         "charge_from_molecules",
+                        "ExternalSource",
                     ):
                         charges[atom_index] = _add_charges(
                             charges.get(atom_index, _ZERO_CHARGE),


### PR DESCRIPTION
### Description

Related to https://github.com/openforcefield/openff-toolkit/pull/1818

### Checklist

- [x] Fix #879
- [x] Fix #858
- [x] Preserve atom metadata in OpenMM roundtrip
- [x] Do not write `_tmp_pdb_file.pdb` to user's disk when visualizing
- [x] Fall back to `Topology.visualize` when virtual sites are not included
- [x] Lint
- [ ] Update docstrings
