### PR TITLE
Use set for 1-4 pair lookup in _create_multiple_nonbonded_forces

### DIFF
--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -645,7 +645,7 @@ def _create_multiple_nonbonded_forces(
 
     coul_14, vdw_14 = _get_14_scaling_factors(data)
 
-    openmm_pairs = list()
+    openmm_pairs = set()
 
     for atom1, atom2 in _get_14_pairs(interchange.topology):
         openff_indices = (
@@ -658,7 +658,7 @@ def _create_multiple_nonbonded_forces(
             openff_openmm_particle_map[openff_indices[1]],
         )
 
-        openmm_pairs.append(openmm_indices)
+        openmm_pairs.add(openmm_indices)
 
     if electrostatics_force is not None:
         for i in range(electrostatics_force.getNumExceptions()):


### PR DESCRIPTION
## Summary

Replace `list()` with `set()` for the `openmm_pairs` container in
`_create_multiple_nonbonded_forces()`, changing 1-4 pair membership checks
from O(N) to O(1). This eliminates quadratic scaling in `to_openmm()` for
systems with many 1-4 interactions.

### Changes

Two lines in `openff/interchange/interop/openmm/_nonbonded.py`:

- `openmm_pairs = list()` → `openmm_pairs = set()`
- `openmm_pairs.append(openmm_indices)` → `openmm_pairs.add(openmm_indices)`

No other code changes are needed — `openmm_pairs` is only used for membership
testing, never indexed or iterated in order.

### Impact

Benchmarks on hexane + water systems show up to **12× speedup** at 25K atoms,
with the improvement growing as system size increases. Full details, benchmark
data, scaling plots, and a reproducer script are available in #1444.

Addresses #1444