### PR TITLE
Finalize release v0.4.3

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,18 +15,20 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ### New features
 
+* #1174 Support Python 3.13.
 * #1216 Type labels can (optionally) be included in LAMMPS files.
 * #1250 Allow `Interchange.combine` to proceed when cutoffs differ by up to 1e-6 nanometers.
 * #1219 Adds `SMIRNOFFElectrostaticsCollection.get_charge_array`.
 
 ### Behavior changes
 
-* #1194 Drop support for Python 3.10
+* #1194 Drop support for Python 3.10.
 * #1137 Internally use `openmm.LangevinMiddleIntegrator`, including in the OpenMM driver.
 * #1186 `GROMACSSystem.molecules` is changed from a dictionary to a list of tuples.
 * #1192 `Interchange.to_pdb` now uses `ensure_unique_atom_names="residues"` when writing PDB files, matching longstanding behavior of the toolkit. For more flexibility, use the `Interchange.topology` and options provided by `openff.toolkit.Topology.to_file`.
-* #1203 Hybrid pair styles, which were never necessary, are no longer used in LAMMPS files.
+* #1205 Hybrid pair styles, which were never necessary, are no longer used in LAMMPS files.
 * #1215 The `topology` argument to `Interchange.from_openmm` is now strictly required. Previously, it could be `None` but would error.
+* #1225 Treat asterisks as comments in GROMACS files.
 
 ### Bug fixes
 
@@ -37,6 +39,11 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 ### Miscellaneous improvements
 
 * #1243 Use `pyedr` instead of `panedr` for quicker processing of GROMACS energy files.
+* #1229 Improve detailed energy reporting.
+* #1175 Make the system in the protein-ligand example charge-neutral.
+* #1183 Remove warning about use of `Interchange.combine`.
+* #1241 Document how to control GROMACS molecule names.
+* #1224 Improve errors when parsing GROMACS files.
 
 ## 0.4.2 - 2025-02-26
 


### PR DESCRIPTION
### Description

Closes #1251 

Might want to include #1220, not planning to get #1252 in this release

Using https://github.com/openforcefield/openff-interchange/milestone/20

Using this as a double-check of merged PRs: https://github.com/openforcefield/openff-interchange/compare/v0.4.2...main

This is a similar report (I think these changes are all called out in release notes):

```shell
$ griffe check -a v0.4.2 -b HEAD openff.interchange
openff/interchange/components/interchange.py:906: Interchange.from_openmm(topology): Parameter is now required
openff/interchange/models.py:394: VirtualSiteKey: Public object points to a different kind of object: class -> attribute
openff/interchange/interop/gromacs/models/models.py:344: GROMACSSystem.molecules: Attribute value was changed: Field(dict(), description='The number of each molecule type in the system, keyed by the name of each molecule.') -> Field(list(), description='The number of each molecule type in the system, ordered topologically.')
```

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
