### PR TITLE
Error when `solvate_topology` result is not charge neutral

### DIFF
--- a/openff/interchange/_tests/unit_tests/components/test_packmol.py
+++ b/openff/interchange/_tests/unit_tests/components/test_packmol.py
@@ -447,3 +447,29 @@ class TestPackmolWrapper:
             assert "STOP 173" in open("packmol_error.log").read()
         else:
             assert not pathlib.Path("packmol_error.log").is_file()
+
+    def test_solvate_topology_neutral_acetic_acid(self):
+        solute = Molecule.from_smiles("CC(=O)[O-]")
+        solute.generate_conformers(n_conformers=1)
+        solute.assign_partial_charges(partial_charge_method="formal_charge")
+
+        assert solute.total_charge.m == -1.0
+
+        with pytest.raises(
+            PACKMOLValueError,
+            match="solute with charge -1.0",
+        ):
+            solvate_topology(solute.to_topology(), nacl_conc=0.1 * unit.molar, padding=2 * unit.nm)
+
+    def test_solvate_topology_neutral_ammonium(self):
+        solute = Molecule.from_smiles("[NH4+]")
+        solute.generate_conformers(n_conformers=1)
+        solute.assign_partial_charges(partial_charge_method="formal_charge")
+
+        assert solute.total_charge.m == 1.0
+
+        with pytest.raises(
+            PACKMOLValueError,
+            match="solute with charge +1.0",
+        ):
+            solvate_topology(solute.to_topology(), nacl_conc=0.1 * unit.molar, padding=2 * unit.nm)

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -909,7 +909,12 @@ def solvate_topology(
     na_to_add = numpy.ceil(nacl_to_add - solute_charge.m / 2.0)
     cl_to_add = numpy.floor(nacl_to_add + solute_charge.m / 2.0)
 
-    # Pack the box
+    if abs(solute_charge.m + na_to_add - cl_to_add) > 1e-6:
+        raise PACKMOLValueError(
+            f"Failed to neutralise solute with charge {solute_charge.m}; meant to add {nacl_to_add} NaCl.\n"
+            f"Tried adding {na_to_add} Na+ and {cl_to_add} Cl- ions.",
+        )
+
     return pack_box(
         [water, na, cl],
         [int(water_to_add), int(na_to_add), int(cl_to_add)],


### PR DESCRIPTION
### Description

Part of #1268, made obsolete if #1269 or #1270 is merged

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
