### PR TITLE
Exclude data files from conda/Python packages

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Run example notebooks
       run: |
-        python -m pytest -c pyproject.toml --nbval-lax --dist loadscope -n logical --durations=20 examples/ \
+        python -m pytest -x -c pyproject.toml --nbval-lax --dist loadscope -n logical --durations=20 examples/ \
           --ignore=examples/deprecated/ \
           --ignore=examples/experimental/ \
           --ignore=examples/lammps/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,9 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = [ 'openff.interchange*' ]
+exclude = [ 'openff.interchange._tests.data*' ]
 
 [tool.ruff]
 line-length = 119


### PR DESCRIPTION
### Description

This is more or less copied from https://github.com/openforcefield/openff-nagl/pull/216

Something like 80% of the size of this package (when ... packaged) is data files that are only needed for testing:

<img width="1030" height="637" alt="image" src="https://github.com/user-attachments/assets/157dc4a8-7cc8-4162-a80b-9fbbf9fc84fe" />