### PR TITLE
Fix beta workflow

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -1,14 +1,8 @@
 name: Tests against betas
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 17 * * *"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
### Description

This workflow has been failing for a few days because #1357 makes AmberTools an optional dependency