### PR TITLE
Add Foyer back to CI

### DIFF
--- a/devtools/conda-envs/test_not_py313.yaml
+++ b/devtools/conda-envs/test_not_py313.yaml
@@ -19,7 +19,7 @@ dependencies:
   # https://github.com/conda-forge/mbuild-feedstock/issues/46
   # https://github.com/conda-forge/mbuild-feedstock/pull/49
   # mbuild =1
-  # foyer =1
+  - foyer =1
   - nglview
   # Drivers
   - gromacs


### PR DESCRIPTION
### Description

We have some packaging conflicts with mBuild, but not Foyer.

### Checklist

- [ ] Add tests
- [ ] Lint
- [ ] Update docstrings
