### PR TITLE
Implement SLTCAP in `solvate_topology`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: add-trailing-comma
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.3
+  rev: v0.12.4
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,15 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ## Current development
 
+### Behavior changes
+
+* #1273 In `solvate_topology`, ions counts are determined using the SLTCAP method.
+
+### Bug fixes
+
+* #1273 `solvate_topology` now returns a charge-neutral topology.
+* #1272 In `pack_box` and other Packmol-wrapping functions, molecules with zero count are skipped.
+
 ### Miscellaneous improvements
 
 * #1263 Removes `importlib_metadata` backport when loading plugins.

--- a/openff/interchange/_tests/unit_tests/components/test_packmol.py
+++ b/openff/interchange/_tests/unit_tests/components/test_packmol.py
@@ -447,3 +447,25 @@ class TestPackmolWrapper:
             assert "STOP 173" in open("packmol_error.log").read()
         else:
             assert not pathlib.Path("packmol_error.log").is_file()
+
+    def test_solvate_topology_neutral_acetic_acid(self):
+        solute = Molecule.from_smiles("CC(=O)[O-]")
+        solute.generate_conformers(n_conformers=1)
+        solute.assign_partial_charges(partial_charge_method="formal_charge")
+
+        assert solute.total_charge.m == -1.0
+
+        topology = solvate_topology(solute.to_topology(), nacl_conc=0.1 * unit.molar, padding=2 * unit.nm)
+
+        assert sum([molecule.total_charge.m for molecule in topology.molecules]) == 0.0
+
+    def test_solvate_topology_neutral_ammonium(self):
+        solute = Molecule.from_smiles("[NH4+]")
+        solute.generate_conformers(n_conformers=1)
+        solute.assign_partial_charges(partial_charge_method="formal_charge")
+
+        assert solute.total_charge.m == 1.0
+
+        topology = solvate_topology(solute.to_topology(), nacl_conc=0.1 * unit.molar, padding=2 * unit.nm)
+
+        assert sum([molecule.total_charge.m for molecule in topology.molecules]) == 0.0

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -127,13 +127,19 @@ def _validate_inputs(
         elements.
 
     """
-    if box_vectors is None and target_density is None and (solute is None or solute.box_vectors is None):
+    if (
+        box_vectors is None
+        and target_density is None
+        and (solute is None or solute.box_vectors is None)
+    ):
         raise PACKMOLValueError(
-            "One of `box_vectors`, `target_density`, or" + " `solute.box_vectors` must be specified.",
+            "One of `box_vectors`, `target_density`, or"
+            + " `solute.box_vectors` must be specified.",
         )
     if box_vectors is not None and target_density is not None:
         raise PACKMOLValueError(
-            "`box_vectors` and `target_density` cannot be specified together;" + " choose one or the other.",
+            "`box_vectors` and `target_density` cannot be specified together;"
+            + " choose one or the other.",
         )
 
     if box_vectors is not None and box_vectors.shape != (3, 3):
@@ -344,7 +350,10 @@ def _box_from_density(
 
     """
     # Get the desired volume in cubic working units
-    total_mass = sum(sum([atom.mass for atom in molecule.atoms]) * n for molecule, n in zip(molecules, n_copies))
+    total_mass = sum(
+        sum([atom.mass for atom in molecule.atoms]) * n
+        for molecule, n in zip(molecules, n_copies)
+    )
     volume = total_mass / target_density
 
     return _scale_box(box_shape, volume)
@@ -880,10 +889,16 @@ def solvate_topology(
     # Compute target masses of solvent
     box_volume = numpy.linalg.det(box_vectors.m) * box_vectors.u**3
     target_mass = box_volume * target_density
-    solute_mass = sum(sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules)
+    solute_mass = sum(
+        sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules
+    )
     solvent_mass = target_mass - solute_mass
 
     _check_add_positive_mass(solvent_mass)
+
+    # Compute total charge of all solute molecules and its magnitude
+    solute_charge = sum([molecule.total_charge.m for molecule in topology.molecules])
+    solute_charge_magnitude = numpy.abs(solute_charge)
 
     # Get reference data and prepare solvent molecules
     water = Molecule.from_smiles("O")
@@ -893,23 +908,51 @@ def solvate_topology(
         [atom.mass for atom in cl.atoms],
     )
     water_mass = sum([atom.mass for atom in water.atoms])
-    molarity_pure_water = Quantity(55.5, "mole / liter")
+    molarity_pure_water = Quantity(55.4, "mole / liter")
 
-    # Compute the number of salt "molecules" to add from the mass and concentration
-    nacl_mass_fraction = (nacl_conc * nacl_mass) / (molarity_pure_water * water_mass)
-    nacl_mass_to_add = solvent_mass * nacl_mass_fraction
-    nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+    # Compute the number of salt ions to add for bulk salt
+    # If ionic strength is zero, then the solute_ion_ratio needed for SLTCAP is undefined
+    if nacl_conc == Quantity(0, "mole / liter"):
+        nacl_to_add = 0
+        water_mass_to_add = solvent_mass
 
-    # Compute the number of water molecules to add to make up the remaining mass
-    water_mass_to_add = solvent_mass - nacl_mass
+    else:
+        # Compute the number of salt "molecules" to add from the mass and concentration
+        # for a neutral solute
+        neutral_nacl_mass_fraction = (nacl_conc * nacl_mass) / (
+            molarity_pure_water * water_mass
+        )
+        neutral_nacl_mass_to_add = solvent_mass * neutral_nacl_mass_fraction
+        neutral_nacl_to_add = (
+            (neutral_nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+        )
+
+        # Compute the number of salt "molecules" to add using the SLTCAP method
+        solute_ion_ratio = solute_charge_magnitude / (2 * neutral_nacl_to_add)
+        sltcap_effective_ionic_strength = nacl_conc * (
+            numpy.sqrt(1 + solute_ion_ratio * solute_ion_ratio) - solute_ion_ratio
+        )
+
+        nacl_mass_fraction = (sltcap_effective_ionic_strength * nacl_mass) / (
+            molarity_pure_water * water_mass
+        )
+        nacl_mass_to_add = solvent_mass * nacl_mass_fraction
+        nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+
+        # Compute the number of water molecules to add to make up the remaining mass
+        water_mass_to_add = solvent_mass - nacl_mass_to_add
+
     water_to_add = (water_mass_to_add / water_mass).m_as("dimensionless").round()
 
     # Neutralise the system by adding and removing salt
-    solute_charge = sum([molecule.total_charge for molecule in topology.molecules])
-    na_to_add = numpy.ceil(nacl_to_add - solute_charge.m / 2.0)
-    cl_to_add = numpy.ceil(nacl_to_add + solute_charge.m / 2.0)
+    na_to_add = numpy.round(
+        nacl_to_add + (solute_charge_magnitude - solute_charge) / 2.0
+    )
+    cl_to_add = numpy.round(
+        nacl_to_add + (solute_charge_magnitude + solute_charge) / 2.0
+    )
 
-    if abs(solute_charge.m + na_to_add - cl_to_add) > 1e-6:
+    if abs(solute_charge + na_to_add - cl_to_add) > 1e-6:
         raise PACKMOLValueError(
             f"Failed to neutralise solute with charge {solute_charge.m}; meant to add {nacl_to_add} NaCl.\n"
             f"Tried adding {na_to_add} Na+ and {cl_to_add} Cl- ions. This should not happen, please raise an issue!",
@@ -986,7 +1029,9 @@ def solvate_topology_nonwater(
     # Compute target masses of solvent
     box_volume = numpy.linalg.det(box_vectors.m) * box_vectors.u**3
     target_mass = box_volume * target_density
-    solute_mass = sum(sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules)
+    solute_mass = sum(
+        sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules
+    )
 
     solvent_mass_to_add = target_mass - solute_mass
 

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -127,19 +127,13 @@ def _validate_inputs(
         elements.
 
     """
-    if (
-        box_vectors is None
-        and target_density is None
-        and (solute is None or solute.box_vectors is None)
-    ):
+    if box_vectors is None and target_density is None and (solute is None or solute.box_vectors is None):
         raise PACKMOLValueError(
-            "One of `box_vectors`, `target_density`, or"
-            + " `solute.box_vectors` must be specified.",
+            "One of `box_vectors`, `target_density`, or" + " `solute.box_vectors` must be specified.",
         )
     if box_vectors is not None and target_density is not None:
         raise PACKMOLValueError(
-            "`box_vectors` and `target_density` cannot be specified together;"
-            + " choose one or the other.",
+            "`box_vectors` and `target_density` cannot be specified together;" + " choose one or the other.",
         )
 
     if box_vectors is not None and box_vectors.shape != (3, 3):
@@ -350,10 +344,7 @@ def _box_from_density(
 
     """
     # Get the desired volume in cubic working units
-    total_mass = sum(
-        sum([atom.mass for atom in molecule.atoms]) * n
-        for molecule, n in zip(molecules, n_copies)
-    )
+    total_mass = sum(sum([atom.mass for atom in molecule.atoms]) * n for molecule, n in zip(molecules, n_copies))
     volume = total_mass / target_density
 
     return _scale_box(box_shape, volume)
@@ -889,9 +880,7 @@ def solvate_topology(
     # Compute target masses of solvent
     box_volume = numpy.linalg.det(box_vectors.m) * box_vectors.u**3
     target_mass = box_volume * target_density
-    solute_mass = sum(
-        sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules
-    )
+    solute_mass = sum(sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules)
     solvent_mass = target_mass - solute_mass
 
     _check_add_positive_mass(solvent_mass)
@@ -919,13 +908,9 @@ def solvate_topology(
     else:
         # Compute the number of salt "molecules" to add from the mass and concentration
         # for a neutral solute
-        neutral_nacl_mass_fraction = (nacl_conc * nacl_mass) / (
-            molarity_pure_water * water_mass
-        )
+        neutral_nacl_mass_fraction = (nacl_conc * nacl_mass) / (molarity_pure_water * water_mass)
         neutral_nacl_mass_to_add = solvent_mass * neutral_nacl_mass_fraction
-        neutral_nacl_to_add = (
-            (neutral_nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
-        )
+        neutral_nacl_to_add = (neutral_nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
 
         # Compute the number of salt "molecules" to add using the SLTCAP method
         solute_ion_ratio = solute_charge_magnitude / (2 * neutral_nacl_to_add)
@@ -933,9 +918,7 @@ def solvate_topology(
             numpy.sqrt(1 + solute_ion_ratio * solute_ion_ratio) - solute_ion_ratio
         )
 
-        nacl_mass_fraction = (sltcap_effective_ionic_strength * nacl_mass) / (
-            molarity_pure_water * water_mass
-        )
+        nacl_mass_fraction = (sltcap_effective_ionic_strength * nacl_mass) / (molarity_pure_water * water_mass)
         nacl_mass_to_add = solvent_mass * nacl_mass_fraction
         nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
 
@@ -946,10 +929,10 @@ def solvate_topology(
 
     # Neutralise the system by adding and removing salt
     na_to_add = numpy.round(
-        nacl_to_add + (solute_charge_magnitude - solute_charge) / 2.0
+        nacl_to_add + (solute_charge_magnitude - solute_charge) / 2.0,
     )
     cl_to_add = numpy.round(
-        nacl_to_add + (solute_charge_magnitude + solute_charge) / 2.0
+        nacl_to_add + (solute_charge_magnitude + solute_charge) / 2.0,
     )
 
     if abs(solute_charge + na_to_add - cl_to_add) > 1e-6:
@@ -1029,9 +1012,7 @@ def solvate_topology_nonwater(
     # Compute target masses of solvent
     box_volume = numpy.linalg.det(box_vectors.m) * box_vectors.u**3
     target_mass = box_volume * target_density
-    solute_mass = sum(
-        sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules
-    )
+    solute_mass = sum(sum([atom.mass for atom in molecule.atoms]) for molecule in topology.molecules)
 
     solvent_mass_to_add = target_mass - solute_mass
 

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -912,7 +912,7 @@ def solvate_topology(
     if abs(solute_charge.m + na_to_add - cl_to_add) > 1e-6:
         raise PACKMOLValueError(
             f"Failed to neutralise solute with charge {solute_charge.m}; meant to add {nacl_to_add} NaCl.\n"
-            f"Tried adding {na_to_add} Na+ and {cl_to_add} Cl- ions.",
+            f"Tried adding {na_to_add} Na+ and {cl_to_add} Cl- ions. This should not happen, please raise an issue!",
         )
 
     return pack_box(

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -912,18 +912,23 @@ def solvate_topology(
         neutral_nacl_mass_to_add = solvent_mass * neutral_nacl_mass_fraction
         neutral_nacl_to_add = (neutral_nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
 
-        # Compute the number of salt "molecules" to add using the SLTCAP method
-        solute_ion_ratio = solute_charge_magnitude / (2 * neutral_nacl_to_add)
-        sltcap_effective_ionic_strength = nacl_conc * (
-            numpy.sqrt(1 + solute_ion_ratio * solute_ion_ratio) - solute_ion_ratio
-        )
+        if neutral_nacl_to_add == 0:
+            nacl_to_add = 0
+            water_mass_to_add = solvent_mass
 
-        nacl_mass_fraction = (sltcap_effective_ionic_strength * nacl_mass) / (molarity_pure_water * water_mass)
-        nacl_mass_to_add = solvent_mass * nacl_mass_fraction
-        nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+        else:
+            # Compute the number of salt "molecules" to add using the SLTCAP method
+            solute_ion_ratio = solute_charge_magnitude / (2 * neutral_nacl_to_add)
+            sltcap_effective_ionic_strength = nacl_conc * (
+                numpy.sqrt(1 + solute_ion_ratio * solute_ion_ratio) - solute_ion_ratio
+            )
 
-        # Compute the number of water molecules to add to make up the remaining mass
-        water_mass_to_add = solvent_mass - nacl_mass_to_add
+            nacl_mass_fraction = (sltcap_effective_ionic_strength * nacl_mass) / (molarity_pure_water * water_mass)
+            nacl_mass_to_add = solvent_mass * nacl_mass_fraction
+            nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+
+            # Compute the number of water molecules to add to make up the remaining mass
+            water_mass_to_add = solvent_mass - nacl_mass_to_add
 
     water_to_add = (water_mass_to_add / water_mass).m_as("dimensionless").round()
 

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -909,7 +909,12 @@ def solvate_topology(
     na_to_add = numpy.ceil(nacl_to_add - solute_charge.m / 2.0)
     cl_to_add = numpy.floor(nacl_to_add + solute_charge.m / 2.0)
 
-    # Pack the box
+    if abs(solute_charge.m + na_to_add - cl_to_add) > 1e-6:
+        raise PACKMOLValueError(
+            f"Failed to neutralise solute with charge {solute_charge.m}; meant to add {nacl_to_add} NaCl.\n"
+            f"Tried adding {na_to_add} Na+ and {cl_to_add} Cl- ions.",
+        )
+
     return pack_box(
         [water, na, cl],
         [int(water_to_add), int(na_to_add), int(cl_to_add)],

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -832,6 +832,8 @@ def solvate_topology(
     """
     Add water and ions to neutralise and solvate a topology.
 
+    The [SLTCAP](10.1021/acs.jctc.7b01254)  method is used to determine the number of each ion to add.
+
     Parameters
     ----------
     topology
@@ -873,6 +875,9 @@ def solvate_topology(
     -----
     Returned topologies may have larger box vectors than what would be defined
     by the target density.
+
+    Returned topologies may have ion concentrations higher than the value of the
+    the `nacl_conc` argument.
     """
     _check_box_shape_shape(box_shape)
 

--- a/openff/interchange/components/_packmol.py
+++ b/openff/interchange/components/_packmol.py
@@ -907,7 +907,7 @@ def solvate_topology(
     # Neutralise the system by adding and removing salt
     solute_charge = sum([molecule.total_charge for molecule in topology.molecules])
     na_to_add = numpy.ceil(nacl_to_add - solute_charge.m / 2.0)
-    cl_to_add = numpy.floor(nacl_to_add + solute_charge.m / 2.0)
+    cl_to_add = numpy.ceil(nacl_to_add + solute_charge.m / 2.0)
 
     if abs(solute_charge.m + na_to_add - cl_to_add) > 1e-6:
         raise PACKMOLValueError(


### PR DESCRIPTION
Fixes #1268 

### Description

This PR implements the SLTCAP method for adding ions to represent bulk salt in a system with a non-neutral solute.

To check my understanding, line 904 previously read
`    water_mass_to_add = solvent_mass - nacl_mass`

But this is the total mass of solvent molecules in the entire box minus the mass of one NaCl molecule. I think this line should have been
`    water_mass_to_add = solvent_mass - nacl_mass_to_add`

For consistency with the protein benchmark setup, I also changed the molarity of pure water from 55.5 M (value at 273 K) to 55.4 M (value at 293 K, closer to the temperature for most protein simulations). This probably won't change the number of ions in most systems, and I don't feel strongly about this change.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
