### PR TITLE
Test that atom names are processed in `Interchange.from_openmm`

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pydantic >=1.10.17,<3
   - openmm >=7.6
   # OpenFF stack
-  - openff-toolkit >=0.15.2
+  - openff-toolkit ~=0.16.4
   - openff-models
   - openff-nagl ~=0.3.7
   - openff-nagl-models =0.1

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pydantic =2
   - openmm
   # OpenFF stack
-  - openff-toolkit ~=0.16
+  - openff-toolkit ~=0.16.4
   - openff-interchange-base
   - openff-models
   - smirnoff-plugins =2024

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - numpy =1
   - pydantic =1.10.17
-  - openff-toolkit-base =0.15.2
+  - openff-toolkit-base ~=0.16.4
   - openff-models
   - openmm >=7.6
   - mbuild

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pydantic =2
   - openmm
   # OpenFF stack
-  - openff-toolkit
+  - openff-toolkit ~=0.16.4
   - openff-models
   - openff-nagl
   - openff-nagl-models

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pydantic >=1.10.17,<3
   # OpenFF stack
-  - openff-toolkit-base >=0.16  # make ~=0.16.4 on release
+  - openff-toolkit-base ~=0.16.4
   - openff-units
   - openff-models
   - ambertools =23
@@ -40,7 +40,3 @@ dependencies:
   - typing-extensions
   - types-setuptools
   - pandas-stubs
-  - pip:
-    # at 1395a6b6ce3dc48600dd7d8ed8a71301d26bbb47
-    # which should be 0.16.4
-    - git+https://github.com/openforcefield/openff-toolkit.git@main

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pydantic >=1.10.17,<3
   # OpenFF stack
-  - openff-toolkit-base >=0.16
+  - openff-toolkit-base >=0.16  # make ~=0.16.4 on release
   - openff-units
   - openff-models
   - ambertools =23
@@ -31,9 +31,16 @@ dependencies:
   # Drivers
   - gromacs
   - lammps >=2023.08.02
+  # shim for a build issue that's probably localized to conda-forge
+  # https://github.com/conda-forge/lammps-feedstock/issues/207
+  - openmpi =4
   - panedr
   # Typing
   - mypy
   - typing-extensions
   - types-setuptools
   - pandas-stubs
+  - pip:
+    # at 1395a6b6ce3dc48600dd7d8ed8a71301d26bbb47
+    # which should be 0.16.4
+    - git+https://github.com/openforcefield/openff-toolkit.git@main

--- a/openff/interchange/_tests/test_issues.py
+++ b/openff/interchange/_tests/test_issues.py
@@ -6,8 +6,9 @@ import numpy
 import parmed
 import pytest
 from openff.toolkit import ForceField, Molecule, Quantity, Topology
-from openff.utilities import get_data_file_path
+from openff.utilities import get_data_file_path, skip_if_missing
 
+from openff.interchange import Interchange
 from openff.interchange._tests import MoleculeWithConformer, shuffle_topology
 from openff.interchange.components._packmol import pack_box
 from openff.interchange.drivers import get_openmm_energies
@@ -76,3 +77,40 @@ def test_issue_1022(pack):
                 ),
                 tolerances={"Nonbonded": Quantity("1e-3 kilojoule_per_mole")},
             )
+
+
+@skip_if_missing("openmm")
+def test_issue_1031(monkeypatch):
+    import openmm.app
+
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+    # just grab some small PDB file from the toolkit, doesn't need to be huge, just
+    # needs to include some relevant atom names
+    openmm_topology = openmm.app.PDBFile(
+        get_data_file_path(
+            "proteins/MainChain_HIE.pdb",
+            "openff.toolkit",
+        ),
+    ).topology
+
+    openmm_atom_names = {atom.name for atom in openmm_topology.atoms()}
+
+    interchange = Interchange.from_openmm(
+        system=openmm.app.ForceField(
+            "amber99sb.xml",
+            "tip3p.xml",
+        ).createSystem(
+            openmm_topology,
+            nonbondedMethod=openmm.app.PME,
+        ),
+        topology=openmm_topology,
+    )
+
+    openff_atom_names = {atom.name for atom in interchange.topology.atoms}
+
+    assert sorted(openmm_atom_names) == sorted(openff_atom_names)
+
+    # check a few atom names to ensure these didn't end up being empty sets
+    for atom_name in ("NE2", "H3", "HA", "CH3", "CA", "CB", "CE1"):
+        assert atom_name in openff_atom_names


### PR DESCRIPTION
### Description

This PR adds a sort of regression test for the behavior observed in #1031. The fix is actually in the toolkit (though in a pinch it would have been possible to add some bubblegum-and-paperclips here) and is expected to land in release 0.16.4 early next week (8/19 or so).

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
