### PR TITLE
Fix JSON serialization with pydantic >=2.12

### DIFF
--- a/.github/workflows/ci-pydantic-latest.yaml
+++ b/.github/workflows/ci-pydantic-latest.yaml
@@ -1,0 +1,44 @@
+name: ci-pydantic-latest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: pixi run -e py312amber bash -e {0}
+
+jobs:
+  test:
+    name: Test with latest pydantic on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up virtual environment
+      uses: prefix-dev/setup-pixi@v0.9.5
+      with:
+        pixi-version: v0.41.4
+        environments: py312amber
+        frozen: true
+
+    - name: Upgrade pydantic to latest
+      run: pip install "pydantic>=2.12"
+
+    - name: Run mypy
+      run: pixi run -e py312amber run_mypy
+
+    - name: Run tests
+      run: pixi run -e py312amber run_tests

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools !=76.0.0
   - pip
   - numpy =2
-  - pydantic >=2,<2.12
+  - pydantic >=2
   - openff-toolkit-base =0.17
   - openmm
   - mbuild-base =1

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -448,7 +448,20 @@ def validate_collections(
         raise ValueError(f"Validation mode {info.mode} not implemented.")
 
 
+def serialize_collections(v: Any, handler: Any, info: Any) -> dict:
+    """Serialize collections using each collection's actual type schema.
+
+    Without this, pydantic uses the declared Collection base class schema and
+    drops subclass-specific fields (e.g. scale_14, cutoff, periodic_potential).
+    """
+    if info.mode == "json":
+        return {name: json.loads(collection.model_dump_json()) for name, collection in v.items()}
+    else:
+        raise NotImplementedError(f"Serialization mode {info.mode} not implemented.")
+
+
 _AnnotatedCollections = Annotated[
     dict[str, Collection],
     WrapValidator(validate_collections),
+    WrapSerializer(serialize_collections),
 ]

--- a/openff/interchange/pydantic.py
+++ b/openff/interchange/pydantic.py
@@ -17,4 +17,7 @@ class _BaseModel(BaseModel):
         return super().model_dump(serialize_as_any=True, **kwargs)
 
     def model_dump_json(self, **kwargs) -> str:
-        return super().model_dump_json(serialize_as_any=True, **kwargs)
+        # serialize_as_any=True breaks pint.Quantity serialization in pydantic >=2.12
+        # (pydantic/pydantic#12348); the Annotated WrapSerializer on _Quantity handles
+        # JSON serialization correctly without it
+        return super().model_dump_json(**kwargs)


### PR DESCRIPTION
## Summary

pydantic 2.12 changed `serialize_as_any=True` to propagate the flag to all nested values ([pydantic/pydantic#12348](https://github.com/pydantic/pydantic/issues/12348)). This broke JSON serialization in two ways, requiring two fixes.

### Fix 1: `pydantic.py` — remove `serialize_as_any=True` from `model_dump_json()`

With pydantic ≥2.12, `serialize_as_any=True` in JSON mode bypasses the `Annotated` `WrapSerializer` on `_Quantity` and tries to serialize `pint.Quantity` by its runtime type, which has no pydantic schema:

```
PydanticSerializationError: Unable to serialize unknown type: <class 'pint.Quantity'>
```

The `WrapSerializer(quantity_json_serializer)` on `_Quantity` handles JSON serialization correctly without this flag. `serialize_as_any=True` is intentionally kept in `model_dump()` (Python mode), which is unaffected by the pydantic 2.12 change.

### Fix 2: `components/potentials.py` — add `WrapSerializer` to `_AnnotatedCollections`

Without `serialize_as_any=True`, pydantic serializes `collections: dict[str, Collection]` using the declared `Collection` base class schema, silently dropping subclass-specific fields (`scale_14`, `cutoff`, `periodic_potential`, etc. from `_NonbondedCollection` and subclasses). This caused wrong electrostatics energies after JSON roundtrip:

```
AssertionError: assert 0.5 == 0.8333333333  # scale_14 reset to default
EnergyError: {'Electrostatics': <Quantity(-17.38, 'kilojoule / mole')>}
```

The fix adds a `WrapSerializer` to `_AnnotatedCollections` that calls `model_dump_json()` on each collection instance directly. Since the call is on the actual instance (e.g. `SMIRNOFFElectrostaticsCollection`), pydantic uses the full subclass schema and all fields are preserved.

Fixes #1346.

## Test results (pydantic 2.13.3, after both fixes, `py312amber` environment)

```
612 passed, 119 skipped, 13 xfailed, 8 xpassed in 248.98s
```

Zero failures. Mypy also passes (`Success: no issues found in 85 source files`).