### PR TITLE
Use custom 1-4 scaling factors on interactions involving virtual sites

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     name: Test on ${{ matrix.os }}, ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
     name: Test on ${{ matrix.os }}, ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -1,3 +1,5 @@
+import random
+
 import numpy
 import pytest
 from openff.toolkit import ForceField, Molecule, Quantity, Topology
@@ -669,3 +671,107 @@ class TestvdWOnVirtualSites:
             break
         else:
             raise Exception("Did not find a NonbondedForce")
+
+    @pytest.mark.parametrize(
+        "nonbonded_handler",
+        ["vdW", "Electrostatics"],
+    )
+    def test_virtual_site_virtual_site_custom_14_scaling(
+        self,
+        nonbonded_handler,
+    ):
+        """
+        Given virtual site parameters with non-zero vdW interactions and a
+        non-standard 1-4 scaling factor, test that the 1-4 interactions between
+        two virtual sites (whos parents also participate in a 1-4 interaction)
+        have their 1-4 interactions correctly scaled.
+
+        Lightly adapted from Evan Pretti's reproduction in issue #1436
+        """
+        force_field = ForceField("""<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+<VirtualSites version="0.3">
+  <VirtualSite
+    type="BondCharge"
+    match="all_permutations"
+    smirks="[H:1]-[O:2]"
+    distance="1 * angstrom"
+    charge_increment1="-1 * elementary_charge"
+    sigma="1.0 * angstrom"
+    epsilon="1.0 * kilojoule_per_mole"
+  />
+</VirtualSites>
+<LibraryCharges version="0.3">
+  <LibraryCharge smirks="[#1:1]" charge1="2 * elementary_charge" />
+  <LibraryCharge smirks="[#8:1]" charge1="-2 * elementary_charge" />
+</LibraryCharges>
+<Electrostatics version="0.3" />
+<vdW version="0.3">
+  <Atom smirks="[*:1]" sigma="1.0 * angstrom" epsilon="1.0 * kilojoule_per_mole" />
+</vdW>
+</SMIRNOFF>""")
+        topology = Molecule.from_mapped_smiles("[H:1][O:2][O:3][H:4]").to_topology()
+
+        # Graph of molecule after parametrization (using zero-indexed OpenMM particle indices):
+        #
+        # H(0) - O(1) - O(2) - H(3)
+        # |                    |
+        # VS(4)                VS(5)
+        #
+        # Using exclusion rule "parents," H-H are a 1-4 pair and so VS-VS are also a 1-4 pair
+        # also H(0)-VS(5) and H(3)-VS(4) are 1-4 pairs, everything else is 1-2, 1-3, so non-interacting
+
+        scale_14 = random.uniform(0.5, 1.0)
+        force_field[nonbonded_handler].scale14 = scale_14
+
+        system = force_field.create_openmm_system(topology)
+
+        def get_applied_scaling_factor(
+            force: openmm.NonbondedForce,
+            handler_name: str,
+        ) -> list[float]:
+            """
+            Get the 1-4 scaling factor that was applied to exceptions
+            0-3, 0-5, 3-4, and 4-5, which should nonzero for this molecule.
+            Look separately at vdW or electrostatics parameters.
+
+            This helper function only works for this test case!
+            """
+            look_at = [
+                (0, 3),
+                (0, 5),
+                (3, 4),
+                (4, 5),
+            ]
+
+            found_factors = list()
+
+            for index in range(force.getNumExceptions()):
+                p1, p2, qq, _, epsilon = force.getExceptionParameters(index)
+
+                if tuple(sorted((p1, p2))) not in look_at:
+                    continue
+
+                if handler_name == "Electrostatics":
+                    # charges are just +1 e to make math simpler
+                    found_factors.append(
+                        round(
+                            qq / openmm.unit.elementary_charge**2,
+                            8,
+                        ),
+                    )
+                elif handler_name == "vdW":
+                    # same but with epsilon being 1 kJ/mol
+                    found_factors.append(
+                        round(
+                            epsilon / openmm.unit.kilojoule_per_mole,
+                            8,
+                        ),
+                    )
+                else:
+                    raise Exception("Unknown nonbonded handler")
+
+            return found_factors
+
+        nonbonded_force = next(force for force in system.getForces() if isinstance(force, openmm.NonbondedForce))
+
+        assert get_applied_scaling_factor(nonbonded_force, nonbonded_handler) == 4 * [round(scale_14, 8)]

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -810,6 +810,12 @@ class TestvdWOnVirtualSites:
 
         system = force_field.create_openmm_system(topology)
 
+        for index in range(4):
+            assert system.getParticleMass(index)._value > 0.0
+
+        system.getVirtualSite(4)
+        system.getVirtualSite(5)
+
         def get_applied_scaling_factor(
             force: openmm.NonbondedForce,
             handler_name: str,

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -865,4 +865,6 @@ class TestvdWOnVirtualSites:
 
         nonbonded_force = next(force for force in system.getForces() if isinstance(force, openmm.NonbondedForce))
 
-        assert get_applied_scaling_factor(nonbonded_force, nonbonded_handler) == 4 * [round(scale_14, 8)]
+        assert get_applied_scaling_factor(nonbonded_force, nonbonded_handler) == 4 * [round(scale_14, 8)], (
+            f"not all 1-4 interactions appear to be scaled by {scale_14}, a randomly-generated scaling factor"
+        )

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -506,6 +506,8 @@ def _create_exceptions(
                         existing_exception_index=exception_index,
                         new_p1=virtual_particle_of_p1,
                         new_p2=p2,
+                        charge_scaling=coul_14,
+                        vdw_scaling=vdw_14,
                     )
 
             # If this iterable is not empty, add an exception between p2's virtual
@@ -517,6 +519,8 @@ def _create_exceptions(
                         existing_exception_index=exception_index,
                         new_p1=virtual_particle_of_p2,
                         new_p2=p1,
+                        charge_scaling=coul_14,
+                        vdw_scaling=vdw_14,
                     )
 
             # Adding (child of this parent)-(child of neighbor) exceptions
@@ -529,6 +533,8 @@ def _create_exceptions(
                     existing_exception_index=exception_index,
                     new_p1=v1,
                     new_p2=v2,
+                    charge_scaling=coul_14,
+                    vdw_scaling=vdw_14,
                 )
 
         for (


### PR DESCRIPTION
### Description

Closes #1436

The short of it is that custom 1-4 scaling factors (i.e. not the default 5/6 and 1/2) were applied to exceptions involving pairs of atoms, but **_not_** to any interactions involving virtual sites.

A small assumption I'm making is that the same 1-4 factor should be applied to all particle pairs (atom-atom, virtual site-virtual site, atom-virtual site. I don't see anything in [the spec](https://openforcefield.github.io/standards/standards/smirnoff/#virtualsites-virtual-sites-for-off-atom-charges) that makes me second-guess myself:

> virtual site particles should exclude non-bonded interactions with, or scale their interactions with, the same particles that the main 'parent atom' that they are attached to does. 

### Checklist

- [x] Ensure virtual site-atom exclusions get get custom 1-4 scaling factors
- [x] Ensure virtual site-virtual site exclusions get custom 1-4 scaling factors
- [x] Add tests
  - [x] Set 1-4 charge scaling factor to non-standard value, ensure virtual site-virtual site exclusions and virtual sites-atom exclusions use this value when inherited from 1-4 parents 
  - [x] Do the same for 1-4 vdW scaling factor (on virtual sites with vdW interactions)
- [x] Lint
- [ ] Update docstrings
