### PR TITLE
Create OpenMM particles even with no non-bonded handlers

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -19,6 +19,7 @@ Please note that all releases prior to a version 1.0.0 are considered pre-releas
 
 ### Bug fixes
 
+* #1431 Exported OpenMM systems no longer lack particles when no non-bonded handlers are present in the force field.
 * #1418 Fixes issues in which `Interchange.combine` inputs could sometimes not then be exported to OpenMM.
 
 ## 0.5.0 - 2025-01-08

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
@@ -61,3 +61,23 @@ class TestToOpenMM:
         # epsilon of 1-4 interaction matches either atom's sigma
         scale = sage_unconstrained["vdW"].scale14
         assert epsilon == vdw_force.getParticleParameters(0)[1] * scale
+
+    def test_particles_exist_without_nonbonded_force(self, sage_unconstrained):
+        valence_ff = ForceField()
+
+        valence_ff.register_parameter_handler(sage_unconstrained["Bonds"])
+        valence_ff.register_parameter_handler(sage_unconstrained["Angles"])
+
+        valence_ff.register_parameter_handler(sage_unconstrained["ProperTorsions"])
+        valence_ff.register_parameter_handler(sage_unconstrained["ImproperTorsions"])
+
+        interchange = valence_ff.create_interchange(Molecule.from_smiles("CCO").to_topology())
+
+        assert "vdW" not in interchange.collections
+        assert "Electrostatics" not in interchange.collections
+
+        openmm_system = interchange.to_openmm()
+
+        # do we want to check the PDB file / OpenMM topology exported fro this state, too?
+
+        assert openmm_system.getNumParticles() == 9

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
@@ -63,6 +63,8 @@ class TestToOpenMM:
         assert epsilon == vdw_force.getParticleParameters(0)[1] * scale
 
     def test_particles_exist_without_nonbonded_force(self, sage_unconstrained):
+        import openmm
+
         valence_ff = ForceField()
 
         valence_ff.register_parameter_handler(sage_unconstrained["Bonds"])
@@ -81,3 +83,13 @@ class TestToOpenMM:
         # do we want to check the PDB file / OpenMM topology exported fro this state, too?
 
         assert openmm_system.getNumParticles() == 9
+
+        for force in openmm_system.getForces():
+            assert not isinstance(force, openmm.NonbondedForce | openmm.CustomNonbondedForce)
+            assert isinstance(
+                force,
+                openmm.HarmonicBondForce
+                | openmm.HarmonicAngleForce
+                | openmm.PeriodicTorsionForce
+                | openmm.CMMotionRemover,
+            )

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_openmm.py
@@ -103,3 +103,25 @@ class TestToOpenMM:
                 | openmm.PeriodicTorsionForce
                 | openmm.CMMotionRemover,
             )
