### PR TITLE
Restore link to Toolkit docs

### DIFF
--- a/docs/using/plugins.md
+++ b/docs/using/plugins.md
@@ -13,7 +13,7 @@ Currently, systems using custom interactions can only be exported to OpenMM. The
 
 ## Creating a custom `ParameterHandler`
 
-There is no formal specification for a `ParameterHandler` as processed by the OpenFF Toolkit, but there are some guidelines that are expected to be followed. A parameter handler requires both a [`ParameterHandler`] class, which performs parametrization, and a [`ParameterType`] class, which stores the corresponding data. For more information, see the Toolkit documentation.
+There is no formal specification for a `ParameterHandler` as processed by the OpenFF Toolkit, but there are some guidelines that are expected to be followed. A parameter handler requires both a [`ParameterHandler`] class, which performs parametrization, and a [`ParameterType`] class, which stores the corresponding data. For more information, see the [Toolkit documentation].
 
 The high-level objectives of a parameter handler are to:
 
@@ -48,6 +48,7 @@ The high-level objectives of a parameter handler are to:
 [`ParameterType`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterType
 [entry point group]: setuptools:userguide/entry_point
 [`check_handler_compatibility`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.check_handler_compatibility
+[Toolkit documentation]: openff.toolkit:developing
 
 ## Creating a custom `SMIRNOFFCollection`
 


### PR DESCRIPTION
### Description

This fixes the link mentioned in https://github.com/openforcefield/openff-interchange/pull/878/files#r1471815719

Unfortunately I'm not sure why the original link ever worked. MyST went through a stage of frequently breaking links, but I thought we were still on a version of MyST prior to that.

This PR restores the link, but makes it point to the whole Toolkit developer page instead of the particular subsection. If we want to point to the subsection, we need a PR to the Toolkit to give the subsection a reference anchor so that it appears in the Intersphinx inventory.

### Checklist

- [x] Lint
