### PR TITLE
Always use `openmm.LangevinMiddleIntegrator`

### DIFF
--- a/examples/ligand_in_water/ligand_in_water.ipynb
+++ b/examples/ligand_in_water/ligand_in_water.ipynb
@@ -154,7 +154,7 @@
     "    pdb_stride: int = 500,\n",
     "    trajectory_name: str = \"trajectory.pdb\",\n",
     ") -> openmm.app.Simulation:\n",
-    "    integrator = openmm.LangevinIntegrator(\n",
+    "    integrator = openmm.LangevinMiddleIntegrator(\n",
     "        300 * openmm.unit.kelvin,\n",
     "        1 / openmm.unit.picosecond,\n",
     "        1 * openmm.unit.femtoseconds,\n",

--- a/examples/openmm/openmm.ipynb
+++ b/examples/openmm/openmm.ipynb
@@ -97,7 +97,7 @@
     "temperature = 300 * openmm.unit.kelvin  # simulation temperature\n",
     "friction = 1 / openmm.unit.picosecond  # friction constant\n",
     "\n",
-    "integrator = openmm.LangevinIntegrator(temperature, friction, time_step)"
+    "integrator = openmm.LangevinMiddleIntegrator(temperature, friction, time_step)"
    ]
   },
   {

--- a/examples/virtual_sites/virtual_sites.ipynb
+++ b/examples/virtual_sites/virtual_sites.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "    # interchange.minimize()\n",
     "\n",
-    "    integrator = openmm.LangevinIntegrator(\n",
+    "    integrator = openmm.LangevinMiddleIntegrator(\n",
     "        300 * openmm.unit.kelvin,\n",
     "        1 / openmm.unit.picosecond,\n",
     "        1 * openmm.unit.femtoseconds,\n",

--- a/openff/interchange/_tests/conftest.py
+++ b/openff/interchange/_tests/conftest.py
@@ -647,7 +647,11 @@ def default_integrator():
         import openmm
         import openmm.unit
 
-        return openmm.VerletIntegrator(2.0 * openmm.unit.femtosecond)
+        return openmm.LangevinMiddleIntegrator(
+            300 * openmm.unit.kelvin,
+            1 / openmm.unit.picosecond,
+            2.0 * openmm.unit.femtosecond,
+        )
 
     except ImportError:
         return None

--- a/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/_import/test_import.py
@@ -250,12 +250,16 @@ class TestFromOpenMM:
             },
         )
 
-    def test_only_constrained_water(self, water_dimer):
+    def test_only_constrained_water(
+        self,
+        water_dimer,
+        default_integrator,
+    ):
         water_dimer.box_vectors = Quantity([4, 4, 4], "nanometer")
 
         interchange = ForceField("openff-2.2.1.offxml").create_interchange(water_dimer)
 
-        simulation = interchange.to_openmm_simulation(integrator=openmm.LangevinIntegrator(300, 1, 0.001))
+        simulation = interchange.to_openmm_simulation(integrator=default_integrator)
         system = simulation.system
 
         for index in range(system.getNumForces()):

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_hmr.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_hmr.py
@@ -103,7 +103,11 @@ def test_hmr_not_applied_to_tip4p(
 
 
 @pytest.mark.parametrize("hydrogen_mass", [1.1, 3.0])
-def test_hmr_with_ligand_virtual_sites(sage_with_bond_charge, hydrogen_mass):
+def test_hmr_with_ligand_virtual_sites(
+    sage_with_bond_charge,
+    hydrogen_mass,
+    default_integrator,
+):
     """Test that a single-molecule sigma hole example runs"""
     pytest.importorskip("openmm")
     import openmm
@@ -113,7 +117,7 @@ def test_hmr_with_ligand_virtual_sites(sage_with_bond_charge, hydrogen_mass):
 
     # should work fine with 4 fs, but be conservative and just use 3 fs
     simulation = sage_with_bond_charge.create_interchange(molecule.to_topology()).to_openmm_simulation(
-        integrator=openmm.VerletIntegrator(3.0 * openmm.unit.femtosecond),
+        integrator=default_integrator,
         hydrogen_mass=hydrogen_mass,
     )
 

--- a/openff/interchange/_tests/unit_tests/smirnoff/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/smirnoff/test_virtual_sites.py
@@ -153,7 +153,11 @@ class TestSMIRNOFFVirtualSites:
 
         context = openmm.Context(
             system,
-            openmm.VerletIntegrator(1.0 * openmm.unit.femtosecond),
+            openmm.LangevinMiddleIntegrator(
+                300 * openmm.unit.kelvin,
+                1 / openmm.unit.picosecond,
+                2.0 * openmm.unit.femtosecond,
+            ),
             openmm.Platform.getPlatformByName("Reference"),
         )
 

--- a/openff/interchange/drivers/openmm.py
+++ b/openff/interchange/drivers/openmm.py
@@ -103,7 +103,12 @@ def _get_openmm_energies(
     for index, force in enumerate(system.getForces()):
         force.setForceGroup(index)
 
-    integrator = openmm.VerletIntegrator(1.0 * openmm.unit.femtoseconds)
+    integrator = openmm.LangevinMiddleIntegrator(
+        300 * openmm.unit.kelvin,
+        1.0 / openmm.unit.picosecond,
+        1.0 * openmm.unit.femtoseconds,
+    )
+
     context = openmm.Context(
         system,
         integrator,


### PR DESCRIPTION
### Description

Resolves #1096 and expands it a bit

### Checklist

- [x] Use `openmm.LangevinMiddleIntegrator` in OpenMM driver
- [x] Use `openmm.LangevinMiddleIntegrator` in tests
- [x] Use `openmm.LangevinMiddleIntegrator` in examples
- [x] Lint
- [ ] Update release history
