### PR TITLE
Fix vsite z-coordinate computation

### DIFF
--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -102,8 +102,8 @@ class TestDivalentLonePairVirtualSite:
         outOfPlaneAngle,
         distance,
     ):
-        from rdkit import Chem
         import rdkit.Chem.rdMolTransforms
+        from rdkit import Chem
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -103,6 +103,7 @@ class TestDivalentLonePairVirtualSite:
         distance,
     ):
         from rdkit import Chem
+        import rdkit.Chem.rdMolTransforms
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -1,6 +1,6 @@
 import numpy
 import pytest
-from openff.toolkit import ForceField, Molecule, Quantity, Topology
+from openff.toolkit import ForceField, Molecule, Quantity, Topology, unit
 from openff.toolkit.typing.engines.smirnoff import VirtualSiteHandler
 from openff.utilities import has_package, skip_if_missing
 
@@ -8,7 +8,6 @@ from openff.interchange._tests import MoleculeWithConformer
 
 if has_package("openmm"):
     import openmm
-
 
 @skip_if_missing("openmm")
 class TestBondChargeVirtualSite:
@@ -90,6 +89,67 @@ class TestTrivalentLonePairVirtualSite:
         )
 
         assert isinstance(system.getVirtualSite(4), openmm.LocalCoordinatesSite)
+
+
+@skip_if_missing("rdkit")
+class TestDivalentLonePairVirtualSite:
+    @pytest.mark.parametrize("outOfPlaneAngle", [10, 20, 30, 40, 50, 60, 70, 80, 90])
+    @pytest.mark.parametrize("distance", [1, 2, 3, 4, 5])
+    def test_expected_geometry_all_permutations(
+        self,
+        water,
+        outOfPlaneAngle,
+        distance,
+    ):
+        from rdkit import Chem
+        from rdkit.Chem import rdMolTransforms
+
+        ff = ForceField("tip3p.offxml")
+        vsite_handler = ff.get_parameter_handler("VirtualSites")
+        assert len(vsite_handler.parameters) == 0
+
+        l_parameter_kwargs = {
+            "smirks": "[#1:2]-[#8X2H2+0:1]-[#1:3]",
+            "type": "DivalentLonePair",
+            "name": "EP-L",
+            "match": "all_permutations",
+            "distance": distance * unit.angstrom,
+            "outOfPlaneAngle": outOfPlaneAngle * unit.degree,
+            "charge_increment": [0 * unit.elementary_charge] * 3,
+            "epsilon": 0.0 * unit.kilocalorie_per_mole,
+            "sigma": 1.0 * unit.angstrom,
+            "id": "water-l"
+        }
+        vsite_handler.add_parameter(l_parameter_kwargs)
+
+        ic = ff.create_interchange(water.to_topology())
+        ic.minimize()
+        positions = ic.get_positions(include_virtual_sites=True)
+
+        rdmol = Chem.RWMol(water.to_rdkit())
+        rdmol.AddAtom(Chem.Atom(0))  # virtual site
+        rdmol.AddAtom(Chem.Atom(0))  # virtual site
+
+        # Create conformer with virtual site positions
+        conf = Chem.Conformer(5)  # 3 atoms + 2 virtual sites
+        for i in range(5):
+            conf.SetAtomPosition(
+                i,
+                (
+                    positions[i, 0].m_as("angstrom"),
+                    positions[i, 1].m_as("angstrom"),
+                    positions[i, 2].m_as("angstrom"),
+                ),
+            )
+        rdmol.AddConformer(conf)
+
+        hoh_angle = Chem.rdMolTransforms.GetAngleDeg(conf, 1, 0, 2)
+        lol_angle = Chem.rdMolTransforms.GetAngleDeg(conf, 3, 0, 4)
+        ol_distance = Chem.rdMolTransforms.GetBondLength(conf, 0, 3)
+
+        assert hoh_angle == pytest.approx(104.52, abs=1.0)
+        assert ol_distance == pytest.approx(distance, abs=0.1)
+        assert lol_angle == pytest.approx(outOfPlaneAngle * 2, abs=1.0)
 
 
 @skip_if_missing("openmm")
