### PR TITLE
Remove `importlib_metadata` backport when loading plugins

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,12 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## Current development
 
+### Miscellaneous improvements
+
+* #1263 Removes `importlib_metadata` backport when loading plugins.
+
+## 0.4.3 - 2025-07-11
+
 ### New features
 
 * #1174 Support Python 3.13.

--- a/openff/interchange/plugins/__init__.py
+++ b/openff/interchange/plugins/__init__.py
@@ -11,7 +11,8 @@ __all__ = [
 
 def load_smirnoff_plugins() -> list:
     """Load external potential handlers as plugins."""
-    from importlib_metadata import entry_points
+    from importlib.metadata import entry_points
+
     from pydantic import PydanticUserError
 
     plugin_handlers = list()


### PR DESCRIPTION
### Description

See https://github.com/conda-forge/openff-interchange-feedstock/issues/99