### PR TITLE
Fixes residue ID increment in GROMACS GRO files

### DIFF
--- a/openff/interchange/_tests/unit_tests/interop/gromacs/export/test_export.py
+++ b/openff/interchange/_tests/unit_tests/interop/gromacs/export/test_export.py
@@ -192,7 +192,7 @@ class TestGROMACSGROFile(_NeedsGROMACS):
         openmm_atom_names = openmm.app.GromacsGroFile("atom_names.gro").atomNames
 
         assert openmm_atom_names == pdb_atom_names
-        
+
     def test_residue_id_increment(self):
         """Test that residue IDs increment properly for multiple molecules."""
 
@@ -204,10 +204,12 @@ class TestGROMACSGROFile(_NeedsGROMACS):
         for atom in mol2.atoms:
             atom.metadata["residue_name"] = "MOL2"
 
-        interchange = Interchange.from_smirnoff(ForceField("openff-2.0.0.offxml"), [mol1, mol2])
+        interchange = Interchange.from_smirnoff(
+            ForceField("openff-2.0.0.offxml"), [mol1, mol2]
+        )
         interchange.to_gro("resid.gro")
 
-        with open("resid.gro", "r") as gro_file:
+        with open("resid.gro") as gro_file:
             lines = gro_file.readlines()
             residue_ids = {int(line[:5].strip()) for line in lines[2:-2]}
 

--- a/openff/interchange/interop/gromacs/export/_export.py
+++ b/openff/interchange/interop/gromacs/export/_export.py
@@ -445,6 +445,7 @@ class GROMACSWriter(DefaultModel):
         gro.write(f"{n_particles}\n")
 
         count = 0
+        residue_id = 1
         for molecule_name, molecule in self.system.molecule_types.items():
             n_copies = self.system.molecules[molecule_name]
 
@@ -456,7 +457,8 @@ class GROMACSWriter(DefaultModel):
                         f"%{decimal + 5}.{decimal}f"
                         f"%{decimal + 5}.{decimal}f\n"
                         % (
-                            atom.residue_index,  # This needs to be looked up from a different data structure
+                            residue_id = 1,
+                            # (hidden: 1013) atom.residue_index,  # This needs to be looked up from a different data structure
                             atom.residue_name[:5],
                             atom.name[:5],
                             (count + 1) % 100000,
@@ -467,6 +469,7 @@ class GROMACSWriter(DefaultModel):
                     )
 
                     count += 1
+                residue_id += 1
 
         if self.system.box is None:
             warnings.warn(


### PR DESCRIPTION
### Description

Addresses failure to increment the residue ID of identical molecule types in .gro files. Similar to #1000. 

### Checklist

- [x] Add tests
- [ ] Lint
- [ ] Update docstrings
