### PR TITLE
Fix type-checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,6 @@ jobs:
         python devtools/scripts/molecule-regressions.py
 
     - name: Run mypy
-      if: ${{ matrix.python-version == '3.11' }}
       run: |
         # As of 01/23, JAX with mypy is too slow to use without a pre-built cache
         # https://github.com/openforcefield/openff-interchange/pull/578#issuecomment-1369979875

--- a/openff/interchange/constants.py
+++ b/openff/interchange/constants.py
@@ -4,16 +4,17 @@ Commonly-used constants.
 
 from openff.units import Unit
 
-_PME = "Ewald3D-ConductingBoundary"
 kj_mol = Unit("kilojoule / mol")
 kcal_mol = Unit("kilocalorie_per_mole")
 
-kcal_ang = kcal_mol / Unit("angstrom**2")
-kcal_rad = kcal_mol / Unit("radian**2")
+kcal_ang = Unit("kilojoule / mol / angstrom**2")
+kcal_rad = Unit("kilojoule / mol / radian**2")
 
-kj_nm = kj_mol / Unit("nanometer**2")
-kj_rad = kj_mol / Unit("radian**2")
+kj_nm = Unit("kilojoule/ mol / nanometer**2")
+kj_rad = Unit("kilojoule/ mol / radian**2")
 
+kcal_mol_a2 = Unit("kilocalorie / mol / angstrom**2")
+kcal_mol_rad2 = Unit("kilocalorie / mol / radian**2")
+
+_PME = "Ewald3D-ConductingBoundary"
 AMBER_COULOMBS_CONSTANT = 18.2223
-kcal_mol_a2 = kcal_mol / Unit("angstrom**2")
-kcal_mol_rad2 = kcal_mol / Unit("radian**2")


### PR DESCRIPTION
### Description

Some workflows have been failing because (somehow) the type-checker doesn't pick up on how `Unit.__div__` is defined