### PR TITLE
LAMMPS type labels

### DIFF
--- a/docs/using/output.md
+++ b/docs/using/output.md
@@ -42,7 +42,9 @@ An [`Interchange`] object can be written to LAMMPS data and run input files with
 
 ```python
 interchange.to_lammps("data")  # Produces `data.lmp` and `data_pointenergy.in`
-interchange.to_lammps("data", include_type_labels=True)  # includes LAMMPS type labels in `data.lmp`
+interchange.to_lammps(
+    "data", include_type_labels=True
+)  # includes LAMMPS type labels in `data.lmp`
 ```
 
 Note that the generated run input file will run a single-point energy calculation and should be modified for the desired simulation.

--- a/docs/using/output.md
+++ b/docs/using/output.md
@@ -42,6 +42,7 @@ An [`Interchange`] object can be written to LAMMPS data and run input files with
 
 ```python
 interchange.to_lammps("data")  # Produces `data.lmp` and `data_pointenergy.in`
+interchange.to_lammps("data", include_type_labels=True)  # includes LAMMPS type labels in `data.lmp`
 ```
 
 Note that the generated run input file will run a single-point energy calculation and should be modified for the desired simulation.

--- a/openff/interchange/_tests/unit_tests/interop/lammps/export/test_lammps.py
+++ b/openff/interchange/_tests/unit_tests/interop/lammps/export/test_lammps.py
@@ -1,4 +1,5 @@
 import copy
+import tempfile
 from pathlib import Path
 
 import numpy
@@ -226,3 +227,35 @@ class TestLammps:
         expected_mol_ids = {i + 1 for i in range(interchange.topology.n_molecules)}
 
         assert expected_mol_ids == written_mol_ids
+
+    @pytest.mark.parametrize(
+        "mol",
+        [
+            "C=O",  # Simplest molecule with any improper torsion
+            "OC=O",  # Simplest molecule with a multi-term torsion
+        ],
+    )
+    def test_to_lammps_with_type_labels(self, mol: str, sage_unconstrained: ForceField) -> None:
+        import lammps
+
+        from openff.interchange.exceptions import LAMMPSRunError
+
+        mol = MoleculeWithConformer.from_smiles(mol)
+        mol.conformers[0] -= numpy.min(mol.conformers[0], axis=0)
+        top = Topology.from_molecules([mol])
+
+        top.box_vectors = 5.0 * numpy.eye(3) * unit.nanometer
+        positions = mol.conformers[0]
+
+        interchange = Interchange.from_smirnoff(sage_unconstrained, top)
+        interchange.positions = positions
+        interchange.box = top.box_vectors
+        with tempfile.TemporaryDirectory():
+            interchange.to_lammps("out", include_type_labels=True)
+
+        runner = lammps.lammps(cmdargs=["-screen", "none", "-nocite"])
+
+        try:
+            runner.file("out_pointenergy.in")
+        except Exception as error:
+            raise LAMMPSRunError from error

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -479,32 +479,33 @@ class Interchange(_BaseModel):
             gro_file=file_path,
         ).to_gro(decimal=decimal)
 
-    def to_lammps(self, prefix: str):
+    def to_lammps(self, prefix: str, include_type_labels: bool = False):
         """
         Export this ``Interchange`` to LAMMPS data and run input files.
 
         Parameters
         ----------
-
-        prefix
+        prefix: str
             The prefix to use for the LAMMPS data and run input files. For
             example, "foo" will produce files named "foo.lmp" and
             "foo_pointenergy.in".
-
+        include_type_labels: bool
+            If True, this will include the SMIRKS strings as LAMMPS type labels
+            in the LAMMPS data file.
         """
         prefix = str(prefix)
         datafile_path = prefix + ".lmp"
-        self.to_lammps_datafile(datafile_path)
+        self.to_lammps_datafile(datafile_path, include_type_labels)
         self.to_lammps_input(
             prefix + "_pointenergy.in",
             datafile_path,
         )
 
-    def to_lammps_datafile(self, file_path: Path | str):
+    def to_lammps_datafile(self, file_path: Path | str, include_type_labels: bool = False):
         """Export this Interchange to a LAMMPS data file."""
         from openff.interchange.interop.lammps import to_lammps
 
