### PR TITLE
Add tests with virtual sites and split forces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,9 @@ jobs:
 
     - name: Install OpenMM
       if: ${{ matrix.openmm == true }}
-      run: micromamba install openmm "smirnoff-plugins =2023" -c conda-forge
+      run: |
+        micromamba install openmm "smirnoff-plugins =2024" -c conda-forge
+        pip install git+https://github.com/jthorton/de-forcefields.git
 
     - name: Uninstall OpenMM
       if: ${{ matrix.openmm == false && matrix.openeye == true }}
@@ -101,7 +103,7 @@ jobs:
       if: always()
       run: |
         python -m pytest $COV openff/interchange/ \
-          -r fE -nauto --durations=10 \
+          -r fExs -nauto --durations=10 \
           -m "slow or not slow" \
           --ignore=openff/interchange/_tests/energy_tests/test_energies.py
 

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -28,6 +28,7 @@ dependencies:
   - pytest-xdist
   - pytest-randomly
   - mdanalysis
+  - de-forcefields
   # Drivers
   - gromacs =2023.3=nompi_*_103
   - lammps
@@ -35,10 +36,12 @@ dependencies:
   - panedr
   # Examples
   - nglview
-  - pytest =8.0
+  - pytest
   - nbval
   # Typing
   - mypy
   - typing-extensions
   - types-setuptools
   - pandas-stubs >=1.2.0.56
+  - pip:
+    - git+https://github.com/jthorton/de-forcefields.git

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -14,7 +14,7 @@ dependencies:
   - openff-toolkit =0.15.2
   - openff-interchange-base
   - openff-models
-  - smirnoff-plugins =2023
+  - smirnoff-plugins =2024
   # openff-nagl
   # openff-nagl-models
   # Optional features

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -30,6 +30,7 @@ dependencies:
   - pytest-randomly
   - nbval
   - mdanalysis
+  - de-forcefields
   # Drivers
   - gromacs =2023.3=nompi_*_103
   - lammps
@@ -52,3 +53,5 @@ dependencies:
   - flake8
   - snakeviz
   - tuna
+  - pip:
+    - git+https://github.com/jthorton/de-forcefields.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - mdtraj
   - intermol
   - jax
-  - pytest =8.0
+  - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-randomly

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,31 +11,32 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
-## Current development
+## 0.3.23 - 2024-03-07
 
 * #912 A warning is raised when writing an input/run file (not data file) to an engine that does not implement a switching function described by SMIRNOFF.
 * #916 Some internal code paths are re-organized, including removing the `openff.interchange.interop.internal` submodule.
 * #916 Improves speed of `Interchange.to_lammps`, particularly for larger systems.
+* #920 Fixes a bug in which virtual site exclusions were incorrect when using split non-bonded forces.
 * #915 Deprecates `Interchange.__add__` in favor of `Interchange.combine`.
 * #897 Improves energy evaluation with LAMMPS when some bonds are constrained.
 
-## 0.3.22 - 2023-02-27
+## 0.3.22 - 2024-02-27
 
 * #912 Fixes a bug in which rigid water geometries were incorrectly written to GROMACS files.
 * #909 Fixes a bug in which numerical values such as `scale_14` were lost when parsing JSON dumps.
 
-## 0.3.21 - 2023-02-20
+## 0.3.21 - 2024-02-20
 
 * #906 Fixes a bug in which intramolecular interactions between virtual sites were not properly excluded with OpenMM.
 * #901 `Interchange.from_openmm` now requires the `system` argument.
 * #903 The Python API of LAMMPS is now internally used for LAMMPS energy calculations.
 
-## 0.3.20 - 2023-02-12
+## 0.3.20 - 2024-02-12
 
 * #891 Adds support for hydrogen mass repartitioning (HMR) in GROMACS export. Note that this implementaiton never modifies masses in waters and requires the system contains no virtual sites.
 * #887 Adds support for hydrogen mass repartitioning (HMR) in OpenMM export. Note that this implementaiton never modifies masses in waters and requires the system contains no virtual sites.
 
-### 0.3.19 - 2023-02-05
+### 0.3.19 - 2024-02-05
 
 * #867 Tags `PotentialKey.virtual_site_type` with the associated type provided by SMIRNOFF parameters.
 * #857 Tags `PotentialKey.associated_handler` when importing data from OpenMM.

