### PR TITLE
Fix to non-unique LAMMPS molecule IDs

### DIFF
--- a/openff/interchange/interop/lammps/export/export.py
+++ b/openff/interchange/interop/lammps/export/export.py
@@ -294,7 +294,7 @@ def _write_atoms(lmp_file: IO, interchange: Interchange, atom_type_map: dict):
         atom_map[atom_index] = atom
 
     for molecule_index, molecule in enumerate(interchange.topology.molecules):
-        molecule_hash = f'{molecule_index}_{molecule.ordered_connection_table_hash()}' # salt with mol ID to allow chemically-identical Molecules to be labelled with distinct IDs)
+        molecule_hash = hash(f'{molecule_index}_{molecule.ordered_connection_table_hash()}') # salt with mol ID to allow chemically-identical Molecules to be labelled with distinct IDs)
         molecule_map[molecule_hash] = molecule_index
         for atom in molecule.atoms:
             atom_molecule_map[atom] = molecule_hash

--- a/openff/interchange/interop/lammps/export/export.py
+++ b/openff/interchange/interop/lammps/export/export.py
@@ -294,7 +294,9 @@ def _write_atoms(lmp_file: IO, interchange: Interchange, atom_type_map: dict):
         atom_map[atom_index] = atom
 
     for molecule_index, molecule in enumerate(interchange.topology.molecules):
-        molecule_hash = hash(f'{molecule_index}_{molecule.ordered_connection_table_hash()}') # salt with mol ID to allow chemically-identical Molecules to be labelled with distinct IDs)
+        molecule_hash = hash(
+            f"{molecule_index}_{molecule.ordered_connection_table_hash()}"
+        )  # salt with mol ID to allow chemically-identical Molecules to be labelled with distinct IDs)
         molecule_map[molecule_hash] = molecule_index
         for atom in molecule.atoms:
             atom_molecule_map[atom] = molecule_hash

--- a/openff/interchange/interop/lammps/export/export.py
+++ b/openff/interchange/interop/lammps/export/export.py
@@ -294,7 +294,7 @@ def _write_atoms(lmp_file: IO, interchange: Interchange, atom_type_map: dict):
         atom_map[atom_index] = atom
 
     for molecule_index, molecule in enumerate(interchange.topology.molecules):
-        molecule_hash = molecule.ordered_connection_table_hash()
+        molecule_hash = f'{molecule_index}_{molecule.ordered_connection_table_hash()}' # salt with mol ID to allow chemically-identical Molecules to be labelled with distinct IDs)
         molecule_map[molecule_hash] = molecule_index
         for atom in molecule.atoms:
             atom_molecule_map[atom] = molecule_hash


### PR DESCRIPTION
### Description

Addresses [issue 998](https://github.com/openforcefield/openff-interchange/issues/998), wherein distinct but chemically-identical molecules are forced to have the same molecule ID when writing the atom table section of LAMMPS files.

### Checklist

- [x] Add molecule_index to CTAB hash to ensure uniqueness
- [ ] Ensure this PR passes existing tests (single-line edit)
- [ ] Lint

