### PR TITLE
Fix error in create_interchange when openff-nagl-models isn't installed

### DIFF
--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -697,6 +697,7 @@ class SMIRNOFFElectrostaticsCollection(ElectrostaticsCollection, SMIRNOFFCollect
 
         if handler_name == "NAGLChargesHandler":
             from openff.toolkit.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY, NAGLToolkitWrapper
+
             from openff.nagl_models._dynamic_fetch import HashComparisonFailedException, UnableToParseDOIException
 
             partial_charge_method = parameter_handler.model_file


### PR DESCRIPTION
### Description

This fixes the issue when I run the reproducing example locally, but I'm unsure how to test in CI without adding a whole new permutation to the matrix.

### Checklist

- [ ] Fix #1309 
- [ ] Lint
- [ ] Update docstrings
