### PR TITLE
Optionally write GROMACS topologies as multiple `.itp` files

### DIFF
--- a/docs/using/output.md
+++ b/docs/using/output.md
@@ -34,6 +34,8 @@ interchange.to_gromacs("mysim")  # Produces the same three files
 
 Note that the MDP file generated is configured for a single-point energy calculation and must be modified to run other simulations.
 
+By default, the topology is written to as a monolithic file, which can be large. To split this into separate files with the `#include "molecule.itp"` convention, use `monolithic=False`. This produces a functionally equivalent topology file which splits non-bonded interactions into a file `mysim_nonbonded.itp` and each molecule's parameters in a separate file named according to the `Molecule.name` attribute.
+
 ## LAMMPS
 
 An [`Interchange`] object can be written to LAMMPS data and run input files with [`Interchange.to_lammps()`]

--- a/examples/protein_ligand/protein_ligand.ipynb
+++ b/examples/protein_ligand/protein_ligand.ipynb
@@ -566,7 +566,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system_intrcg.to_gromacs(prefix=\"out\")"
+    "system_intrcg.to_gromacs(prefix=\"out\", monolithic=False)"
    ]
   },
   {
@@ -703,7 +703,7 @@
  "metadata": {
   "category": "tutorial",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -717,12 +717,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "86c9b142c8dc60dd36d17e2a57efabbd2ed015b9d3db80dd77f3e0894d5aea85"
-   }
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/openff/interchange/_tests/_gromacs.py
+++ b/openff/interchange/_tests/_gromacs.py
@@ -1,0 +1,16 @@
+"""Helpers for testing GROMACS interoperability."""
+
+from openff.utilities import temporary_cd
+
+from openff.interchange import Interchange
+from openff.interchange.drivers import get_gromacs_energies
+
+
+def gmx_monolithic_vs_itp(state: Interchange):
+    with temporary_cd():
+        get_gromacs_energies(state, _monolithic=True).compare(get_gromacs_energies(state, _monolithic=False))
+
+        # TODO: More helpful handling of failures, i.e.
+        #         * Detect differences in positions
+        #         * Detect differences in box vectors
+        #         * Detect differences in non-bonded settings

--- a/openff/interchange/_tests/conftest.py
+++ b/openff/interchange/_tests/conftest.py
@@ -288,6 +288,21 @@ def gbsa_force_field() -> ForceField:
 
 
 @pytest.fixture
+def ff14sb() -> ForceField:
+    return ForceField("ff14sb_off_impropers_0.0.3.offxml")
+
+
+@pytest.fixture
+def ligand():
+    return MoleculeWithConformer.from_smiles("CC[C@@](/C=C\\[H])(C=C)O", allow_undefined_stereo=True)
+
+
+@pytest.fixture
+def caffeine():
+    return MoleculeWithConformer.from_smiles("Cn1cnc2c1c(=O)n(C)c(=O)n2C")
+
+
+@pytest.fixture
 def basic_top() -> Topology:
     topology = MoleculeWithConformer.from_smiles("C").to_topology()
     topology.box_vectors = Quantity([5, 5, 5], unit.nanometer)
@@ -469,27 +484,33 @@ def ethanol_top(ethanol):
 
 
 @pytest.fixture
-def mainchain_ala():
-    molecule = Molecule.from_file(
-        get_data_file_path("proteins/MainChain_ALA.sdf", "openff.toolkit"),
+def alanine_dipeptide() -> Topology:
+    return Topology.from_pdb(
+        get_data_file_path(
+            "proteins/MainChain_ALA_ALA.pdb",
+            "openff.toolkit",
+        ),
     )
-    molecule._add_default_hierarchy_schemes()
-    molecule.perceive_residues()
-    molecule.perceive_hierarchy()
-
-    return molecule
 
 
 @pytest.fixture
-def mainchain_arg():
-    molecule = Molecule.from_file(
-        get_data_file_path("proteins/MainChain_ARG.sdf", "openff.toolkit"),
-    )
-    molecule._add_default_hierarchy_schemes()
-    molecule.perceive_residues()
-    molecule.perceive_hierarchy()
+def mainchain_ala() -> Molecule:
+    return Topology.from_pdb(
+        get_data_file_path(
+            "proteins/MainChain_ALA.pdb",
+            "openff.toolkit",
+        ),
+    ).molecule(0)
 
-    return molecule
+
+@pytest.fixture
+def mainchain_arg() -> Molecule:
+    return Topology.from_pdb(
+        get_data_file_path(
+            "proteins/MainChain_ARG.pdb",
+            "openff.toolkit",
+        ),
+    ).molecule(0)
 
 
 @pytest.fixture

--- a/openff/interchange/_tests/interoperability_tests/gromacs/test_systems.py
+++ b/openff/interchange/_tests/interoperability_tests/gromacs/test_systems.py
@@ -1,0 +1,24 @@
+from openff.toolkit import Quantity
+
+from openff.interchange._tests._gromacs import gmx_monolithic_vs_itp
+
+
+def test_ligand_vacuum(caffeine, sage_unconstrained, monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+    topology = caffeine.to_topology()
+    topology.box_vectors = Quantity([4, 4, 4], "nanometer")
+
+    gmx_monolithic_vs_itp(sage_unconstrained.create_interchange(topology))
+
+
+def test_water_dimer(water_dimer, tip3p, monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+    gmx_monolithic_vs_itp(tip3p.create_interchange(water_dimer))
+
+
+def test_alanine_dipeptide(alanine_dipeptide, ff14sb, monkeypatch):
+    monkeypatch.setenv("INTERCHANGE_EXPERIMENTAL", "1")
+
+    gmx_monolithic_vs_itp(ff14sb.create_interchange(alanine_dipeptide))

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -1,5 +1,6 @@
 """An object for storing, manipulating, and converting molecular mechanics data."""
 
+import tempfile
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -323,6 +324,7 @@ class Interchange(_BaseModel):
         prefix: str,
         decimal: int = 3,
         hydrogen_mass: PositiveFloat = 1.007947,
+        monolithic: bool = True,
         _merge_atom_types: bool = False,
     ):
         """
@@ -339,6 +341,8 @@ class Interchange(_BaseModel):
             The mass to use for hydrogen atoms if not present in the topology. If non-trivially different
             than the default value, mass will be transferred from neighboring heavy atoms. Note that this is currently
             not applied to any waters and is unsupported when virtual sites are present.
+        monolithic: bool, default=False
+            Whether the topology file should be monolithic or reference individual .itp files.
         _merge_atom_types: bool, default = False
             The flag to define behaviour of GROMACSWriter. If True, then similar atom types will be merged.
             If False, each atom will have its own atom type.
@@ -360,7 +364,7 @@ class Interchange(_BaseModel):
             gro_file=prefix + ".gro",
         )
 
-        writer.to_top(_merge_atom_types=_merge_atom_types)
+        writer.to_top(monolithic=monolithic, _merge_atom_types=_merge_atom_types)
         writer.to_gro(decimal=decimal)
 
         self.to_mdp(prefix + "_pointenergy.mdp")
@@ -394,6 +398,7 @@ class Interchange(_BaseModel):
         self,
         file_path: Path | str,
         hydrogen_mass: PositiveFloat = 1.007947,
+        monolithic: bool = True,
         _merge_atom_types: bool = False,
     ):
         """
@@ -407,6 +412,8 @@ class Interchange(_BaseModel):
             The mass to use for hydrogen atoms if not present in the topology. If non-trivially different
             than the default value, mass will be transferred from neighboring heavy atoms. Note that this is currently
             not applied to any waters and is unsupported when virtual sites are present.
+        monolithic: bool, default=False
+            Whether the topology file should be monolithic or reference individual .itp files.
         _merge_atom_types: book, default=False
             The flag to define behaviour of GROMACSWriter. If True, then similar atom types will be merged.
             If False, each atom will have its own atom type.
@@ -423,7 +430,11 @@ class Interchange(_BaseModel):
         GROMACSWriter(
             system=_convert(self, hydrogen_mass=hydrogen_mass),
             top_file=file_path,
-        ).to_top(_merge_atom_types=_merge_atom_types)
+            gro_file=tempfile.NamedTemporaryFile(suffix=".gro").file.name,
+        ).to_top(
+            monolithic=monolithic,
+            _merge_atom_types=_merge_atom_types,
+        )
 
     def to_gro(self, file_path: Path | str, decimal: int = 3):
         """
@@ -456,6 +467,7 @@ class Interchange(_BaseModel):
         # TODO: Write the coordinates without the full conversion
         GROMACSWriter(
             system=_convert(self),
+            top_file=tempfile.NamedTemporaryFile(suffix=".top").file.name,
             gro_file=file_path,
         ).to_gro(decimal=decimal)
 

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -342,7 +342,8 @@ class Interchange(_BaseModel):
             than the default value, mass will be transferred from neighboring heavy atoms. Note that this is currently
             not applied to any waters and is unsupported when virtual sites are present.
         monolithic: bool, default=False
-            Whether the topology file should be monolithic or reference individual .itp files.
+            Whether the topology file should be monolithic (True) or reference individual .itp files (False). Note that
+            these individual .itp files rely on ad hoc atom types and cannot be transferred between systems.
         _merge_atom_types: bool, default = False
             The flag to define behaviour of GROMACSWriter. If True, then similar atom types will be merged.
             If False, each atom will have its own atom type.
@@ -413,7 +414,8 @@ class Interchange(_BaseModel):
             than the default value, mass will be transferred from neighboring heavy atoms. Note that this is currently
             not applied to any waters and is unsupported when virtual sites are present.
         monolithic: bool, default=False
-            Whether the topology file should be monolithic or reference individual .itp files.
+            Whether the topology file should be monolithic (True) or reference individual .itp files (False). Note that
+            these individual .itp files rely on ad hoc atom types and cannot be transferred between systems.
         _merge_atom_types: book, default=False
             The flag to define behaviour of GROMACSWriter. If True, then similar atom types will be merged.
             If False, each atom will have its own atom type.

--- a/openff/interchange/drivers/gromacs.py
+++ b/openff/interchange/drivers/gromacs.py
@@ -52,6 +52,7 @@ def get_gromacs_energies(
     round_positions: int = 8,
     detailed: bool = False,
     _merge_atom_types: bool = False,
+    _monolithic: bool = True,
 ) -> EnergyReport:
     """
     Given an OpenFF Interchange object, return single-point energies as computed by GROMACS.
@@ -83,6 +84,7 @@ def get_gromacs_energies(
             mdp=mdp,
             round_positions=round_positions,
             merge_atom_types=_merge_atom_types,
+            monolithic=_monolithic,
         ),
         detailed=detailed,
     )
@@ -93,6 +95,7 @@ def _get_gromacs_energies(
     mdp: str = "auto",
     round_positions: int = 8,
     merge_atom_types: bool = False,
+    monolithic: bool = True,
 ) -> dict[str, Quantity]:
     with tempfile.TemporaryDirectory() as tmpdir:
         with temporary_cd(tmpdir):
@@ -100,6 +103,7 @@ def _get_gromacs_energies(
             interchange.to_gromacs(
                 prefix=prefix,
                 decimal=round_positions,
+                monolithic=monolithic,
                 _merge_atom_types=merge_atom_types,
             )
 


### PR DESCRIPTION
### Description

Resolves #95

This is opt-in with a `monolithic=False` argument wired through various methods.

Currently, this splits out monolithic topology files into
* A single `f"{prefix}_atomtypes.itp` containing non-bonded parameters
  * Currently this is just `[ atomtypes ]` and I don't see anything else in `$CONDA_PREFIX/share/gromacs/top/*.ff/ffnonbonded.itp` that indicates other directives conventionally go here
* A `f"{prefix}_{molecule_name}.itp` file for each unique molecule type, containing each molecule type's atom types, charges, valence parameters, constraints, virtual sites, etc.
  * The molecule name is meant to be a canonicalized version of the `Molecule.name` attribute

I don't think this actually reduces the net file size on disk, barring sketchy force field re-use, but it does split it across several files which might make things more human-readable.

I doubt it's relevant to current OpenFE work but cc @hannahbaumann

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
