### PR TITLE
Ensure electrostatics "cutoff" is set in `from_openmm`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     exclude: openff/interchange/_version.py|setup.py
     args: ["--py310-plus"]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.7
+  rev: v0.4.1
   hooks:
     - id: ruff
       args: ["check", "--select", "NPY"]

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,10 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## Current development
+
+* #972 Fixes a bug in which PME electrostatics "cutoffs" were not parsed in `from_openmm`.
+
 ## 0.3.26 - 2024-04-16
 
 * #952 Drops support for Python 3.9.

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -216,6 +216,7 @@ def _convert_nonbonded_force(
 
     if force.getNonbondedMethod() == 4:
         vdw.cutoff = force.getCutoffDistance()
+        electrostatics.cutoff = force.getCutoffDistance()
     else:
         raise UnsupportedImportError(
             f"Parsing a non-bonded force of type {type(force)} with {force.getNonbondedMethod()} not yet supported.",


### PR DESCRIPTION
### Description

Resolves #971 

At some point I recently set the default "cutoff" of the base electrostatics class to 10 A, differing from SMIRNOFF's 9 A, partially because it's OpenMM's default but mostly to avoid it drifting away from really being a base class. Previously they were all set to 9 A so this conflict never arose; now it's as simple as setting it when parsing. This will surely get more complicated when we consider non-PME settings.

### Checklist

- [ ] Add tests
- [x] Lint
- [ ] Update docstrings
