### PR TITLE
Update Sphinx to 6.1.2

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -20,8 +20,8 @@ dependencies:
   - myst-parser
   - numpydoc
   - autodoc-pydantic =2
-  - sphinx ~=4.4
+  - sphinx ~=5.3
   - sphinxcontrib-mermaid
   - sphinx-notfound-page
   - pip:
-    - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
+      - git+https://github.com/openforcefield/openff-sphinx-theme.git@main

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -20,7 +20,7 @@ dependencies:
   - myst-parser
   - numpydoc
   - autodoc-pydantic =2
-  - sphinx ~=5.3
+  - sphinx ==6.1.3
   - sphinxcontrib-mermaid
   - sphinx-notfound-page
   - pip:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ autodoc_mock_imports = ["jax"]
 autodoc_default_options = {
     "member-order": "bysource",
     "undoc-members": True,
-    "inherited-members": [],
+    "inherited-members": "",
     "show-inheritance": True,
 }
 autodoc_preserve_defaults = True
@@ -169,7 +169,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,2 @@
+[html writers]
+table-style: colwidths-grid

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-These instructions assume that the `mamba` package manager is installed. If you do not have Conda/Mamba or a drop-in replacement installed, see the [OpenFF installation documentation](openff.docs:install).
+These instructions assume that the `mamba` package manager is installed. If you do not have Conda/Mamba or a drop-in replacement installed, see the [OpenFF installation documentation](inv:openff.docs#install).
 
 ## Quick Installation
 

--- a/docs/using/plugins.md
+++ b/docs/using/plugins.md
@@ -8,7 +8,7 @@ Currently, systems using custom interactions can only be exported to OpenMM. The
 
 [`ParameterHandler`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler
 [`SMIRNOFFCollection`]: openff.interchange.plugins.SMIRNOFFCollection
-[SetupTools entry points]: setuptools:userguide/entry_point
+[SetupTools entry points]: inv:setuptools#userguide/entry_point
 [`openmm.Force`]: openmm.openmm.Force
 
 ## Creating a custom `ParameterHandler`
@@ -46,9 +46,9 @@ The high-level objectives of a parameter handler are to:
   * define optional attributes such as `id`
 
 [`ParameterType`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterType
-[entry point group]: setuptools:userguide/entry_point
+[entry point group]: inv:setuptools#userguide/entry_point
 [`check_handler_compatibility`]: openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.check_handler_compatibility
-[Toolkit documentation]: openff.toolkit:developing
+[Toolkit documentation]: inv:openff.toolkit#developing
 
 ## Creating a custom `SMIRNOFFCollection`
 

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -120,12 +120,14 @@ class Interchange(_BaseModel):
 
         Notes
         -----
-        If the `Molecule` objects in the `topology` argument each contain conformers, the returned `Interchange` object
-        will have its positions set via concatenating the 0th conformer of each `Molecule`.
+        If the ``Molecule`` objects in the ``topology`` argument each contain
+        conformers, the returned ``Interchange`` object will have its positions
+        set via concatenating the 0th conformer of each ``Molecule``.
 
-        If the `Molecule` objects in the `topology` argument have stored partial charges, these are ignored and charges
-        are assigned according to the contents of the force field. To override the force field and use preset charges,
-        use the `charge_from_molecules` argument.
+        If the ``Molecule`` objects in the ``topology`` argument have stored
+        partial charges, these are ignored and charges are assigned according to
+        the contents of the force field. To override the force field and use
+        preset charges, use the ``charge_from_molecules`` argument.
 
         Examples
         --------
@@ -342,7 +344,7 @@ class Interchange(_BaseModel):
         Molecule names in written files are not guaranteed to match the `Moleclue.name` attribute of the
         molecules in the topology, especially if they are empty strings or not unique.
 
-        See `to_gro` and `to_top` for more details.
+        See :py:meth:`to_gro <Interchange.to_gro>` and :py:meth:`to_top <Interchange.to_top>` for more details.
 
         """
         from openff.interchange.interop.gromacs.export._export import GROMACSWriter
@@ -429,6 +431,9 @@ class Interchange(_BaseModel):
             The path to the GROMACS coordinate file to write.
         decimal: int, default=3
             The number of decimal places to use when writing the GROMACS coordinate file.
+
+        Notes
+        -----
 
         Residue IDs must be positive integers (or string representations thereof).
 
@@ -569,9 +574,10 @@ class Interchange(_BaseModel):
         Parameters
         ----------
         collate
-            If False, the default, all virtual sites will be added to a single residue at the end of the topology.
-            If True, virtual sites will be collated with their associated molecule and added to the residue of the last
-            atom in the molecule they belong to.
+            If ``False``, the default, all virtual sites will be added to a
+            single residue at the end of the topology. If ``True``, virtual
+            sites will be collated with their associated molecule and added to
+            the residue of the last atom in the molecule they belong to.
 
         """
         from openff.interchange.interop.openmm._topology import to_openmm_topology
@@ -593,9 +599,14 @@ class Interchange(_BaseModel):
         **kwargs,
     ) -> "openmm.app.simulation.Simulation":
         """
-        Export this Interchange to an OpenMM `Simulation` object.
+        Export this Interchange to an OpenMM ``Simulation`` object.
 
-        Positions are set on the `Simulation` if present on the `Interchange`.
+        A :py:class:`Simulation <openmm.app.simulation.Simulation>` encapsulates
+        all the information needed for a typical OpenMM simulation into a single
+        object with a simple API.
+
+        Positions are set on the ``Simulation`` if present on the
+        ``Interchange``.
 
         Additional forces, such as a barostat, should be added with the
         ``additional_forces`` argument to avoid having to re-initialize


### PR DESCRIPTION
### Description

This PR updates Sphinx to a more recent version, as well as fixing a few rendering issues in the API docs. The main beneficial change here is that the API docs now have a right hand margin navigation menu, so users can quickly navigate to a field or function. Previously, this worked for modules but not classes.

![api_docs_side_nav](https://github.com/user-attachments/assets/d9e172a0-6edf-41d5-830f-16b618b84e4f)

I investigated updating further, but 6.2+ made changes to how privacy detection works that breaks our lazy loading subpackages. Curse Python for making modules and packages different!

I also investigated using a pre-commit hook to line wrap docstrings. I tried two formatters, [docformatter](https://github.com/PyCQA/docformatter) and [pydocstringformatter](https://github.com/DanielNoord/pydocstringformatter). Neither seemed to be able to reliably get docstrings to wrap to the correct width, and both introduced other changes I didn't like, so I haven't included them.

