### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -19,7 +19,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
         openeye:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -25,7 +25,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python-version:
-          - "3.10"
           - "3.11"
 
     env:

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # Base depends
   # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
-  - python =3.10
+  - python =3.11
   - setuptools !=76.0.0
   - versioningit
   - pip

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -17,6 +17,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 * #1137 Internally use `openmm.LangevinMiddleIntegrator`, including in the OpenMM driver.
 * #1186 `GROMACSSystem.molecules` is changed from a dictionary to a list of tuples.
+* #1194 Drop support for Python 3.10
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Applies to any release made on or after April 4, 2025.

Python 3.11 was released in October 2022 and anything that has not been updated is, in my judgement, de facto unmaintained.

https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table