### PR TITLE
Constrain to `openff-nagl ==0.3.6`

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   # OpenFF stack
   - openff-toolkit >=0.15.2
   - openff-models
-  - openff-nagl
+  - openff-nagl ~=0.3.7
   - openff-nagl-models
   # Optional features
   - jax

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -9,10 +9,10 @@ dependencies:
   - pydantic =2
   - openmm
   # OpenFF stack
-  - openff-toolkit =0.15.2
+  - openff-toolkit ~=0.15.2
   - openff-models
-  - openff-nagl ==0.3
-  - openff-nagl-models ==0.1
+  - openff-nagl ==0.3.6
+  - openff-nagl-models =0.1
   - dgl =1
   # Optional features
   - unyt
@@ -25,7 +25,7 @@ dependencies:
   - pdbfixer
   - nglview
   - openeye-toolkits >=2023.2
-  - pytest =8.0
+  - pytest =8
   - pytest-xdist
   - nbval
   - openmmforcefields >=0.11.2


### PR DESCRIPTION
### Description

Some funky stuff happened with 0.3.7; I don't doubt it'll be fixed soon, this just down-constrains to a slightly older version.
