### PR TITLE
Constrain `openmm =8.1.2` in tests

### DIFF
--- a/devtools/conda-envs/beta_env.yaml
+++ b/devtools/conda-envs/beta_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - numpy >=1.21
   - pydantic >=1.10.17,<3
-  - openmm >=7.6
+  - openmm
   # OpenFF stack
   - openff-toolkit ~=0.16.4
   - openff-nagl ~=0.3.7

--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - openff-units
   - ambertools =23
   # Optional features
-  - openmm
+  - openmm =8.1.2
   # smirnoff-plugins =2024
   # de-forcefields  # add back after smirnoff-plugins update
   - openff-nagl

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - numpy =1
   - pydantic =2
   - openff-toolkit-base ~=0.16.4
-  - openmm =8
+  - openmm =8.1.2
   - mbuild
   - foyer =1
   - nglview

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Needs to be explicitly listed to not be dropped when AmberTools is removed
   - rdkit
   # Optional features
-  - openmm
+  - openmm =8.1.2
   # smirnoff-plugins =2024
   # de-forcefields  # add back after smirnoff-plugins update
   - openff-nagl


### PR DESCRIPTION
### Description

Something changed in regression tests, but not in a way I can reproduce locally
