### PR TITLE
Fix indexing in vdW lookup of atoms in GROMACS export

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,9 +11,10 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
-## Current development
+## 0.3.29 - 2024-08-01
 
 * #1023 Fixes a bug in which non-bonded parameter lookup sometimes crashed when virtual sites were present.
+* #1018 #1019 Improve performance of `Interchange.to_top`, particularly after importing from OpenMM objects.
 
 ## 0.3.28 - 2024-07-17
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,10 @@ Dates are given in YYYY-MM-DD format.
 
 Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
 
+## Current development
+
+* #1023 Fixes a bug in which non-bonded parameter lookup sometimes crashed when virtual sites were present.
+
 ## 0.3.28 - 2024-07-17
 
 * #991 Fixes the virtual site example for upstream changes in virtual site parameter lookup.

--- a/openff/interchange/_tests/data/example-sigma-hole-bromine.offxml
+++ b/openff/interchange/_tests/data/example-sigma-hole-bromine.offxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <VirtualSites version="0.3" exclusion_policy="parents">
+        <!-- A chlorine bound to (any) carbon, for fixing sigma holes -->
+        <VirtualSite
+            smirks="[#6:2]-[#35X1:1]"
+            epsilon="0.0 * kilojoules_per_mole ** 1"
+            type="BondCharge"
+            match="all_permutations"
+            distance="1.45 * angstrom ** 1"
+            outOfPlaneAngle="None"
+            inPlaneAngle="None"
+            charge_increment1="-0.063 * elementary_charge ** 1"
+            charge_increment2="0.0 * elementary_charge ** 1"
+            sigma="0.0 * angstrom ** 1"
+            name="sigma_hole">
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>

--- a/openff/interchange/_tests/test_issues.py
+++ b/openff/interchange/_tests/test_issues.py
@@ -1,10 +1,16 @@
 """Tests reproducing specific issues that are otherwise uncategorized."""
 
+import random
+
+import numpy
 import parmed
-from openff.toolkit import ForceField, Molecule, Topology
+import pytest
+from openff.toolkit import ForceField, Molecule, Quantity, Topology
 from openff.utilities import get_data_file_path
 
-from openff.interchange._tests import MoleculeWithConformer
+from openff.interchange._tests import MoleculeWithConformer, shuffle_topology
+from openff.interchange.components._packmol import pack_box
+from openff.interchange.drivers import get_openmm_energies
 
 
 def test_issue_723():
@@ -18,7 +24,8 @@ def test_issue_723():
     parmed.load_file("_x.top")
 
 
-def test_issue_1022():
+@pytest.mark.parametrize("pack", [True, False])
+def test_issue_1022(pack):
 
     topology = Topology.from_molecules(
         [
@@ -34,12 +41,38 @@ def test_issue_1022():
         ],
     )
 
-    interchange = ForceField(
+    topology.box_vectors = Quantity(numpy.eye(3) * 10.0, "nanometer")
+
+    if pack:
+        topology = pack_box(
+            molecules=[*topology.unique_molecules],
+            number_of_copies=[1, 3, 1, 1],
+            box_vectors=topology.box_vectors,
+        )
+
+    force_field = ForceField(
         "openff-2.0.0.offxml",
         get_data_file_path(
             "example-sigma-hole-bromine.offxml",
             "openff.interchange._tests.data",
         ),
-    ).create_interchange(topology)
+    )
+
+    interchange = force_field.create_interchange(topology)
 
     interchange.to_top("tmp")
+
+    if pack:
+        for seed in random.sample(range(0, 10**10), 5):
+
+            # TODO: Compare GROMACS energies here as well
+            get_openmm_energies(interchange).compare(
+                get_openmm_energies(
+                    shuffle_topology(
+                        interchange,
+                        force_field,
+                        seed=seed,
+                    ),
+                ),
+                tolerances={"Nonbonded": Quantity("1e-3 kilojoule_per_mole")},
+            )

--- a/openff/interchange/_tests/test_issues.py
+++ b/openff/interchange/_tests/test_issues.py
@@ -1,7 +1,10 @@
 """Tests reproducing specific issues that are otherwise uncategorized."""
 
 import parmed
-from openff.toolkit import ForceField, Molecule
+from openff.toolkit import ForceField, Molecule, Topology
+from openff.utilities import get_data_file_path
+
+from openff.interchange._tests import MoleculeWithConformer
 
 
 def test_issue_723():
@@ -13,3 +16,30 @@ def test_issue_723():
     force_field.create_interchange(molecule.to_topology()).to_top("_x.top")
 
     parmed.load_file("_x.top")
+
+
+def test_issue_1022():
+
+    topology = Topology.from_molecules(
+        [
+            MoleculeWithConformer.from_smiles(smi)
+            for smi in [
+                "CBr",
+                "O",
+                "O",
+                "O",
+                "[Na+]",
+                "[Cl-]",
+            ]
+        ],
+    )
+
+    interchange = ForceField(
+        "openff-2.0.0.offxml",
+        get_data_file_path(
+            "example-sigma-hole-bromine.offxml",
+            "openff.interchange._tests.data",
+        ),
+    ).create_interchange(topology)
+
+    interchange.to_top("tmp")

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -133,11 +133,15 @@ def _convert(
             atom_type_name = f"{unique_molecule.name}_{particle_map[unique_molecule.atom_index(atom)]}"
             _atom_atom_type_map[atom] = atom_type_name
 
-            topology_index = particle_map[interchange.topology.atom_index(atom)]
+            # when looking up parameters, use the topology index, not the particle index ...
+            # ... or so I think is the expectation of the `TopologyKey`s in the vdW collection
+            topology_index = interchange.topology.atom_index(atom)
             key = TopologyKey(atom_indices=(topology_index,))
+
             vdw_parameters = vdw_collection.potentials[
                 vdw_collection.key_map[key]
             ].parameters
+
             charge = electrostatics_collection.charges[key]
 
             # Build atom types

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -389,6 +389,9 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
 
         for index, charge in charges.items():
             if type(index) is int:
+                # Note this uses the topology index, even if the particle index differs in an export,
+                # i.e. if a molecule earlier in the topology has (collated) virtual sites as is
+                # common with GROMACS files
                 returned_charges[TopologyKey(atom_indices=(index,))] = charge
             elif type(index) is VirtualSiteKey:
                 if include_virtual_sites:


### PR DESCRIPTION
### Description

Resolves #1022

I'm confused how the ligand-in-water example was working previously, since this may cause the incorrect non-bonded (both vdW and electrostatics) parameters to be looked up on molecules placed in a topology after a virtual site-bearing molecule.

### Checklist

- [x] Add tests
- [x] Lint
- [x] Update docstrings
