### PR TITLE
Optionally collate virtual site positions in getter

### DIFF
--- a/examples/ligand_in_water/ligand_in_water.ipynb
+++ b/examples/ligand_in_water/ligand_in_water.ipynb
@@ -454,7 +454,7 @@
    "id": "32",
    "metadata": {},
    "source": [
-    "From here we can create a new `Interchange` object - necessary since we're using a different force field - and use the `Interchange.to_gromacs` method to write GROMACS files."
+    "From here we can create a new `Interchange` object - only necessary since we're using a different force field - and use the `Interchange.to_gromacs` method to write GROMACS files. We'll also run an energy minimization before writing otu GROMACS files - this could also be done as an extra step with GROMACS, but it's convient to just call it from the Interchange API here."
    ]
   },
   {
@@ -464,27 +464,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Interchange.from_smirnoff(\n",
+    "out = Interchange.from_smirnoff(\n",
     "    force_field=sage_tip4p_fb,\n",
     "    topology=topology,\n",
-    ").to_gromacs(\"tip4p\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Cheat a little and use the final coordinates from the OPC simulation as a starting point;\n",
-    "# even though it's a different force field, it'll likely be a better starting configuration than naive packing\n",
-    "mdtraj.load(\"trajectory_opc.pdb\")[-1].save(\"tip4p.gro\")"
+    ")\n",
+    "\n",
+    "# could take a few seconds\n",
+    "out.minimize()\n",
+    "\n",
+    "out.to_gromacs(\"tip4p\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "34",
    "metadata": {},
    "source": [
     "Now, with GROMACS files written, we can use the bundled `run.mdp` file to compile and run a GROMACS simulation!"
@@ -493,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "36",
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -535,7 +528,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/openff/interchange/interop/_virtual_sites.py
+++ b/openff/interchange/interop/_virtual_sites.py
@@ -58,9 +58,12 @@ def _virtual_site_parent_molecule_mapping(
 
 def get_positions_with_virtual_sites(
     interchange: Interchange,
+    collate: bool = False,
     use_zeros: bool = False,
 ) -> Quantity:
     """Return the positions of all particles (atoms and virtual sites)."""
+    from openff.interchange.interop.common import _build_particle_map
+
     if interchange.positions is None:
         raise MissingPositionsError(
             f"Positions are required, found {interchange.positions=}.",
@@ -99,13 +102,62 @@ def get_positions_with_virtual_sites(
                 interchange["VirtualSites"],
             )
 
-        return numpy.concatenate(
-            [
-                interchange.positions,
-                virtual_site_positions,
-            ],
-        )
+        if collate:
+            # for i.e. a 4-site water dimer, these would be
 
+            # {
+            #   0: 0,
+            #   1: 1,
+            #   2: 2,
+            #   3: 3,
+            #   4: 4,
+            #   5: 5,
+            #   VirtualSiteKey with atom indices None: 6,
+            #   VirtualSiteKey with atom indices None: 7,
+            #   }
+            uncollated = _build_particle_map(
+                interchange=interchange,
+                molecule_virtual_site_map=molecule_virtual_site_map,
+                collate=False,
+            )
+
+            # {
+            #   0: 0,
+            #   1: 1,
+            #   2: 2,
+            #   VirtualSiteKey with atom indices None: 3,
+            #   3: 4:
+            #   4: 5,
+            #   5: 6,
+            #   VirtualSiteKey with atom indices None: 7,
+            #   }
+            collated = _build_particle_map(
+                interchange=interchange,
+                molecule_virtual_site_map=molecule_virtual_site_map,
+                collate=True,
+            )
+
+            # and so the mapping from collated to uncollated would be
+            # [0, 1, 2, 6, 3, 4, 5, 7]
+            uncollated_to_collated_mapping = [uncollated[key] for key in collated]
+
+            return numpy.concatenate(
+                [
+                    interchange.positions,
+                    virtual_site_positions,
+                ],
+            )[uncollated_to_collated_mapping]
+
+        else:
+            # could just pass it through a [0, 1, 3, 4, ...] mapping
+            # but that seems like a waste
+
+            return numpy.concatenate(
+                [
+                    interchange.positions,
+                    virtual_site_positions,
+                ],
+            )
     else:
         return interchange.positions
 

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -287,7 +287,11 @@ def _convert(
             get_positions_with_virtual_sites,
         )
 
-        system.positions = get_positions_with_virtual_sites(interchange)
+        system.positions = get_positions_with_virtual_sites(
+            interchange,
+            collate=True,
+        )
+
     else:
         system.positions = interchange.positions
 


### PR DESCRIPTION
### Description

This PR adds an argument to `get_positions_with_virtual_sites(..., collate=False)` which brings the logic up to date with the rest of the topological and physical information. This should resolve #931 and #941

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
