### PR TITLE
Add non-water solvation helper function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     additional_dependencies: [
         'flake8-bugbear',
         'flake8-absolute-import',
-        'flake8-pytest-style',
+        'flake8-pytest-style==1',
         'flake8-no-pep420',
     ]
 - repo: https://github.com/asottile/pyupgrade

--- a/openff/interchange/_tests/interoperability_tests/components/test_packmol.py
+++ b/openff/interchange/_tests/interoperability_tests/components/test_packmol.py
@@ -1,0 +1,43 @@
+import pytest
+from openff.toolkit import Quantity
+
+from openff.interchange._tests import MoleculeWithConformer
+from openff.interchange.components._packmol import (
+    _find_packmol,
+    solvate_topology_nonwater,
+)
+from openff.interchange.drivers import get_openmm_energies
+
+
+@pytest.mark.slow()
+@pytest.mark.skipif(_find_packmol() is None, reason="PACKMOL not found")
+def test_solvate_ligand_in_nonwater(sage):
+    """
+    Test that a ligand can be solvated in a non-water solvent with a sane
+    starting point, like setting up a SFE run.
+
+    See uses of `solvate_topology` somewhere in openfe_skunkworks
+    """
+    pytest.importorskip("openmm")
+
+    # ibuprofen in hexanol
+    ligand = MoleculeWithConformer.from_smiles(
+        "CC(C)CC1=CC=C(C=C1)C(C)C(=O)O",
+        allow_undefined_stereo=True,
+    )
+    solvent = MoleculeWithConformer.from_smiles("CCCCCCO")
+
+    topology = solvate_topology_nonwater(
+        topology=ligand.to_topology(),
+        solvent=solvent,
+        padding=Quantity(0.8, "nanometer"),
+        target_density=Quantity(800, "kilogram / meter ** 3"),
+    )
+
+    interchange = sage.create_interchange(topology)
+
+    packed_energy = get_openmm_energies(interchange)
+
+    interchange.minimize(force_tolerance=Quantity(100, "kJ / mol / nm"))
+
+    assert get_openmm_energies(interchange).total_energy < packed_energy.total_energy

--- a/openff/interchange/_tests/unit_tests/components/test_packmol.py
+++ b/openff/interchange/_tests/unit_tests/components/test_packmol.py
@@ -5,9 +5,10 @@ Units tests for openff.interchange.components._packmol
 import numpy
 import pytest
 from openff.toolkit.topology import Molecule
-from openff.units import unit
+from openff.units import Quantity, unit
 from openff.utilities import has_package, skip_if_missing
 
+from openff.interchange._tests import MoleculeWithConformer
 from openff.interchange.components._packmol import (
     RHOMBIC_DODECAHEDRON,
     RHOMBIC_DODECAHEDRON_XYHEX,
@@ -17,6 +18,7 @@ from openff.interchange.components._packmol import (
     _scale_box,
     pack_box,
     solvate_topology,
+    solvate_topology_nonwater,
 )
 from openff.interchange.exceptions import PACKMOLRuntimeError, PACKMOLValueError
 
@@ -134,6 +136,20 @@ class TestPackmolWrapper:
                 molecules,
                 [2],
                 box_vectors=20 * numpy.identity(4) * unit.angstrom,
+            )
+
+    def test_packmol_bad_box_shape(self, molecules):
+        with pytest.raises(PACKMOLValueError, match=r"with shape \(3, 3\)"):
+            solvate_topology(
+                molecules[0].to_topology(),
+                box_shape=20 * numpy.identity(4) * unit.angstrom,
+            )
+
+        with pytest.raises(PACKMOLValueError, match=r"with shape \(3, 3\)"):
+            solvate_topology_nonwater(
+                molecules[0].to_topology(),
+                solvent=Molecule.from_smiles("CCCCCCO"),
+                box_shape=20 * numpy.identity(4) * unit.angstrom,
             )
 
     def test_packmol_underspecified(self, molecules):
@@ -349,6 +365,28 @@ class TestPackmolWrapper:
         assert (
             solvated_topology.box_vectors[2, 0] == solvated_topology.box_vectors[2, 1]
         )
+
+    def test_packmol_add_negative_solvent_mass(self):
+        ligand = MoleculeWithConformer.from_smiles("C1CN2C(=N1)SSC2=S")
+
+        with pytest.raises(
+            PACKMOLValueError,
+            match="Solute mass is greater than target mass",
+        ):
+            solvate_topology(
+                ligand.to_topology(),
+                target_density=Quantity(1e-6, "kilogram/meter**3"),
+            )
+
+        with pytest.raises(
+            PACKMOLValueError,
+            match="Solute mass is greater than target mass",
+        ):
+            solvate_topology_nonwater(
+                ligand.to_topology(),
+                solvent=Molecule.from_smiles("CCCCCCO"),
+                target_density=Quantity(1e-6, "kilogram/meter**3"),
+            )
 
     @pytest.mark.skipif(
         has_package("mdtraj"),


### PR DESCRIPTION
### Description

`solvate_topology` is written in a way that makes it fairly tricky to use non-water, so I grumble grumble made a new method. I was tempted to make the existing method `hydrate_topology` mirroring how people talk about solvation in water and non-water generally, but I don't think people use that language in system preparation steps.

This can all be done with `pack_box`, but this makes it a little easier.
 
### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
