### PR TITLE
Ensure Pydantic 2.12.1+ is not installed in tests

### DIFF
--- a/devtools/conda-envs/dev_env.yaml
+++ b/devtools/conda-envs/dev_env.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python =3.12
   - versioningit
   - numpy =2.2
-  - pydantic =2,!=2.12
+  - pydantic >=2,<2.12
   # OpenFF stack
   - openff-toolkit-base =0.17
   - openff-units

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - versioningit
   - pip
   - numpy =1
-  - pydantic =2,!=2.12
+  - pydantic >=2,<2.12
   - openff-toolkit-base =0.17
   - openmm
   - mbuild

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python
   - versioningit
   - numpy
-  - pydantic =2,!=2.12
+  - pydantic >=2,<2.12
   # OpenFF stack
   - openff-toolkit-base =0.17
   - openff-units

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - versioningit
   - numpy =2.2
-  - pydantic =2,!=2.12
+  - pydantic >=2,<2.12
   # OpenFF stack
   - openff-toolkit-base =0.17
   - openff-units

--- a/devtools/conda-envs/test_not_py313.yaml
+++ b/devtools/conda-envs/test_not_py313.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - versioningit
   - numpy <2.3
-  - pydantic =2,!=2.12
+  - pydantic >=2,<2.12
   # OpenFF stack
   - openff-toolkit-base =0.17
   - openff-units


### PR DESCRIPTION
### Description

Pydantic 2.12.1 was released but it does not fix the regression introduced in 2.12.0. Related #1347 

Conda expands forbidden versions with trailing zeros; `!=2.12` is the same as `!=2.12.0`, so 2.12.1 is a valid solution.