-        to_lammps(self, file_path)
+        to_lammps(self, file_path, include_type_labels)
 
     def to_lammps_input(
         self,

--- a/openff/interchange/interop/lammps/export/export.py
+++ b/openff/interchange/interop/lammps/export/export.py
@@ -11,7 +11,7 @@ from openff.interchange.exceptions import UnsupportedExportError
 from openff.interchange.models import PotentialKey
 
 
-def to_lammps(interchange: Interchange, file_path: Path | str):
+def to_lammps(interchange: Interchange, file_path: Path | str, include_type_labels: bool = False):
     """Write an Interchange object to a LAMMPS data file."""
     if isinstance(file_path, str):
         path = Path(file_path)
@@ -84,6 +84,17 @@ def to_lammps(interchange: Interchange, file_path: Path | str):
 
         lmp_file.write("0.0 0.0 0.0 xy xz yz\n")
 
+        if include_type_labels:
+            _write_atom_type_labels(lmp_file=lmp_file, interchange=interchange)
+            if n_bonds > 0:
+                _write_bond_type_labels(lmp_file=lmp_file, interchange=interchange)
+            if n_angles > 0:
+                _write_angle_type_labels(lmp_file=lmp_file, interchange=interchange)
+            if n_propers > 0:
+                _write_proper_type_labels(lmp_file=lmp_file, interchange=interchange)
+            if n_impropers > 0:
+                _write_improper_type_labels(lmp_file=lmp_file, interchange=interchange)
+
         lmp_file.write("\nMasses\n\n")
 
         vdw_handler = interchange["vdW"]
@@ -128,6 +139,66 @@ def to_lammps(interchange: Interchange, file_path: Path | str):
             _write_propers(lmp_file=lmp_file, interchange=interchange)
         if n_impropers > 0:
             _write_impropers(lmp_file=lmp_file, interchange=interchange)
+
+
+def _write_atom_type_labels(lmp_file: IO, interchange: Interchange):
+    """Write the Atom Type Labels section of a LAMMPS data file."""
+    lmp_file.write("\nAtom Type Labels\n\n")
+
+    vdw_handler = interchange["vdW"]
+    atom_type_map = dict(enumerate(vdw_handler.potentials))
+
+    for atom_type_idx, smirks in atom_type_map.items():
+        atom_type_label = f"{smirks.id}"
+        lmp_file.write(f"{atom_type_idx + 1:d}\t{atom_type_label}\n")
+
+
+def _write_bond_type_labels(lmp_file: IO, interchange: Interchange):
+    """Write the Bond Type Labels section of a LAMMPS data file."""
+    lmp_file.write("\nBond Type Labels\n\n")
+
+    bond_handler = interchange["Bonds"]
+    bond_type_map = dict(enumerate(bond_handler.potentials))
+
+    for bond_type_idx, smirks in bond_type_map.items():
+        bond_type_label = f"{smirks.id}"
+        lmp_file.write(f"{bond_type_idx + 1:d}\t{bond_type_label}\n")
+
+
+def _write_angle_type_labels(lmp_file: IO, interchange: Interchange):
+    """Write the Angle Type Labels section of a LAMMPS data file."""
+    lmp_file.write("\nAngle Type Labels\n\n")
+
+    angle_handler = interchange["Angles"]
+    angle_type_map = dict(enumerate(angle_handler.potentials))
+
+    for angle_type_idx, smirks in angle_type_map.items():
+        angle_type_label = f"{smirks.id}"
+        lmp_file.write(f"{angle_type_idx + 1:d}\t{angle_type_label}\n")
+
+
+def _write_proper_type_labels(lmp_file: IO, interchange: Interchange):
+    """Write the Dihedral Type Labels section of a LAMMPS data file."""
+    lmp_file.write("\nDihedral Type Labels\n\n")
+
+    proper_handler = interchange["ProperTorsions"]
+    proper_type_map = dict(enumerate(proper_handler.potentials))
+
+    for proper_type_idx, smirks in proper_type_map.items():
+        proper_type_label = f"{smirks.id}mult:{smirks.mult}"
+        lmp_file.write(f"{proper_type_idx + 1:d}\t{proper_type_label}\n")
+
+
+def _write_improper_type_labels(lmp_file: IO, interchange: Interchange):
+    """Write the Improper Type Labels section of a LAMMPS data file."""
+    lmp_file.write("\nImproper Type Labels\n\n")
+
+    improper_handler = interchange["ImproperTorsions"]
+    improper_type_map = dict(enumerate(improper_handler.potentials))
+
+    for improper_type_idx, smirks in improper_type_map.items():
+        improper_type_label = f"{smirks.id}"
+        lmp_file.write(f"{improper_type_idx + 1:d}\t{improper_type_label}\n")
 
 
 def _write_pair_coeffs(lmp_file: IO, interchange: Interchange, atom_type_map: dict):


### PR DESCRIPTION
### Description

This adds the option to export the SMIRKs as LAMMPS type labels. For multi-term torsions, the multi index is appended to the SMIRKs.

This is implemeted through an optional flag in `to_lammps()`. For example: `interchange.to_lammps("out", include_type_labels=True)`.

This feature is necessary when combing files using external software where types are not consistent between files. For example, when using LAMMPS `fix bond/react` a user needs to create pre- and post-reaction templates with consistent atom/bond/etc types.

An example of the type labels that can be included in the LAMMPS data file are shown below for `OC=O`. See https://docs.lammps.org/Howto_type_labels.html for more information on LAMMPS type labels. Note that type labels were added in LAMMPS version `15Sep2022`.

I have been using this feature myself in a modified version of Interchange for some time now, and thought it may be helpful to others in the community to have access to it.

```
Atom Type Labels

1	[#8X2H1+0:1]
2	[#6:1]
3	[#8:1]
4	[#1:1]-[#8]
5	[#1:1]-[#6X3](~[#7,#8,#9,#16,#17,#35])~[#7,#8,#9,#16,#17,#35]

Bond Type Labels

1	[#6X3:1]-[#8X2H1:2]
2	[#8:1]-[#1:2]
3	[#6:1]=[#8X1+0,#8X2+1:2]
4	[#6X3:1]-[#1:2]

Angle Type Labels

1	[#8X1:1]~[#6X3:2]~[#8:3]
2	[#1:1]-[#6X3:2]~[*:3]
3	[*:1]-[#8:2]-[*:3]

Dihedral Type Labels

1	[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]mult:0
2	[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]mult:1
3	[*:1]~[#6X3:2](=[#8,#16,#7])-[#8:3]-[#1:4]mult:0

Improper Type Labels

1	[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]
```

### Checklist

- [X] Add tests
- [X] Lint
- [X] Update docstrings