@@ -291,7 +351,38 @@ class TestTIP5PVsOpenMM:
         assert openff_virtual_sites[0].getParticle(1) == openff_virtual_sites[1].getParticle(2)
         assert openff_virtual_sites[0].getParticle(2) == openff_virtual_sites[1].getParticle(1)
 
-        # TODO: Also doubly compare geometry to OpenMM result
+        # Compare virtual site positions computed by OpenMM vs OpenFF
+        # Create OpenMM context to compute virtual site positions
+        integrator = openmm.VerletIntegrator(0.001)
+        context = openmm.Context(openff_system, integrator)
+        
+        # set up positions
+        positions = water.conformers[0].to_openmm().value_in_unit(openmm.unit.nanometer)
+        positions = numpy.concatenate([positions, numpy.zeros((2, 3))])  # add placeholders for virtual sites
+        context.setPositions(positions)
+        
+        # Compute virtual site positions using OpenMM's algorithm
+        context.computeVirtualSites()
+        
+        # Get all positions including computed virtual sites
+        openmm_state = context.getState(getPositions=True)
+        openmm_positions = openmm_state.getPositions(asNumpy=True).value_in_unit(
+            openmm.unit.nanometer,
+        )
+        
+        # Get OpenFF interchange positions with virtual sites
+        openff_interchange = tip5p.create_interchange(water.to_topology())
+        openff_positions = openff_interchange.get_positions(
+            include_virtual_sites=True,
+        ).m_as("nanometer")
+        
+        # Compare all 5 particle positions (O, H, H, VS1, VS2)
+        numpy.testing.assert_allclose(
+            openmm_positions,
+            openff_positions,
+            rtol=1e-6,
+            atol=1e-8,
+        )
 
 
 # TODO: Port xml_ff_virtual_sites_monovalent from toolkit

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -102,7 +102,7 @@ class TestDivalentLonePairVirtualSite:
         distance,
     ):
         from rdkit import Chem
-        from rdkit.Chem import rdMolTransforms
+        import rdkit.Chem.rdMolTransforms
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -9,6 +9,7 @@ from openff.interchange._tests import MoleculeWithConformer
 if has_package("openmm"):
     import openmm
 
+
 @skip_if_missing("openmm")
 class TestBondChargeVirtualSite:
     @pytest.mark.parametrize(
@@ -102,7 +103,6 @@ class TestDivalentLonePairVirtualSite:
         distance,
     ):
         from rdkit import Chem
-        import rdkit.Chem.rdMolTransforms
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")
@@ -118,7 +118,7 @@ class TestDivalentLonePairVirtualSite:
             "charge_increment": [0 * unit.elementary_charge] * 3,
             "epsilon": 0.0 * unit.kilocalorie_per_mole,
             "sigma": 1.0 * unit.angstrom,
-            "id": "water-l"
+            "id": "water-l",
         }
         vsite_handler.add_parameter(l_parameter_kwargs)
 
@@ -355,27 +355,27 @@ class TestTIP5PVsOpenMM:
         # Create OpenMM context to compute virtual site positions
         integrator = openmm.VerletIntegrator(0.001)
         context = openmm.Context(openff_system, integrator)
-        
+
         # set up positions
         positions = water.conformers[0].to_openmm().value_in_unit(openmm.unit.nanometer)
         positions = numpy.concatenate([positions, numpy.zeros((2, 3))])  # add placeholders for virtual sites
         context.setPositions(positions)
-        
+
         # Compute virtual site positions using OpenMM's algorithm
         context.computeVirtualSites()
-        
+
         # Get all positions including computed virtual sites
         openmm_state = context.getState(getPositions=True)
         openmm_positions = openmm_state.getPositions(asNumpy=True).value_in_unit(
             openmm.unit.nanometer,
         )
-        
+
         # Get OpenFF interchange positions with virtual sites
         openff_interchange = tip5p.create_interchange(water.to_topology())
         openff_positions = openff_interchange.get_positions(
             include_virtual_sites=True,
         ).m_as("nanometer")
