### PR TITLE
More directly parse packed coordinates

### DIFF
--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -788,7 +788,7 @@ def _load_positions(output_file_path) -> NDArray:
             [
                 [line[31:39], line[39:46], line[47:54]]
                 for line in open(output_file_path).readlines()
-                if line.startswith("HETATM")
+                if line.startswith("HETATM") or line.startswith("ATOM")
             ],
             dtype=numpy.float32,
         )


### PR DESCRIPTION
### Description

This is a simpler, and I think better, fix for #984 than #985

I did some rough benchmarking and for systems between 100,000 and 1,000,000 atoms, the time it takes to load coordinates is several of orders of magnitude less than the time it takes to actually pack the coordinates. So I'm not worried about optimizing this one-liner right now.