### PR TITLE
Remove an extra `@experimental` decorator

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,10 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## Current development
 
+### Bug fixes
+
+* Removes an internal use of the `@experimental` decorator which prevented `Interchange.from_openmm` from being fully removed from an experimental state.
+
 ## 0.4.0 - 2024
 
 ### Breaking changes and behavior changes

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Union
 from openff.toolkit import Quantity, Topology
 from openff.utilities.utilities import has_package, requires_package
 
-from openff.interchange._experimental import experimental
 from openff.interchange.common._nonbonded import vdWCollection
 from openff.interchange.common._valence import (
     AngleCollection,
@@ -33,7 +32,6 @@ if TYPE_CHECKING:
 
 
 @requires_package("openmm")
-@experimental
 def from_openmm(
     *,
     system: "openmm.System",


### PR DESCRIPTION
I missed this at some point in 0.4.0 testing; the decorator was removed from `Interchange.from_openmm` but not this (internal) call.