-        
+
         # Compare all 5 particle positions (O, H, H, VS1, VS2)
         numpy.testing.assert_allclose(
             openmm_positions,

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -125,7 +125,7 @@ class TestDivalentLonePairVirtualSite:
 
         ic = ff.create_interchange(water.to_topology())
         ic.minimize()
-        positions = ic.get_positions(include_virtual_sites=True)
+        positions = ic.get_positions(include_virtual_sites=True).m_as("angstrom")
 
         rdmol = Chem.RWMol(water.to_rdkit())
         rdmol.AddAtom(Chem.Atom(0))  # virtual site
@@ -134,14 +134,7 @@ class TestDivalentLonePairVirtualSite:
         # Create conformer with virtual site positions
         conf = Chem.Conformer(5)  # 3 atoms + 2 virtual sites
         for i in range(5):
-            conf.SetAtomPosition(
-                i,
-                (
-                    positions[i, 0].m_as("angstrom"),
-                    positions[i, 1].m_as("angstrom"),
-                    positions[i, 2].m_as("angstrom"),
-                ),
-            )
+            conf.SetAtomPosition(i, positions[i])
         rdmol.AddConformer(conf)
 
         hoh_angle = rdkit.Chem.rdMolTransforms.GetAngleDeg(conf, 1, 0, 2)

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -143,9 +143,9 @@ class TestDivalentLonePairVirtualSite:
             )
         rdmol.AddConformer(conf)
 
-        hoh_angle = Chem.rdMolTransforms.GetAngleDeg(conf, 1, 0, 2)
-        lol_angle = Chem.rdMolTransforms.GetAngleDeg(conf, 3, 0, 4)
-        ol_distance = Chem.rdMolTransforms.GetBondLength(conf, 0, 3)
+        hoh_angle = rdkit.Chem.rdMolTransforms.GetAngleDeg(conf, 1, 0, 2)
+        lol_angle = rdkit.Chem.rdMolTransforms.GetAngleDeg(conf, 3, 0, 4)
+        ol_distance = rdkit.Chem.rdMolTransforms.GetBondLength(conf, 0, 3)
 
         assert hoh_angle == pytest.approx(104.52, abs=1e-4)
         assert ol_distance == pytest.approx(distance, abs=1e-4)

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -103,7 +103,6 @@ class TestDivalentLonePairVirtualSite:
         distance,
     ):
         from rdkit import Chem
-        import rdkit.Chem.rdMolTransforms
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")

--- a/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
+++ b/openff/interchange/_tests/unit_tests/interop/openmm/test_virtual_sites.py
@@ -103,6 +103,7 @@ class TestDivalentLonePairVirtualSite:
         distance,
     ):
         from rdkit import Chem
+        import rdkit.Chem.rdMolTransforms
 
         ff = ForceField("tip3p.offxml")
         vsite_handler = ff.get_parameter_handler("VirtualSites")
@@ -147,9 +148,9 @@ class TestDivalentLonePairVirtualSite:
         lol_angle = Chem.rdMolTransforms.GetAngleDeg(conf, 3, 0, 4)
         ol_distance = Chem.rdMolTransforms.GetBondLength(conf, 0, 3)
 
