### PR TITLE
Fix access to `_NonbondedData` NamedTuple

### DIFF
--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -342,15 +342,15 @@ def _create_single_nonbonded_force(
             non_bonded_force.setNonbondedMethod(openmm.NonbondedForce.LJPME)
             non_bonded_force.setEwaldErrorTolerance(ewald_tolerance)
 
-        elif data["vdw_method"] == data["electrostatics_method"] == "cutoff":
-            if data["vdw_cutoff"] != data["electrostatics_collection"].cutoff:
+        elif data.vdw_method == data.electrostatics_method == "cutoff":
+            if data.vdw_cutoff != data.electrostatics_collection.cutoff:
                 raise UnsupportedExportError(
                     "If using cutoff vdW and electrostatics, cutoffs must match.",
                 )
 
             non_bonded_force.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
             non_bonded_force.setCutoffDistance(
-                to_openmm_quantity(data["vdw_cutoff"]),
+                to_openmm_quantity(data.vdw_cutoff),
             )
 
         else:
@@ -708,7 +708,7 @@ def _create_multiple_nonbonded_forces(
                             eps_14 = (eps1 * eps2) ** 0.5 * vdw_14
                         else:
                             raise UnsupportedExportError(
-                                f"Unsupported mixing rule: {data['mixing_rule']}",
+                                f"Unsupported mixing rule: {data.mixing_rule}",
                             )
 
                         # ... and set the 1-4 interactions


### PR DESCRIPTION
### Description

I'm not certain if `_NonbondedData` was implemented as a dictionary in earlier versions of the code, but it is now a `NamedTuple`. Therefore, it should be accessed using either integer indices or attribute names. This PR addresses this issue. The error I encountered was the following:

```python                                    │
│ /home/joaomorado/opt/micromamba/envs/fes-ml-dev/lib/python3.10/site-packages/openff/interchange/ │
│ interop/openmm/_nonbonded.py:345 in _create_single_nonbonded_force                               │
│                                                                                                  │
│    342 │   │   │   non_bonded_force.setNonbondedMethod(openmm.NonbondedForce.LJPME)              │
│    343 │   │   │   non_bonded_force.setEwaldErrorTolerance(ewald_tolerance)                      │
│    344 │   │                                                                                     │
│ ❱  345 │   │   elif data["vdw_method"] == data["electrostatics_method"] == "cutoff":             │
│    346 │   │   │   if data["vdw_cutoff"] != data["electrostatics_collection"].cutoff:            │
│    347 │   │   │   │   raise UnsupportedExportError(                                             │
│    348 │   │   │   │   │   "If using cutoff vdW and electrostatics, cutoffs must match.",        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: tuple indices must be integers or slices, not str
```