### PR TITLE
Deprecate `Interchange.__add__`, rename to `Interchange.combine`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,10 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## Current development
+
+* #915 Deprecates `Interchange.__add__` in favor of `Interchange.combine`.
+
 ## 0.3.22 - 2023-02-27
 
 * #912 Fixes a bug in which rigid water geometries were incorrectly written to GROMACS files.

--- a/examples/host-guest/.gitignore
+++ b/examples/host-guest/.gitignore
@@ -1,0 +1,1 @@
+trajectory.dcd

--- a/examples/protein_ligand/protein_ligand.ipynb
+++ b/examples/protein_ligand/protein_ligand.ipynb
@@ -299,11 +299,11 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "Now that we have two interchanges, we can combine them with the `+` operator! We'll need a combined system to solvate too, so this'll be useful in a second.\n",
+    "Now that we have two interchanges, we can combine them with the `Interchange.combine` method! We'll need a combined system to solvate too, so this'll be useful in a second.\n",
     "\n",
     "<div class=\"alert alert-danger\" style=\"max-width: 700px; margin-left: auto; margin-right: auto;\">\n",
     "    <b>🚧 This code is not production-ready</b><br />\n",
-    "    The <code>+</code> operator is unstable and may break unexpectedly or be removed altogether at any time. In the future, OpenFF force fields will support biopolymers and combining Interchanges will be less necessary than at present. Don't combine force fields in production code.\n",
+    "    The <code>Interchange.combine</code> method is unstable and may break unexpectedly or be removed altogether at any time. In the future, OpenFF force fields will support biopolymers and combining Interchanges will be less necessary than at present. Don't combine force fields in production code.\n",
     "</div>"
    ]
   },
@@ -314,7 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docked_intrcg = protein_intrcg + ligand_intrcg"
+    "docked_intrcg = protein_intrcg.combine(ligand_intrcg)"
    ]
   },
   {
@@ -434,7 +434,7 @@
     "\n",
     "<div class=\"alert alert-danger\" style=\"max-width: 700px; margin-left: auto; margin-right: auto;\">\n",
     "    <b>🚧 This code is not production-ready</b><br />\n",
-    "    The <code>+</code> operator is unstable and under-tested and may break unexpectedly or be removed altogether.\n",
+    "    The <code>`Interchange.combine`</code> method is unstable and under-tested and may break unexpectedly or be removed altogether.\n",
     "</div>"
    ]
   },
@@ -445,7 +445,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system_intrcg = docked_intrcg + water_intrcg\n",
+    "system_intrcg = docked_intrcg.combine(water_intrcg)\n",
     "system_intrcg.positions = packed_topology.get_positions()\n",
     "system_intrcg.box = packed_topology.box_vectors"
    ]

--- a/examples/virtual_sites/.gitignore
+++ b/examples/virtual_sites/.gitignore
@@ -1,0 +1,1 @@
+trajectory.dcd

--- a/openff/interchange/_tests/test_deprecations.py
+++ b/openff/interchange/_tests/test_deprecations.py
@@ -33,3 +33,12 @@ class TestDeprecation:
             match="The `handlers` attribute is deprecated. Use `collections` instead.",
         ):
             prepared_system.handlers
+
+    def test_plus_operator_warning(self, monkeypatch, prepared_system):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+        with pytest.warns(
+            InterchangeDeprecationWarning,
+            match="combine.*instead",
+        ):
+            prepared_system + prepared_system

--- a/openff/interchange/_tests/unit_tests/components/test_interchange.py
+++ b/openff/interchange/_tests/unit_tests/components/test_interchange.py
@@ -114,7 +114,7 @@ class TestInterchange:
         other = deepcopy(interchange)
         other.positions += 1.0 * unit.nanometer
 
-        combined = interchange + other
+        combined = interchange.combine(other)
 
         # Just see if it can be converted into OpenMM and run
         get_openmm_energies(combined)
@@ -140,7 +140,7 @@ class TestInterchange:
 
         thf_interchange = make_interchange(thf)
         ace_interchange = make_interchange(ace)
-        complex_interchange = thf_interchange + ace_interchange
+        complex_interchange = thf_interchange.combine(ace_interchange)
 
         thf_vdw = thf_interchange["vdW"].get_system_parameters()
         ace_vdw = ace_interchange["vdW"].get_system_parameters()
@@ -168,11 +168,11 @@ class TestInterchange:
         ethane.generate_conformers(n_conformers=1)
         methane.generate_conformers(n_conformers=1)
 
-        assert (methane_interchange + ethane_interchange).positions is None
+        assert (methane_interchange.combine(ethane_interchange)).positions is None
         methane_interchange.positions = methane.conformers[0]
-        assert (methane_interchange + ethane_interchange).positions is None
+        assert (methane_interchange.combine(ethane_interchange)).positions is None
         ethane_interchange.positions = ethane.conformers[0]
-        assert (methane_interchange + ethane_interchange).positions is not None
+        assert (methane_interchange.combine(ethane_interchange)).positions is not None
 
     def test_input_topology_not_modified(self, sage):
         molecule = Molecule.from_smiles("CCO")

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -916,8 +916,19 @@ class Interchange(DefaultModel):
             )
 
     @experimental
-    def __add__(self, other):
-        """Combine two Interchange objects. This method is unstable and likely unsafe."""
+    def __add__(self, other: "Interchange") -> "Interchange":
+        """Combine two Interchange objects. This method is unstable and not yet unsafe."""
+        warnings.warn(
+            "The `+` operator is deprecated. Use `Interchange.combine` instead.",
+            InterchangeDeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.combine(other)
+
+    @experimental
+    def combine(self, other: "Interchange") -> "Interchange":
+        """Combine two Interchange objects. This method is unstable and not yet unsafe."""
         from openff.interchange.components.toolkit import _combine_topologies
 
         warnings.warn(


### PR DESCRIPTION
### Description

`Interchange.__add__` is deprecated, rerouting to a new method `Interchange.combine` that includes the same logic.

This change is motivated by two key factors:

* `object.__add__` is a little magical and might interact surprisingly with standard expectations of Python classes
* The `+` operator cannot take arguments or return extra information. This makes it impossible to pass optional settings to the function or clearly return information about any transformations, i.e. mapping of residue information between input and output.

Thanks to @richardjgowers for the suggestion

cc: @pbuslaev - this is a non-erroring renaming of the function, so if you were working on any tests please update the ` + `. The business logic should be unchanged as of now
### Checklist

- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