-        assert hoh_angle == pytest.approx(104.52, abs=1.0)
-        assert ol_distance == pytest.approx(distance, abs=0.1)
-        assert lol_angle == pytest.approx(outOfPlaneAngle * 2, abs=1.0)
+        assert hoh_angle == pytest.approx(104.52, abs=1e-4)
+        assert ol_distance == pytest.approx(distance, abs=1e-4)
+        assert lol_angle == pytest.approx(outOfPlaneAngle * 2, abs=1e-4)
 
 
 @skip_if_missing("openmm")

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -445,7 +445,7 @@ def _build_local_coordinate_frames(
         else:
             # Degenerate case for co-linear atoms, most likely as BondCharges
             # Construct an arbitrary perpendicular vector to x_hat
-            if abs(x_hat[0]) < 0.9: # corresponds to >= ~26 degrees away from x-axis
+            if abs(x_hat[0]) < 0.9:  # corresponds to >= ~26 degrees away from x-axis
                 z_hat = numpy.cross(x_hat, numpy.array([1.0, 0.0, 0.0]))
             else:
                 z_hat = numpy.cross(x_hat, numpy.array([0.0, 1.0, 0.0]))

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -436,7 +436,8 @@ def _build_local_coordinate_frames(
         ).reshape(-1, 1)
 
         x_hat = xy_plane_norm[0, :]
-        z_hat = numpy.cross(x_hat, xy_plane[1, :])
+        z_hat = numpy.cross(x_hat, xy_plane_norm[1, :])
+        z_hat = z_hat / numpy.linalg.norm(z_hat)
         y_hat = numpy.cross(z_hat, x_hat)
 
         stacked_frames[0].append(origin.reshape(1, -1))

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -443,9 +443,9 @@ def _build_local_coordinate_frames(
         if z_norm > THRESHOLD:
             z_hat /= z_norm
         else:
-            # Degenerate case for BondCharges
+            # Degenerate case for co-linear atoms, most likely as BondCharges
             # Construct an arbitrary perpendicular vector to x_hat
-            if abs(x_hat[0]) < 0.9:
+            if abs(x_hat[0]) < 0.9: # corresponds to >= ~26 degrees away from x-axis
                 z_hat = numpy.cross(x_hat, numpy.array([1.0, 0.0, 0.0]))
             else:
                 z_hat = numpy.cross(x_hat, numpy.array([0.0, 1.0, 0.0]))

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -436,8 +436,7 @@ def _build_local_coordinate_frames(
         ).reshape(-1, 1)
 
         x_hat = xy_plane_norm[0, :]
-        z_hat = numpy.cross(x_hat, xy_plane_norm[1, :])
-        z_hat = z_hat / numpy.linalg.norm(z_hat)
+        z_hat = numpy.cross(x_hat, xy_plane[1, :])
         y_hat = numpy.cross(z_hat, x_hat)
 
         stacked_frames[0].append(origin.reshape(1, -1))

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -437,7 +437,20 @@ def _build_local_coordinate_frames(
 
         x_hat = xy_plane_norm[0, :]
         z_hat = numpy.cross(x_hat, xy_plane_norm[1, :])
-        z_hat = z_hat / numpy.linalg.norm(z_hat)
+        z_norm = numpy.linalg.norm(z_hat)
+
+        THRESHOLD = 1e-6
+        if z_norm > THRESHOLD:
+            z_hat /= z_norm
+        else:
+            # Degenerate case for BondCharges
+            # Construct an arbitrary perpendicular vector to x_hat
+            if abs(x_hat[0]) < 0.9:
+                z_hat = numpy.cross(x_hat, numpy.array([1.0, 0.0, 0.0]))
+            else:
+                z_hat = numpy.cross(x_hat, numpy.array([0.0, 1.0, 0.0]))
+            z_hat = z_hat / numpy.linalg.norm(z_hat)
+        
         y_hat = numpy.cross(z_hat, x_hat)
 
         stacked_frames[0].append(origin.reshape(1, -1))

--- a/openff/interchange/smirnoff/_virtual_sites.py
+++ b/openff/interchange/smirnoff/_virtual_sites.py
@@ -450,7 +450,7 @@ def _build_local_coordinate_frames(
             else:
                 z_hat = numpy.cross(x_hat, numpy.array([0.0, 1.0, 0.0]))
             z_hat = z_hat / numpy.linalg.norm(z_hat)
-        
+
         y_hat = numpy.cross(z_hat, x_hat)
 
         stacked_frames[0].append(origin.reshape(1, -1))


### PR DESCRIPTION
### Description

Fixes #1438

The ultimate issue was the local coordinate frame was being computed with unnormalized vectors.

It may be worth expanding this OpenFF vs OpenMM coordinate geometry test to the other water models, but I haven't done that here.

### Checklist

- [x] Add tests
- [ ] Lint
- [ ] Update docstrings
