### PR TITLE
Allow `Interchange.combine` when cutoffs differ by tiny amount

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 ### New features
 
 * #1216 Type labels can (optionally) be included in LAMMPS files.
+* #1250 Allow `Interchange.combine` to proceed when cutoffs differ by up to 1e-6 nanometers.
 
 ### Behavior changes
 


### PR DESCRIPTION
### Description

Resolves #1165. By default, `Interchange.combine` allows the vdW and Electrostatics cutoffs (and the switching distance) to differ by up to 1e-6 nm. The tolerance for 1-4 scaling is 1e-6 (unitless). These are not exposed to the user and I don't want them to change much, but I'm open to them being the wrong choices to start them out at.

### Checklist

- [x] Add tests
- [x] Lint
- [ ] Update docstrings
