### PR TITLE
Use better NAGL constraints

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   # OpenFF stack
   - openff-toolkit >=0.15.2
   - openff-models
-  - openff-nagl ~=0.3.7
+  - openff-nagl
   - openff-nagl-models
   # Optional features
   - jax

--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -12,8 +12,8 @@ dependencies:
   # OpenFF stack
   - openff-toolkit >=0.15.2
   - openff-models
-  - openff-nagl
-  - openff-nagl-models
+  - openff-nagl ~=0.3.7
+  - openff-nagl-models =0.1
   # Optional features
   - jax
   - unyt

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -11,8 +11,8 @@ dependencies:
   # OpenFF stack
   - openff-toolkit =0.15.2
   - openff-models
-  - openff-nagl ==0.3
-  - openff-nagl-models ==0.1
+  - openff-nagl ~=0.3.7
+  - openff-nagl-models =0.1
   - dgl =1
   # Optional features
   - unyt

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -9,10 +9,10 @@ dependencies:
   - pydantic =2
   - openmm
   # OpenFF stack
-  - openff-toolkit ~=0.15.2
+  - openff-toolkit =0.15.2
   - openff-models
-  - openff-nagl ==0.3.6
-  - openff-nagl-models =0.1
+  - openff-nagl ==0.3
+  - openff-nagl-models ==0.1
   - dgl =1
   # Optional features
   - unyt
@@ -25,7 +25,7 @@ dependencies:
   - pdbfixer
   - nglview
   - openeye-toolkits >=2023.2
-  - pytest =8
+  - pytest =8.0
   - pytest-xdist
   - nbval
   - openmmforcefields >=0.11.2

--- a/openff/interchange/_tests/unit_tests/smirnoff/test_nonbonded.py
+++ b/openff/interchange/_tests/unit_tests/smirnoff/test_nonbonded.py
@@ -12,6 +12,7 @@ from openff.toolkit.utils.exceptions import SMIRNOFFVersionError
 from packaging.version import Version
 
 from openff.interchange import Interchange
+from openff.interchange.exceptions import NonIntegralMoleculeChargeError
 from openff.interchange.smirnoff._nonbonded import (
     SMIRNOFFElectrostaticsCollection,
     _downconvert_vdw_handler,
@@ -227,6 +228,18 @@ class TestElectrostatics:
 
         compare_charges(original, get_charges_from_interchange(original))
         compare_charges(reordered, get_charges_from_interchange(reordered))
+
+
+def test_nonintegral_molecule_charge_error(sage, water):
+    funky_charges = Quantity([0, 0, -5.5], "elementary_charge")
+
+    water.partial_charges = funky_charges
+
+    with pytest.raises(
+        NonIntegralMoleculeChargeError,
+        match="net charge of -5.5 compared to a total formal charge of 0.0",
+    ):
+        sage.create_interchange(water.to_topology(), charge_from_molecules=[water])
 
 
 class TestSMIRNOFFChargeIncrements:

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -912,7 +912,7 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
                 else:
                     raise NonIntegralMoleculeChargeError(
                         f"Molecule {molecule.to_smiles(explicit_hydrogens=False)} has "
-                        f"a net charge of {charge_sum} compared to a total formal charge of ",
+                        f"a net charge of {charge_sum} compared to a total formal charge of "
                         f"{formal_sum}.",
                     )
 

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -912,7 +912,8 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
                 else:
                     raise NonIntegralMoleculeChargeError(
                         f"Molecule {molecule.to_smiles(explicit_hydrogens=False)} has "
-                        f"a net charge of {charge_sum}",
+                        f"a net charge of {charge_sum} compared to a total formal charge of ",
+                        f"{formal_sum}.",
                     )
 
             molecule.partial_charges = Quantity(


### PR DESCRIPTION
### Description

Follow-on to #957 

### Checklist

- [ ] Add tests
  - [ ] Actually test `NonIntegralMoleculeChargeError` - maybe requires passing `charge_from_molecules` through? Otherwise we'd be relying on a molecule/charge method combination that regularly gives bad charges