### PR TITLE
Fix `[ settles ]` distances when bond parameters are present

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,10 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## 0.3.22 - 2023-02-27
+
+* #912 Fixes a bug in which rigid water geometries were incorrectly written to GROMACS files.
+
 ## 0.3.21 - 2023-02-20
 
 * #906 Fixes a bug in which intramolecular interactions between virtual sites were not properly excluded with OpenMM.

--- a/openff/interchange/_tests/unit_tests/interop/gromacs/export/test_export.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/export/test_export.py
@@ -62,7 +62,7 @@ class TestSettles:
         settles = system.molecule_types["WAT"].settles[0]
 
         assert settles.oxygen_hydrogen_distance.m_as(unit.angstrom) == pytest.approx(
-            0.981124525388,
+            0.9572,
         )
         assert settles.hydrogen_hydrogen_distance.m_as(unit.angstrom) == pytest.approx(
             1.513900654525,

--- a/openff/interchange/_tests/unit_tests/smirnoff/test_gromacs.py
+++ b/openff/interchange/_tests/unit_tests/smirnoff/test_gromacs.py
@@ -40,6 +40,10 @@ class TestSettles:
     def tip3p_interchange(self, tip3p, water):
         return tip3p.create_interchange(water.to_topology())
 
+    @pytest.fixture()
+    def sage_tip3p_interchange(self, sage, water):
+        return sage.create_interchange(water.to_topology())
+
     def test_catch_other_water_ordering(self, tip3p):
         molecule = Molecule.from_mapped_smiles("[H:1][O:2][H:3]")
         interchange = tip3p.create_interchange(molecule.to_topology())
@@ -51,14 +55,27 @@ class TestSettles:
                 interchange,
             )
 
-    def test_convert_settles(self, tip3p_interchange):
+    @pytest.mark.parametrize("use_bundled_tip3p", [True, False])
+    def test_convert_settles(
+        self,
+        use_bundled_tip3p,
+        tip3p_interchange,
+        sage_tip3p_interchange,
+    ):
         molecule = GROMACSMolecule(name="foo")
 
-        _convert_settles(
-            molecule,
-            tip3p_interchange.topology.molecule(0),
-            tip3p_interchange,
-        )
+        if use_bundled_tip3p:
+            _convert_settles(
+                molecule,
+                tip3p_interchange.topology.molecule(0),
+                tip3p_interchange,
+            )
+        else:
+            _convert_settles(
+                molecule,
+                sage_tip3p_interchange.topology.molecule(0),
+                sage_tip3p_interchange,
+            )
 
         assert len(molecule.settles) == 1
 

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -647,23 +647,19 @@ def _convert_settles(
     for atom_pair in itertools.combinations(topology_atom_indices, 2):
         key = BondKey(atom_indices=atom_pair)
 
+        # Assume that SETTLES distances are defined by constraints, not bond lengths
         if key not in interchange["Constraints"].key_map:
             return
 
+        constraints = interchange["Constraints"]
+
         try:
             constraint_lengths.add(
-                interchange["Bonds"]
-                .potentials[interchange["Bonds"].key_map[key]]
-                .parameters["length"],
+                constraints.potentials[constraints.key_map[key]].parameters["distance"],
             )
-        # KeyError (subclass of LookupErrorR) when this BondKey is not found in the bond collection
-        # LookupError for the Interchange not having a bond collection
-        # in either case, look to the constraint collection for this distance
         except LookupError:
-            constraint_lengths.add(
-                interchange["Constraints"]
-                .potentials[interchange["Constraints"].key_map[key]]
-                .parameters["distance"],
+            raise RuntimeError(
+                f"Could not find a constraint distance for atoms {atom_pair=}.",
             )
 
     if len(constraint_lengths) != 2:


### PR DESCRIPTION
Resolves #911

When an `Interchange` has both bond parameters and constraints (with distances), constrained bonds are errneously given the bond length in the GROMACS `[ settles ]` section. SMIRNOFF says these should be given the constraint distances.

### Description

Provide a brief description of the PR's purpose here.

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