--- a/openff/interchange/_tests/data/hexanol-water.pdb
+++ b/openff/interchange/_tests/data/hexanol-water.pdb
@@ -1,0 +1,152 @@
+REMARK   1 CREATED WITH OPENMM 8.1.1, 2024-03-06
+HETATM    1  C1x UNK A   1       1.718   6.917   2.572  1.00  0.00           C  
+HETATM    2  C2x UNK A   1       0.930   5.618   2.455  1.00  0.00           C  
+HETATM    3  H1x UNK A   1       2.650   6.760   3.125  1.00  0.00           H  
+HETATM    4  O1x UNK A   1       2.030   7.415   1.280  1.00  0.00           O  
+HETATM    5  H2x UNK A   1       1.122   7.670   3.097  1.00  0.00           H  
+HETATM    6  C3x UNK A   1       1.736   4.511   1.769  1.00  0.00           C  
+HETATM    7  H3x UNK A   1       0.629   5.291   3.457  1.00  0.00           H  
+HETATM    8  H4x UNK A   1       0.016   5.799   1.876  1.00  0.00           H  
+HETATM    9  C4x UNK A   1       0.963   3.191   1.750  1.00  0.00           C  
+HETATM   10  H5x UNK A   1       1.977   4.808   0.742  1.00  0.00           H  
+HETATM   11  H6x UNK A   1       2.687   4.369   2.296  1.00  0.00           H  
+HETATM   12  C5x UNK A   1       1.755   2.093   1.040  1.00  0.00           C  
+HETATM   13  H7x UNK A   1       0.000   3.334   1.245  1.00  0.00           H  
+HETATM   14  H8x UNK A   1       0.745   2.880   2.779  1.00  0.00           H  
+HETATM   15  C6x UNK A   1       1.011   0.767   1.060  1.00  0.00           C  
+HETATM   16  H9x UNK A   1       1.943   2.385   0.000  1.00  0.00           H  
+HETATM   17 H10x UNK A   1       2.731   1.964   1.522  1.00  0.00           H  
+HETATM   18 H11x UNK A   1       0.038   0.855   0.567  1.00  0.00           H  
+HETATM   19 H12x UNK A   1       1.590   0.000   0.536  1.00  0.00           H  
+HETATM   20 H13x UNK A   1       0.846   0.426   2.087  1.00  0.00           H  
+HETATM   21 H14x UNK A   1       2.537   8.235   1.405  1.00  0.00           H  
+TER      22      UNK A   1
+HETATM   23  C1x UNK B   1       4.718   6.917   2.572  1.00  0.00           C  
+HETATM   24  C2x UNK B   1       3.930   5.618   2.455  1.00  0.00           C  
+HETATM   25  H1x UNK B   1       5.650   6.760   3.125  1.00  0.00           H  
+HETATM   26  O1x UNK B   1       5.030   7.415   1.280  1.00  0.00           O  
+HETATM   27  H2x UNK B   1       4.122   7.670   3.097  1.00  0.00           H  
+HETATM   28  C3x UNK B   1       4.736   4.511   1.769  1.00  0.00           C  
+HETATM   29  H3x UNK B   1       3.629   5.291   3.457  1.00  0.00           H  
+HETATM   30  H4x UNK B   1       3.016   5.799   1.876  1.00  0.00           H  
+HETATM   31  C4x UNK B   1       3.963   3.191   1.750  1.00  0.00           C  
+HETATM   32  H5x UNK B   1       4.977   4.808   0.742  1.00  0.00           H  
+HETATM   33  H6x UNK B   1       5.687   4.369   2.296  1.00  0.00           H  
+HETATM   34  C5x UNK B   1       4.755   2.093   1.040  1.00  0.00           C  
+HETATM   35  H7x UNK B   1       3.000   3.334   1.245  1.00  0.00           H  
+HETATM   36  H8x UNK B   1       3.745   2.880   2.779  1.00  0.00           H  
+HETATM   37  C6x UNK B   1       4.011   0.767   1.060  1.00  0.00           C  
+HETATM   38  H9x UNK B   1       4.943   2.385   0.000  1.00  0.00           H  
+HETATM   39 H10x UNK B   1       5.731   1.964   1.522  1.00  0.00           H  
+HETATM   40 H11x UNK B   1       3.038   0.855   0.567  1.00  0.00           H  
+HETATM   41 H12x UNK B   1       4.590   0.000   0.536  1.00  0.00           H  
+HETATM   42 H13x UNK B   1       3.846   0.426   2.087  1.00  0.00           H  
+HETATM   43 H14x UNK B   1       5.537   8.235   1.405  1.00  0.00           H  
+TER      44      UNK B   1
+HETATM   45  C1x UNK C   1       1.718   6.917   5.572  1.00  0.00           C  
+HETATM   46  C2x UNK C   1       0.930   5.618   5.455  1.00  0.00           C  
+HETATM   47  H1x UNK C   1       2.650   6.760   6.125  1.00  0.00           H  
+HETATM   48  O1x UNK C   1       2.030   7.415   4.280  1.00  0.00           O  
+HETATM   49  H2x UNK C   1       1.122   7.670   6.097  1.00  0.00           H  
+HETATM   50  C3x UNK C   1       1.736   4.511   4.769  1.00  0.00           C  
+HETATM   51  H3x UNK C   1       0.629   5.291   6.457  1.00  0.00           H  
+HETATM   52  H4x UNK C   1       0.016   5.799   4.876  1.00  0.00           H  
+HETATM   53  C4x UNK C   1       0.963   3.191   4.750  1.00  0.00           C  
+HETATM   54  H5x UNK C   1       1.977   4.808   3.742  1.00  0.00           H  
+HETATM   55  H6x UNK C   1       2.687   4.369   5.296  1.00  0.00           H  
+HETATM   56  C5x UNK C   1       1.755   2.093   4.040  1.00  0.00           C  
+HETATM   57  H7x UNK C   1       0.000   3.334   4.245  1.00  0.00           H  
+HETATM   58  H8x UNK C   1       0.745   2.880   5.779  1.00  0.00           H  
+HETATM   59  C6x UNK C   1       1.011   0.767   4.060  1.00  0.00           C  
+HETATM   60  H9x UNK C   1       1.943   2.385   3.000  1.00  0.00           H  
+HETATM   61 H10x UNK C   1       2.731   1.964   4.522  1.00  0.00           H  
+HETATM   62 H11x UNK C   1       0.038   0.855   3.567  1.00  0.00           H  
+HETATM   63 H12x UNK C   1       1.590   0.000   3.536  1.00  0.00           H  
+HETATM   64 H13x UNK C   1       0.846   0.426   5.087  1.00  0.00           H  
+HETATM   65 H14x UNK C   1       2.537   8.235   4.405  1.00  0.00           H  
+TER      66      UNK C   1
+HETATM   67  O1x UNK D   1       3.061  10.389   0.059  1.00  0.00           O  
+HETATM   68  H1x UNK D   1       3.724   9.688  -0.038  1.00  0.00           H  
+HETATM   69  H2x UNK D   1       2.215   9.923  -0.021  1.00  0.00           H  
+TER      70      UNK D   1
+HETATM   71  O1x UNK E   1       8.061  10.389   3.059  1.00  0.00           O  
+HETATM   72  H1x UNK E   1       8.724   9.688   2.962  1.00  0.00           H  
+HETATM   73  H2x UNK E   1       7.215   9.923   2.979  1.00  0.00           H  
+TER      74      UNK E   1
+HETATM   75  O1x UNK F   1       3.061  10.389   3.059  1.00  0.00           O  
+HETATM   76  H1x UNK F   1       3.724   9.688   2.962  1.00  0.00           H  
+HETATM   77  H2x UNK F   1       2.215   9.923   2.979  1.00  0.00           H  
+TER      78      UNK F   1
+CONECT    1    2    3    4    5
+CONECT    2    1    6    7    8
+CONECT    3    1
+CONECT    4    1   21
+CONECT    5    1
+CONECT    6    2    9   10   11
+CONECT    7    2
+CONECT    8    2
+CONECT    9    6   12   13   14
+CONECT   10    6
+CONECT   11    6
+CONECT   12    9   15   16   17
+CONECT   13    9
+CONECT   14    9
+CONECT   15   12   18   19   20
+CONECT   16   12
+CONECT   17   12
+CONECT   18   15
+CONECT   19   15
+CONECT   20   15
+CONECT   21    4
+CONECT   23   24   25   26   27
+CONECT   24   23   28   29   30
+CONECT   25   23
+CONECT   26   23   43
+CONECT   27   23
+CONECT   28   24   31   32   33
+CONECT   29   24
+CONECT   30   24
+CONECT   31   28   34   35   36
+CONECT   32   28
+CONECT   33   28
+CONECT   34   31   37   38   39
+CONECT   35   31
+CONECT   36   31
+CONECT   37   34   40   41   42
+CONECT   38   34
+CONECT   39   34
+CONECT   40   37
+CONECT   41   37
+CONECT   42   37
+CONECT   43   26
+CONECT   45   46   47   48   49
+CONECT   46   45   50   51   52
+CONECT   47   45
+CONECT   48   45   65
+CONECT   49   45
+CONECT   50   46   53   54   55
+CONECT   51   46
+CONECT   52   46
+CONECT   53   50   56   57   58
+CONECT   54   50
+CONECT   55   50
+CONECT   56   53   59   60   61
+CONECT   57   53
+CONECT   58   53
+CONECT   59   56   62   63   64
+CONECT   60   56
+CONECT   61   56
+CONECT   62   59
+CONECT   63   59
+CONECT   64   59
+CONECT   65   48
+CONECT   67   68   69
+CONECT   68   67
+CONECT   69   67
+CONECT   71   72   73
+CONECT   72   71
+CONECT   73   71
+CONECT   75   76   77
+CONECT   76   75
+CONECT   77   75
+END

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -501,9 +501,9 @@ def _create_exceptions(
             (
                 p1,
                 p2,
-                charge_prod,
                 _,
-                epsilon,
+                _,
+                _,
             ) = non_bonded_force.getExceptionParameters(exception_index)
 
             # Adding parent-(child of neighbor) exceptions from either p1 or p2
@@ -778,6 +778,7 @@ def _create_vdw_force(
         for _ in molecule.atoms:
             vdw_force.addParticle(vdw_collection.default_parameter_values())
 
+    for molecule in interchange.topology.molecules:
         if has_virtual_sites:
             molecule_index = interchange.topology.molecule_index(molecule)
             for _ in molecule_virtual_site_map[molecule_index]:
@@ -846,12 +847,16 @@ def _create_electrostatics_force(
         for _ in molecule.atoms:
             electrostatics_force.addParticle(0.0, 1.0, 0.0)
 
+    for molecule in interchange.topology.molecules:
         if has_virtual_sites:
             molecule_index = interchange.topology.molecule_index(molecule)
             for virtual_site_key in molecule_virtual_site_map[molecule_index]:
                 force_index = electrostatics_force.addParticle(0.0, 1.0, 0.0)
 
+                # this is an "OpenFF" index
                 parent_atom_index = virtual_site_key.orientation_atom_indices[0]
+
+                # this dict contains only "OpenMM" indices, so look through map
                 parent_virtual_particle_mapping[
                     openff_openmm_particle_map[parent_atom_index]
                 ].append(force_index)

--- a/openff/interchange/operations/minimize/openmm.py
+++ b/openff/interchange/operations/minimize/openmm.py
@@ -23,11 +23,12 @@ def minimize_openmm(
     from openff.units.openmm import from_openmm
 
     simulation = interchange.to_openmm_simulation(
-        openmm.LangevinMiddleIntegrator(
+        integrator=openmm.LangevinMiddleIntegrator(
             293.15 * openmm.unit.kelvin,
             1.0 / openmm.unit.picosecond,
             2.0 * openmm.unit.femtosecond,
         ),
+        combine_nonbonded_forces=False,
     )
 
     simulation.context.computeVirtualSites()


### PR DESCRIPTION
### Description

This change fixes the particle collation issue that caused #919

### Checklist

- [x] Add tests, ensuring the correct number and/or correct particulars of exceptions across some combination of
  - [x] Split forces with virtual sites
  - [x] Split forces with virtual sites and multiple molecules
  - [x] Split forces with multiple molecules, including a mix with and without virtual sites
  - [x] Split forces with virtual sites and non-12-6 vdW interactions
- [x] Lint
- [ ] Update docstrings
