### PR TITLE
Test more cases of handling GROMACS residue IDs

### DIFF
--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -4,7 +4,7 @@ channels:
   - openeye
 dependencies:
   # Core
-  - python =3.10
+  - python
   - pip
   - numpy
   - pydantic =2
@@ -34,6 +34,8 @@ dependencies:
   # Drivers
   - gromacs
   - lammps >=2023.08.02
+  # https://github.com/conda-forge/lammps-feedstock/issues/207
+  - openmpi =4
   - panedr
   # Typing
   - mypy

--- a/openff/interchange/_tests/interoperability_tests/internal/test_gromacs.py
+++ b/openff/interchange/_tests/interoperability_tests/internal/test_gromacs.py
@@ -98,57 +98,6 @@ class TestGROMACSGROFile:
         with pytest.warns(UserWarning, match="gitlab"):
             out.to_gro("tmp.gro")
 
-    @pytest.mark.slow
-    @skip_if_missing("openmm")
-    def test_residue_info(self, sage):
-        """Test that residue information is passed through to .gro files."""
-        import mdtraj
-
-        protein = Molecule.from_polymer_pdb(
-            get_data_file_path(
-                "proteins/MainChain_HIE.pdb",
-                "openff.toolkit",
-            ),
-        )
-
-        ff14sb = ForceField("ff14sb_off_impropers_0.0.3.offxml")
-
-        out = Interchange.from_smirnoff(
-            force_field=ff14sb,
-            topology=[protein],
-        )
-
-        out.to_gro("tmp.gro")
-
-        mdtraj_topology = mdtraj.load("tmp.gro").topology
-
-        for found_residue, original_residue in zip(
-            mdtraj_topology.residues,
-            out.topology.hierarchy_iterator("residues"),
-        ):
-            assert found_residue.name == original_residue.residue_name
-            assert str(found_residue.resSeq) == original_residue.residue_number
-
-    @pytest.mark.slow
-    def test_atom_names_pdb(self):
-        peptide = Molecule.from_polymer_pdb(
-            get_data_file_path("proteins/MainChain_ALA_ALA.pdb", "openff.toolkit"),
-        )
-        ff14sb = ForceField("ff14sb_off_impropers_0.0.3.offxml")
-
-        Interchange.from_smirnoff(ff14sb, peptide.to_topology()).to_gro(
-            "atom_names.gro",
-        )
-
-        pdb_object = openmm.app.PDBFile(
-            get_data_file_path("proteins/MainChain_ALA_ALA.pdb", "openff.toolkit"),
-        )
-        pdb_atom_names = [atom.name for atom in pdb_object.topology.atoms()]
-
-        openmm_atom_names = openmm.app.GromacsGroFile("atom_names.gro").atomNames
-
-        assert openmm_atom_names == pdb_atom_names
-
 
 @needs_gmx
 class TestGROMACS:

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -330,7 +330,6 @@ class TestOpenMMVirtualSiteExclusions:
                     # Safeguard against some of the behavior seen in #919
                     for index in range(num_exceptions):
                         p1, p2, *_ = force.getExceptionParameters(index)
-                        print(p1, p2)
 
                         if sorted([p1, p2]) == [0, 3]:
                             raise Exception(

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -446,6 +446,8 @@ class Interchange(DefaultModel):
         Molecule names in written files are not guaranteed to match the `Moleclue.name` attribute of the
         molecules in the topology, especially if they are empty strings or not unique.
 
+        See `to_gro` and `to_top` for more details.
+
         """
         from openff.interchange.interop.gromacs.export._export import GROMACSWriter
         from openff.interchange.smirnoff._gromacs import _convert
@@ -504,6 +506,16 @@ class Interchange(DefaultModel):
             The path to the GROMACS coordinate file to write.
         decimal: int, default=3
             The number of decimal places to use when writing the GROMACS coordinate file.
+
+        Residue IDs must be positive integers (or string representations thereof).
+
+        Residue IDs greater than 99,999 are reduced modulo 100,000 in line with common GROMACS practice.
+
+        Residue names and IDs from the topology are used, if present, and otherwise are generated internally.
+
+        Behavior when some, but not all, residue names and IDs are present in the topology is undefined.
+
+        If residue IDs are generated internally, they are assigned sequentially to each molecule starting at 1.
 
         """
         from openff.interchange.interop.gromacs.export._export import GROMACSWriter

--- a/openff/interchange/interop/gromacs/export/_export.py
+++ b/openff/interchange/interop/gromacs/export/_export.py
@@ -200,7 +200,7 @@ class GROMACSWriter(DefaultModel):
                 top.write(
                     f"{atom.index :6d} "
                     f"{mapping_to_reduced_atom_types[atom.atom_type] :6s}"
-                    f"{atom.residue_index :8d} "
+                    f"{atom.residue_index % 100_000 :8d} "
                     f"{atom.residue_name :8s} "
                     f"{atom.name :6s}"
                     f"{atom.charge_group_number :6d}"
@@ -211,7 +211,7 @@ class GROMACSWriter(DefaultModel):
                 top.write(
                     f"{atom.index :6d} "
                     f"{atom.atom_type :6s}"
-                    f"{atom.residue_index :8d} "
+                    f"{atom.residue_index % 100_000 :8d} "
                     f"{atom.residue_name :8s} "
                     f"{atom.name :6s}"
                     f"{atom.charge_group_number :6d}"
@@ -448,15 +448,17 @@ class GROMACSWriter(DefaultModel):
         for molecule_name, molecule in self.system.molecule_types.items():
             n_copies = self.system.molecules[molecule_name]
 
-            for _ in range(n_copies):
+            for copy_index in range(n_copies):
+
                 for atom in molecule.atoms:
+
                     gro.write(
                         f"%5d%-5s%5s%5d"
                         f"%{decimal + 5}.{decimal}f"
                         f"%{decimal + 5}.{decimal}f"
                         f"%{decimal + 5}.{decimal}f\n"
                         % (
-                            atom.residue_index,  # This needs to be looked up from a different data structure
+                            (atom.residue_index + copy_index) % 100_000,
                             atom.residue_name[:5],
                             atom.name[:5],
                             (count + 1) % 100000,


### PR DESCRIPTION
### Description

Does something with #1016

Fixes #1028 

### Checklist

- [x] Add tests
  - [x] residue IDs offset from 1
  - [x] residue IDs not specified in input
  - [ ] some, but not all, residue IDs specified in input
  - [x] residue IDs > 99,999
  - [ ] discontinuous residue IDs
- [ ] Consider offering a way for users to re-index (i.e. to avoid zero or negative residue IDs)
- [x] Lint
- [x] Update docstrings
  - [x] Document current behavior and what is currently undefined