### PR TITLE
Fix ordering of charges in CHARGE section when using to_prmtop

### DIFF
--- a/openff/interchange/interop/amber/export/_export.py
+++ b/openff/interchange/interop/amber/export/_export.py
@@ -515,8 +515,8 @@ def to_prmtop(interchange: "Interchange", file_path: Path | str):
 
         prmtop.write("%FLAG CHARGE\n" "%FORMAT(5E16.8)\n")
         charges = [
-            charge.m_as(unit.e) * AMBER_COULOMBS_CONSTANT
-            for charge in interchange["Electrostatics"].charges.values()
+            atom.partial_charge.m_as(unit.e) * AMBER_COULOMBS_CONSTANT
+            for atom in interchange.topology.atoms
         ]
         text_blob = "".join([f"{val:16.8E}" for val in charges])
         _write_text_blob(prmtop, text_blob)


### PR DESCRIPTION
### Description
The ordering of the atomic charges in the CHARGE section of the .prmtop was wrong because we iterated over a dictionary. Now we excplicitly iterate over the atoms of interchange.topolgy to avoid this and fixes the following bug:

**Reproduction**
```python
from openff.toolkit import ForceField, Molecule
from openff.interchange import Interchange

water = Molecule.from_smiles("O")
topology = water.to_topology()

for i in range(2):
	topology.add_molecule(water)

sage = ForceField("openff-2.0.0.offxml")

interchange = Interchange.from_smirnoff(force_field=sage, topology=topology)
interchange.to_prmtop("test.prmtop")
```
**Output**
Among others, we can see the following entries in the test.prmtop file:

```
%FLAG ATOM_NAME
%FORMAT(20a4)
   O   H   H   O   H   H   O   H   H
...
%FLAG CHARGE
%FORMAT(5E16.8)
 -1.51973982E+01 -1.51973982E+01 -1.51973982E+01  7.59869910E+00  7.59869910E+00
  7.59869910E+00  7.59869910E+00  7.59869910E+00  7.59869910E+00
```
where the oxygen charges are listed first, which is wrong.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
