### PR TITLE
Update `Interchange.combine` warning

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -5,6 +5,7 @@ dependencies:
   # Base depends
   # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
   - python =3.10
+  - setuptools !=76.0.0
   - versioningit
   - pip
   - numpy =1

--- a/openff/interchange/operations/_combine.py
+++ b/openff/interchange/operations/_combine.py
@@ -75,10 +75,8 @@ def _combine(
     input2: "Interchange",
 ) -> "Interchange":
     warnings.warn(
-        "Interchange object combination is complex and likely to produce strange results outside "
-        "of a limited set of use cases it has been tested in. Any workflow using this method is "
-        "not guaranteed to be suitable for production or stable between versions. Use with "
-        "extreme caution and thoroughly validate results!",
+        "Interchange object combination is complex and may produce strange results outside "
+        "of use cases it has been tested in. Use with caution and thoroughly validate results!",
         InterchangeCombinationWarning,
     )
 


### PR DESCRIPTION
### Description

The current warning message communicates that `Interchange.combine` is not suitable for production and marginally tested, neither of which is the case.