+
+    def test_particles_exist_with_no_forces(self):
+        import openmm
+
+        empty_ff = ForceField()
+
+        assert len(empty_ff.registered_parameter_handlers) == 0
+
+        interchange = empty_ff.create_interchange(Molecule.from_smiles("CCO").to_topology())
+
+        # Interchange creates an empty ConstraintsCollection by default, even with no
+        # constraints handler or other handlers that would populate it
+        assert len(interchange.collections) == 1
+
+        openmm_system = interchange.to_openmm()
+
+        assert openmm_system.getNumParticles() == 9
+
+        # CMMotionRemover is added by default, even with no forces
+        assert openmm_system.getNumForces() == 1
+
+        assert type(openmm_system.getForce(0)) is openmm.CMMotionRemover

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -67,19 +67,7 @@ def _process_nonbonded_forces(
     `combine_nonbondoed_forces=False`.
 
     """
-    from openff.interchange.common._nonbonded import _NonbondedCollection
-
-    for collection in interchange.collections.values():
-        if isinstance(collection, _NonbondedCollection):
-            break
-    else:
-        # If there are no non-bonded collections, assume here that there can be no virtual sites,
-        # so just return an i-i mapping between OpenFF and OpenMM indices
-        return {i: i for i in range(interchange.topology.n_atoms)}
-
-    has_virtual_sites = "VirtualSites" in interchange.collections
-
-    if has_virtual_sites:
+    if "VirtualSites" in interchange.collections:
         from openff.interchange.interop._virtual_sites import (
             _virtual_site_parent_molecule_mapping,
         )
@@ -126,26 +114,19 @@ def _process_nonbonded_forces(
                 has_vdw = True
                 break
 
-    if not has_vdw:
-        if has_virtual_sites:
-            raise UnsupportedExportError(
-                "Virtual sites with no vdW handler not currently supported. If this use case is "
-                "important to you, please raise an issue describing the functionality you wish to "
-                "see.",
-            )
-
-        try:
-            interchange["Electrostatics"]
-        except LookupError:
-            raise InternalInconsistencyError(
-                "In a confused state, could not find any vdW interactions but also failed to find "
-                "any electrostatics collection. This is a supported use case but should have been caught "
-                "earlier in this function. Please file an issue with a minimal reproducing example.",
-            )
+    if not has_vdw and "VirtualSites" in interchange.collections:
+        raise UnsupportedExportError(
+            "Virtual sites with no vdW handler not currently supported. If this use case is "
+            "important to you, please raise an issue describing the functionality you wish to "
+            "see.",
+        )
 
     _data = _prepare_input_data(interchange)
 
-    if combine_nonbonded_forces:
+    if _data.vdw_collection is None and _data.electrostatics_collection is None:
+        # Will not make any non-bonded forces, but we have made particles, so just return early
+        return openff_openmm_particle_map
+    elif combine_nonbonded_forces:
         _func = _create_single_nonbonded_force
     else:
         _func = _create_multiple_nonbonded_forces

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -108,7 +108,8 @@ def _process_nonbonded_forces(
     if _data.vdw_collection is None and _data.electrostatics_collection is None:
         # Will not make any non-bonded forces, but we have made particles, so just return early
         return openff_openmm_particle_map
-    elif combine_nonbonded_forces:
+
+    if combine_nonbonded_forces:
         _func = _create_single_nonbonded_force
     else:
         _func = _create_multiple_nonbonded_forces

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -102,24 +102,6 @@ def _process_nonbonded_forces(
     )
 
     # TODO: Process ElectrostaticsHandler.exception_potential
-    has_vdw = False
-
-    for name, collection in interchange.collections.items():
-        if name == "vdW":
-            has_vdw = True
-            break
-        if collection.is_plugin:
-            # TODO: Here is where to detect an electrostatics plugin, if one ever exists
-            if collection.acts_as == "vdW":  # type: ignore[attr-defined]
-                has_vdw = True
-                break
-
-    if not has_vdw and "VirtualSites" in interchange.collections:
-        raise UnsupportedExportError(
-            "Virtual sites with no vdW handler not currently supported. If this use case is "
-            "important to you, please raise an issue describing the functionality you wish to "
-            "see.",
-        )
 
     _data = _prepare_input_data(interchange)
 

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -64,7 +64,7 @@ def _process_nonbonded_forces(
     This typically involves processing the vdW and Electrostatics sections of an Interchange object
     into a corresponding openmm.NonbondedForce (if `combine_nonbonded_forces=True`) or a
     collection of other forces (NonbondedForce, CustomNonbondedForce, CustomBondForce) if
-    `combine_nonbondoed_forces=False`.
+    `combine_nonbonded_forces=False`.
 
     """
     if "VirtualSites" in interchange.collections:

--- a/openff/interchange/smirnoff/_create.py
+++ b/openff/interchange/smirnoff/_create.py
@@ -13,6 +13,7 @@ from openff.interchange.exceptions import (
     MissingParameterHandlerError,
     PresetChargesError,
     SMIRNOFFHandlersNotImplementedError,
+    UnsupportedExportError,
 )
 from openff.interchange.plugins import load_smirnoff_plugins
 from openff.interchange.smirnoff._base import SMIRNOFFCollection, _check_all_valence_terms_assigned
@@ -469,7 +470,11 @@ def _virtual_sites(
                     vdw = collection  # type: ignore[assignment]
                     break
         else:
-            vdw = None
+            raise UnsupportedExportError(
+                "Virtual sites with no vdW handler not currently supported. If this use case is "
+                "important to you, please raise an issue describing the functionality you wish to "
+                "see.",
+            )
 
     electrostatics: SMIRNOFFElectrostaticsCollection = interchange["Electrostatics"]  # type: ignore[assignment]
 


### PR DESCRIPTION
### Description

Create an `openmm.System` from a force field with no non-bonded handlers and check that it contains particles

This ended up being simpler to implement than I originally thought - 

Subtle behavior(s) resulting here:
- [x] If no non-bonded handlers are present, no `openmm.NonbondedForce`s are created (even though they would be empty)
- [x] If a virtual site handler is present and no vdW handler (or plugin) is present, error

Adjacent behaviors (still) unimplemented (are any relevant now or soon?):
- [ ] If a virtual site handler is present without electrostatics handler(s), unspecified/unhandled behavior
- [ ] If no vdW handler (or plugin) is present but an electrostatics handler(s) is present, don't know what would happen
- [ ] Any Electrostatics "plugins"

Closes #1429

91c55819b2edcb6d1d7a868fab4e00893f9efc37 is a bit of a diversion and I will split it off if this grows in scope any more

### Checklist

- [x] Add tests
  - [x] [Reproduce original issue](https://github.com/openforcefield/openff-interchange/actions/runs/22104013351/job/63881357796?pr=1431)
- [x] Lint
- [ ] Update docstrings