### PR TITLE
Update description of `target_density` usage in release notes

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -18,7 +18,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
   * Periodic boundary conditions are accounted for when placing molecules if the box is orthorhombic and Packmol version 20.15.0 or newer is installed; this is the minimum version supporting this feature.
     * This is functionally the same as the previous behavior, so no workaround is needed to recover it.
   * The `tolerance` parameter is subtracted from computed box lengths when placing molecules if a Packmol version older than 20.15.0 is installed; this is the previous behavior.
-  * The `target_density` is used in box size calculations with modification; previously, box volumes were scaled up by a factor of 1.1.
+  * The `target_density` is used in box size calculations without modification; previously, box volumes were scaled up by a factor of 1.1.
     * The previous behavior can be restored by passing scaling the `target_density` argument down by a factor of 1.1.
 
 * #1376 Makes `Interchange.topology` not store positions. Use `Interchange.positions` instead.


### PR DESCRIPTION
This was a typo - and unfortunately a very important one.