### PR TITLE
Raise errors when `from_openmm` inputs are incompatible or unsupported

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## Current development
 
+* #923 An error is raised in `Interchange.from_openmm` when the topology and system are incompatible.
 * #912 A warning is raised when writing an input/run file (not data file) to an engine that does not implement a switching function described by SMIRNOFF.
 * #916 Some internal code paths are re-organized, including removing the `openff.interchange.interop.internal` submodule.
 * #916 Improves speed of `Interchange.to_lammps`, particularly for larger systems.

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_compat.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_compat.py
@@ -1,0 +1,54 @@
+"""Test compatibility checks in OpenMM import."""
+
+import re
+
+import pytest
+from openff.toolkit import Molecule, Quantity
+
+from openff.interchange.exceptions import UnsupportedImportError
+from openff.interchange.interop.openmm._import import from_openmm
+
+
+class TestUnsupportedCases:
+    def test_error_topology_mismatch(self, monkeypatch, sage_unconstrained, ethanol):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+        topology = ethanol.to_topology()
+        topology.box_vectors = Quantity([4, 4, 4], "nanometer")
+
+        other_topology = Molecule.from_smiles("O").to_topology()
+        other_topology.box_vectors = Quantity([4, 4, 4], "nanometer")
+
+        system = sage_unconstrained.create_openmm_system(topology)
+
+        # This should not error
+        from_openmm(system=system, topology=topology.to_openmm())
+
+        with pytest.raises(
+            UnsupportedImportError,
+            match=re.escape(
+                "The number of particles in the system (9) and "
+                "the number of atoms in the topology (3) do not match.",
+            ),
+        ):
+            from_openmm(
+                system=system,
+                topology=other_topology.to_openmm(),
+            )
+
+    def test_found_virtual_sites(self, monkeypatch, tip4p, water):
+        monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+        topology = water.to_topology()
+        topology.box_vectors = Quantity([4, 4, 4], "nanometer")
+
+        system = tip4p.create_openmm_system(topology)
+
+        with pytest.raises(
+            UnsupportedImportError,
+            match="A particle is a virtual site, which is not yet supported.",
+        ):
+            from_openmm(
+                system=system,
+                topology=topology.to_openmm(),
+            )

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -787,7 +787,7 @@ class Interchange(DefaultModel):
     @experimental
     def from_openmm(
         cls,
-        system: "openmm.System" = None,
+        system: "openmm.System",
         topology: Union["openmm.app.Topology", Topology, None] = None,
         positions: Union[Quantity, None] = None,
         box_vectors: Union[Quantity, None] = None,

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -16,6 +16,7 @@ from openff.interchange.exceptions import UnsupportedImportError
 from openff.interchange.interop.openmm._import._nonbonded import (
     BasicElectrostaticsCollection,
 )
+from openff.interchange.interop.openmm._import.compat import _check_compatible_inputs
 
 if has_package("openmm"):
     import openmm
@@ -33,14 +34,15 @@ if TYPE_CHECKING:
 @requires_package("openmm")
 @experimental
 def from_openmm(
+    system: "openmm.System",
     topology: Union["openmm.app.Topology", Topology, None] = None,
-    system: Union["openmm.System", None] = None,
     positions=None,
     box_vectors=None,
 ) -> "Interchange":
     """Create an Interchange object from OpenMM data."""
     from openff.interchange import Interchange
 
+    _check_compatible_inputs(system=system, topology=topology)
     interchange = Interchange()
 
     if system:

--- a/openff/interchange/interop/openmm/_import/compat.py
+++ b/openff/interchange/interop/openmm/_import/compat.py
@@ -1,0 +1,35 @@
+from typing import Union
+
+import openmm
+import openmm.app
+from openff.toolkit import Topology
+
+from openff.interchange.exceptions import UnsupportedImportError
+
+
+def _check_compatible_inputs(
+    system: openmm.System,
+    topology: Union[openmm.app.Topology, Topology, None],
+):
+    """Check that inputs are compatible and supported."""
+    for index in range(system.getNumParticles()):
+        if system.isVirtualSite(index):
+            raise UnsupportedImportError(
+                "A particle is a virtual site, which is not yet supported.",
+            )
+        if system.getParticleMass(index)._value == 0.0:
+            raise UnsupportedImportError(
+                "A particle has a mass of 0.0. Is this intentional?",
+            )
+
+    if isinstance(topology, Topology):
+        _topology = topology.to_openmm()
+    else:
+        _topology = topology
+
+    if _topology is not None:
+        if system.getNumParticles() != _topology.getNumAtoms():
+            raise UnsupportedImportError(
+                f"The number of particles in the system ({system.getNumParticles()}) and "
+                f"the number of atoms in the topology ({_topology.getNumAtoms()}) do not match.",
+            )

--- a/openff/interchange/interop/openmm/_import/compat.py
+++ b/openff/interchange/interop/openmm/_import/compat.py
@@ -17,10 +17,6 @@ def _check_compatible_inputs(
             raise UnsupportedImportError(
                 "A particle is a virtual site, which is not yet supported.",
             )
-        if system.getParticleMass(index)._value == 0.0:
-            raise UnsupportedImportError(
-                "A particle has a mass of 0.0. Is this intentional?",
-            )
 
     if isinstance(topology, Topology):
         _topology = topology.to_openmm()


### PR DESCRIPTION
### Description

#921 

### Checklist

- [x] Add tests
- [x] Lint
- [x] Update docstrings
