### PR TITLE
Defer evaluation of annotations, automatically guard annotation-only imports

### DIFF
--- a/openff/interchange/common/_valence.py
+++ b/openff/interchange/common/_valence.py
@@ -1,10 +1,12 @@
 from collections.abc import Iterable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from openff.toolkit.topology import Atom
 from pydantic import Field
 
 from openff.interchange.components.potentials import Collection
+
+if TYPE_CHECKING:
+    from openff.toolkit.topology import Atom
 
 
 class ConstraintCollection(Collection):

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pathlib
 import tempfile
 import warnings
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
@@ -14,21 +13,13 @@ from openff.utilities.utilities import has_package, requires_package
 from pydantic import Field
 
 from openff.interchange._annotations import (
-    PositiveFloat,
     _BoxQuantity,
     _PositionsQuantity,
     _VelocityQuantity,
 )
 from openff.interchange._experimental import experimental
-from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
-from openff.interchange.common._valence import (
-    AngleCollection,
-    BondCollection,
-    ImproperTorsionCollection,
-    ProperTorsionCollection,
-)
 from openff.interchange.components.mdconfig import MDConfig
-from openff.interchange.components.potentials import Collection, _AnnotatedCollections
+from openff.interchange.components.potentials import _AnnotatedCollections
 from openff.interchange.exceptions import (
     InvalidPositionsError,
     MissingParameterHandlerError,
@@ -40,19 +31,32 @@ from openff.interchange.operations.minimize import (
 )
 from openff.interchange.pydantic import _BaseModel
 from openff.interchange.serialization import _AnnotatedTopology
-from openff.interchange.smirnoff import (
-    SMIRNOFFConstraintCollection,
-    SMIRNOFFVirtualSiteCollection,
-)
-from openff.interchange.smirnoff._gbsa import SMIRNOFFGBSACollection
 from openff.interchange.warnings import InterchangeDeprecationWarning
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import openmm
     import openmm.app
     from openff.toolkit import ForceField
 
+    from openff.interchange._annotations import (
+        PositiveFloat,
+    )
+    from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
+    from openff.interchange.common._valence import (
+        AngleCollection,
+        BondCollection,
+        ImproperTorsionCollection,
+        ProperTorsionCollection,
+    )
+    from openff.interchange.components.potentials import Collection
     from openff.interchange.foyer._guard import has_foyer
+    from openff.interchange.smirnoff import (
+        SMIRNOFFConstraintCollection,
+        SMIRNOFFVirtualSiteCollection,
+    )
+    from openff.interchange.smirnoff._gbsa import SMIRNOFFGBSACollection
 
     if has_foyer:
         try:

--- a/openff/interchange/components/interchange.py
+++ b/openff/interchange/components/interchange.py
@@ -1,11 +1,13 @@
 """An object for storing, manipulating, and converting molecular mechanics data."""
 
+from __future__ import annotations
+
 import pathlib
 import tempfile
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Union, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from openff.toolkit import Molecule, Quantity, Topology
 from openff.utilities.utilities import has_package, requires_package
@@ -92,14 +94,14 @@ class Interchange(_BaseModel):
     @classmethod
     def from_smirnoff(
         cls,
-        force_field: "ForceField",
+        force_field: ForceField,
         topology: Topology | list[Molecule],
         box: Quantity | None = None,
         positions: Quantity | None = None,
         charge_from_molecules: list[Molecule] | None = None,
         partial_bond_orders_from_molecules: list[Molecule] | None = None,
         allow_nonintegral_charges: bool = False,
-    ) -> "Interchange":
+    ) -> Interchange:
         """
         Create a new object by parameterizing a topology with a SMIRNOFF force field.
 
@@ -172,7 +174,7 @@ class Interchange(_BaseModel):
         self,
         backend: str = "nglview",
         include_virtual_sites: bool = False,
-    ) -> "nglview.NGLWidget":
+    ) -> nglview.NGLWidget:
         """
         Visualize this Interchange.
 
@@ -222,7 +224,7 @@ class Interchange(_BaseModel):
     def _visualize_nglview(
         self,
         include_virtual_sites: bool = False,
-    ) -> "nglview.NGLWidget":
+    ) -> nglview.NGLWidget:
         """
         Visualize the system using NGLView via a PDB file.
 
@@ -603,14 +605,14 @@ class Interchange(_BaseModel):
 
     def to_openmm_simulation(
         self,
-        integrator: "openmm.Integrator",
+        integrator: openmm.Integrator,
         combine_nonbonded_forces: bool = True,
         add_constrained_forces: bool = False,
         ewald_tolerance: float = 1e-4,
         hydrogen_mass: PositiveFloat = 1.007947,
-        additional_forces: Iterable["openmm.Force"] = tuple(),
+        additional_forces: Iterable[openmm.Force] = tuple(),
         **kwargs,
-    ) -> "openmm.app.simulation.Simulation":
+    ) -> openmm.app.simulation.Simulation:
         """
         Export this Interchange to an OpenMM ``Simulation`` object.
 
@@ -813,12 +815,12 @@ class Interchange(_BaseModel):
     @requires_package("foyer")
     def from_foyer(
         cls,
-        force_field: "FoyerForcefield",
+        force_field: FoyerForcefield,
         topology: Topology,
         box=None,
         positions=None,
         **kwargs,
-    ) -> "Interchange":
+    ) -> Interchange:
         """
         Create an Interchange object from a Foyer force field and an OpenFF topology.
 
@@ -856,7 +858,7 @@ class Interchange(_BaseModel):
         cls,
         topology_file: Path | str,
         gro_file: Path | str,
-    ) -> "Interchange":
+    ) -> Interchange:
         """
         Create an Interchange object from GROMACS files.
 
@@ -918,11 +920,11 @@ class Interchange(_BaseModel):
     @classmethod
     def from_openmm(
         cls,
-        system: "openmm.System",
-        topology: Union["openmm.app.Topology", Topology],
+        system: openmm.System,
+        topology: openmm.app.Topology | Topology,
         positions: Quantity | None = None,
         box_vectors: Quantity | None = None,
-    ) -> "Interchange":
+    ) -> Interchange:
         """
         Create an Interchange object from OpenMM objects.
 
@@ -985,58 +987,58 @@ class Interchange(_BaseModel):
         )
 
     @overload
-    def __getitem__(self, item: Literal["Bonds"]) -> "BondCollection": ...
+    def __getitem__(self, item: Literal["Bonds"]) -> BondCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["Constraints"],
-    ) -> "SMIRNOFFConstraintCollection": ...
+    ) -> SMIRNOFFConstraintCollection: ...
 
     @overload
-    def __getitem__(self, item: Literal["Angles"]) -> "AngleCollection": ...
+    def __getitem__(self, item: Literal["Angles"]) -> AngleCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["vdW"],
-    ) -> "vdWCollection": ...
+    ) -> vdWCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["ProperTorsions"],
-    ) -> "ProperTorsionCollection": ...
+    ) -> ProperTorsionCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["ImproperTorsions"],
-    ) -> "ImproperTorsionCollection": ...
+    ) -> ImproperTorsionCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["VirtualSites"],
-    ) -> "SMIRNOFFVirtualSiteCollection": ...
+    ) -> SMIRNOFFVirtualSiteCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["Electrostatics"],
-    ) -> "ElectrostaticsCollection": ...
+    ) -> ElectrostaticsCollection: ...
 
     @overload
     def __getitem__(
         self,
         item: Literal["GBSA"],
-    ) -> "SMIRNOFFGBSACollection": ...
+    ) -> SMIRNOFFGBSACollection: ...
 
     @overload
     def __getitem__(
         self,
         item: str,
-    ) -> "Collection": ...
+    ) -> Collection: ...
 
     def __getitem__(self, item: str):
         """Syntax sugar for looking up collections or other components."""
@@ -1056,7 +1058,7 @@ class Interchange(_BaseModel):
                 f"collections registered:\n\t{[*self.collections.keys()]}",
             )
 
-    def __add__(self, other: "Interchange") -> "Interchange":
+    def __add__(self, other: Interchange) -> Interchange:
         """Combine two Interchange objects."""
         warnings.warn(
             "The `+` operator is deprecated. Use `Interchange.combine` instead.",
@@ -1065,7 +1067,7 @@ class Interchange(_BaseModel):
 
         return self.combine(other)
 
-    def combine(self, other: "Interchange") -> "Interchange":
+    def combine(self, other: Interchange) -> Interchange:
         """
         Combine two Interchange objects.
 

--- a/openff/interchange/components/mbuild.py
+++ b/openff/interchange/components/mbuild.py
@@ -1,5 +1,7 @@
 """Utilities for processing and interfacing with mBuild models."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from openff.toolkit import Molecule, Topology
@@ -10,7 +12,7 @@ if has_package("mbuild") or TYPE_CHECKING:
 
 
 @requires_package("mbuild")
-def offmol_to_compound(off_mol: "Molecule") -> "mbuild.Compound":
+def offmol_to_compound(off_mol: Molecule) -> mbuild.Compound:
     """
     Convert an OpenFF Molecule into an mBuild Compound.
 
@@ -48,7 +50,7 @@ def offmol_to_compound(off_mol: "Molecule") -> "mbuild.Compound":
 
 
 @requires_package("mbuild")
-def offtop_to_compound(off_top: "Topology") -> "mbuild.Compound":
+def offtop_to_compound(off_top: Topology) -> mbuild.Compound:
     """
     Convert an OpenFF Topology into an mBuild Compound.
 

--- a/openff/interchange/components/mbuild.py
+++ b/openff/interchange/components/mbuild.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from openff.toolkit import Molecule, Topology
 from openff.utilities.utilities import has_package, requires_package
+
+if TYPE_CHECKING:
+    from openff.toolkit import Molecule, Topology
 
 if has_package("mbuild") or TYPE_CHECKING:
     import mbuild

--- a/openff/interchange/components/mdconfig.py
+++ b/openff/interchange/components/mdconfig.py
@@ -1,5 +1,7 @@
 """Runtime settings for MD simulations."""
 
+from __future__ import annotations
+
 import warnings
 from io import StringIO
 from pathlib import Path
@@ -78,7 +80,7 @@ class MDConfig(_BaseModel):
     )
 
     @classmethod
-    def from_interchange(cls, interchange: "Interchange") -> "MDConfig":
+    def from_interchange(cls, interchange: Interchange) -> MDConfig:
         """Generate a MDConfig object from an Interchange object."""
         mdconfig = cls(
             periodic=interchange.box is not None,
@@ -113,7 +115,7 @@ class MDConfig(_BaseModel):
 
         return mdconfig
 
-    def apply(self, interchange: "Interchange"):
+    def apply(self, interchange: Interchange):
         """Attempt to apply these settings to an Interchange object."""
         if self.periodic:
             if interchange.box is None:
@@ -220,7 +222,7 @@ class MDConfig(_BaseModel):
 
     def write_lammps_input(
         self,
-        interchange: "Interchange",
+        interchange: Interchange,
         input_file: str = "run.in",
         data_file: str = "out.lmp",
     ) -> None:
@@ -240,7 +242,7 @@ class MDConfig(_BaseModel):
         # TODO: Process rigid water
 
         def _get_coeffs_of_constrained_bonds_and_angles(
-            interchange: "Interchange",
+            interchange: Interchange,
         ) -> tuple[set[int], set[int]]:
             """
             Get coefficients of bonds and angles that appear to be constrained.
@@ -473,7 +475,7 @@ class MDConfig(_BaseModel):
             Path(input_file).write_text(sander.getvalue())
 
 
-def _infer_constraints(interchange: "Interchange") -> str:
+def _infer_constraints(interchange: Interchange) -> str:
     if "Constraints" not in interchange.collections:
         return "none"
     elif "Bonds" not in interchange.collections:

--- a/openff/interchange/components/potentials.py
+++ b/openff/interchange/components/potentials.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import numpy
 from numpy.typing import ArrayLike
-from openff.toolkit import Quantity
 from openff.utilities.utilities import has_package, requires_package
 from pydantic import (
     Field,
@@ -29,6 +28,8 @@ from openff.interchange.models import (
 from openff.interchange.pydantic import _BaseModel
 
 if TYPE_CHECKING:
+    from openff.toolkit import Quantity
+
     if has_package("jax"):
         from jax import Array
     else:

--- a/openff/interchange/components/toolkit.py
+++ b/openff/interchange/components/toolkit.py
@@ -11,15 +11,12 @@ import numpy
 from openff.toolkit import ForceField, Molecule, Quantity, Topology
 from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler, VirtualSiteHandler
-from openff.toolkit.utils.collections import ValidatedList
-from openff.utilities.utilities import has_package
 
 from openff.interchange.models import ImportedVirtualSiteKey, PotentialKey
 
-if has_package("openmm") or TYPE_CHECKING:
+if TYPE_CHECKING:
     import openmm
-    import openmm.app
-
+    from openff.toolkit.utils.collections import ValidatedList
 
 _IDIVF_1 = Quantity(1.0, "dimensionless")
 _PERIODICITIES = {

--- a/openff/interchange/components/toolkit.py
+++ b/openff/interchange/components/toolkit.py
@@ -1,5 +1,7 @@
 """Utilities for processing and interfacing with the OpenFF Toolkit."""
 
+from __future__ import annotations
+
 from collections import defaultdict
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -30,7 +32,7 @@ _PERIODICITIES = {
 }
 
 
-def _get_num_h_bonds(topology: "Topology") -> int:
+def _get_num_h_bonds(topology: Topology) -> int:
     """Get the number of (covalent) bonds containing a hydrogen atom."""
     n_bonds_containing_hydrogen = 0
 
@@ -77,7 +79,7 @@ def _get_14_pairs(topology_or_molecule: Topology | Molecule):
                         yield (atom_i_partner, atom_j_partner)
 
 
-def _validated_list_to_array(validated_list: "ValidatedList") -> Quantity:
+def _validated_list_to_array(validated_list: ValidatedList) -> Quantity:
     unit_ = validated_list[0].units
     return Quantity(numpy.asarray([val.m for val in validated_list]), unit_)
 
@@ -92,7 +94,7 @@ def _combine_topologies(topology1: Topology, topology2: Topology) -> Topology:
     return topology1_
 
 
-def _check_electrostatics_handlers(force_field: "ForceField") -> bool:
+def _check_electrostatics_handlers(force_field: ForceField) -> bool:
     """
     Return whether or not this ForceField should have an Electrostatics tag.
     """
@@ -122,8 +124,8 @@ def _check_electrostatics_handlers(force_field: "ForceField") -> bool:
 
 
 def _simple_topology_from_openmm(
-    openmm_topology: "openmm.app.Topology",
-    system: "openmm.System" | None = None,
+    openmm_topology: openmm.app.Topology,
+    system: openmm.System | None = None,
 ) -> Topology:
     """
     Convert an OpenMM Topology into an OpenFF Topology consisting **only** of so-called `_SimpleMolecule`s.
@@ -135,6 +137,8 @@ def _simple_topology_from_openmm(
     system
         The OpenMM System associated with the topology. Only needed if there are virtual sites in the topology.
     """
+    import openmm
+
     # TODO: Splice in fully-defined OpenFF `Molecule`s?
 
     graph = networkx.Graph()

--- a/openff/interchange/components/toolkit.py
+++ b/openff/interchange/components/toolkit.py
@@ -15,6 +15,7 @@ from openff.utilities.utilities import has_package
 from openff.interchange.models import ImportedVirtualSiteKey, PotentialKey
 
 if has_package("openmm") or TYPE_CHECKING:
+    import openmm
     import openmm.app
 
 
@@ -122,7 +123,7 @@ def _check_electrostatics_handlers(force_field: "ForceField") -> bool:
 
 def _simple_topology_from_openmm(
     openmm_topology: "openmm.app.Topology",
-    system: openmm.System | None = None,
+    system: "openmm.System" | None = None,
 ) -> Topology:
     """
     Convert an OpenMM Topology into an OpenFF Topology consisting **only** of so-called `_SimpleMolecule`s.

--- a/openff/interchange/drivers/all.py
+++ b/openff/interchange/drivers/all.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from openff.utilities.utilities import requires_package
 
-from openff.interchange import Interchange
 from openff.interchange.drivers.amber import get_amber_energies
 from openff.interchange.drivers.gromacs import get_gromacs_energies
 from openff.interchange.drivers.lammps import get_lammps_energies
 from openff.interchange.drivers.openmm import get_openmm_energies
-from openff.interchange.drivers.report import EnergyReport
 from openff.interchange.exceptions import (
     AmberError,
     GMXError,
@@ -22,7 +19,12 @@ from openff.interchange.exceptions import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import pandas
+
+    from openff.interchange import Interchange
+    from openff.interchange.drivers.report import EnergyReport
 
 
 def get_all_energies(

--- a/openff/interchange/drivers/all.py
+++ b/openff/interchange/drivers/all.py
@@ -1,5 +1,7 @@
 """Functions for running energy evluations with all available engines."""
 
+from __future__ import annotations
+
 import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
 
 
 def get_all_energies(
-    interchange: "Interchange",
+    interchange: Interchange,
     combine_nonbonded_forces: bool = False,
     _engines: Iterable[str] = ("OpenMM", "Amber", "GROMACS", "LAMMPS"),
 ) -> dict[str, EnergyReport]:
@@ -64,10 +66,10 @@ def get_all_energies(
 
 @requires_package("pandas")
 def get_summary_data(
-    interchange: "Interchange",
+    interchange: Interchange,
     combine_nonbonded_forces: bool = False,
     _engines: Iterable[str] = ("OpenMM", "Amber", "GROMACS", "LAMMPS"),
-) -> "pandas.DataFrame":
+) -> pandas.DataFrame:
     """Return a pandas DataFrame with summaries of energies from all available engines."""
     from pandas import DataFrame
 

--- a/openff/interchange/drivers/openmm.py
+++ b/openff/interchange/drivers/openmm.py
@@ -1,7 +1,9 @@
 """Functions for running energy evluations with OpenMM."""
 
+from __future__ import annotations
+
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy
 from openff.toolkit import Quantity
@@ -98,12 +100,12 @@ def get_openmm_energies(
 
 
 def _get_openmm_energies(
-    system: "openmm.System",
-    box_vectors: Optional["openmm.unit.Quantity"],
-    positions: "openmm.unit.Quantity",
+    system: openmm.System,
+    box_vectors: openmm.unit.Quantity | None,
+    positions: openmm.unit.Quantity,
     round_positions: int | None,
     platform: str,
-) -> dict[int, "openmm.unit.Quantity"]:
+) -> dict[int, openmm.unit.Quantity]:
     """Given prepared `openmm` objects, run a single-point energy calculation."""
     for index, force in enumerate(system.getForces()):
         force.setForceGroup(index)
@@ -141,8 +143,8 @@ def _get_openmm_energies(
 
 
 def _process(
-    raw_energies: dict[int, "openmm.unit.Quantity"],
-    system: "openmm.System",
+    raw_energies: dict[int, openmm.unit.Quantity],
+    system: openmm.System,
     combine_nonbonded_forces: bool,
     detailed: bool,
 ) -> EnergyReport:

--- a/openff/interchange/drivers/openmm.py
+++ b/openff/interchange/drivers/openmm.py
@@ -6,14 +6,17 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy
-from openff.toolkit import Quantity
 from openff.units import ensure_quantity
 from openff.utilities.utilities import has_package, requires_package
 
-from openff.interchange import Interchange
 from openff.interchange.drivers.report import EnergyReport
 from openff.interchange.exceptions import CannotInferNonbondedEnergyError
 from openff.interchange.interop.openmm._positions import to_openmm_positions
+
+if TYPE_CHECKING:
+    from openff.toolkit import Quantity
+
+    from openff.interchange import Interchange
 
 if has_package("openmm") or TYPE_CHECKING:
     import openmm

--- a/openff/interchange/drivers/report.py
+++ b/openff/interchange/drivers/report.py
@@ -1,5 +1,7 @@
 """Storing and processing results of energy evaluations."""
 
+from __future__ import annotations
+
 import warnings
 from typing import Annotated
 
@@ -98,7 +100,7 @@ class EnergyReport(_BaseModel):
 
     def compare(
         self,
-        other: "EnergyReport",
+        other: EnergyReport,
         tolerances: dict[str, Quantity] | None = None,
     ):
         """
@@ -146,7 +148,7 @@ class EnergyReport(_BaseModel):
 
     def diff(
         self,
-        other: "EnergyReport",
+        other: EnergyReport,
     ) -> dict[str, Quantity]:
         """
         Return the per-key energy differences between these reports.
@@ -198,7 +200,7 @@ class EnergyReport(_BaseModel):
 
         return energy_differences
 
-    def __sub__(self, other: "EnergyReport") -> dict[str, Quantity]:
+    def __sub__(self, other: EnergyReport) -> dict[str, Quantity]:
         diff = dict()
         for key in self.energies:
             if key not in other.energies:

--- a/openff/interchange/foyer/_base.py
+++ b/openff/interchange/foyer/_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from copy import copy
 from typing import TYPE_CHECKING
@@ -51,7 +53,7 @@ class FoyerConnectedAtomsHandler(Collection):
     def store_matches(
         self,
         atom_slots: dict[TopologyKey, PotentialKey],
-        topology: "Topology",
+        topology: Topology,
     ) -> None:
         """Populate self.key_map with key-val pairs of [TopologyKey, PotentialKey]."""
         for connection in getattr(topology, self.connection_attribute):
@@ -68,7 +70,7 @@ class FoyerConnectedAtomsHandler(Collection):
                 id=POTENTIAL_KEY_SEPARATOR.join(pot_key_ids),
             )
 
-    def store_potentials(self, force_field: "Forcefield") -> None:
+    def store_potentials(self, force_field: Forcefield) -> None:
         """Populate self.potentials with key-val pairs of [PotentialKey, Potential]."""
         from foyer.exceptions import MissingForceError, MissingParametersError
 

--- a/openff/interchange/foyer/_base.py
+++ b/openff/interchange/foyer/_base.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 from openff.toolkit import Quantity, Topology
 
 from openff.interchange.components.potentials import Collection, Potential
-from openff.interchange.foyer._guard import has_foyer
 from openff.interchange.models import PotentialKey, TopologyKey
 
 if TYPE_CHECKING:
+    from openff.interchange.foyer._guard import has_foyer
+
     if has_foyer:
         try:
             from foyer import Forcefield

--- a/openff/interchange/foyer/_create.py
+++ b/openff/interchange/foyer/_create.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy
 from numpy.typing import NDArray
 from openff.toolkit import Quantity, Topology
@@ -44,7 +46,7 @@ def get_handlers_callable() -> dict[str, _CollectionAlias]:
 
 
 def _create_interchange(
-    force_field: "Forcefield",
+    force_field: Forcefield,
     topology: Topology,
     box: Quantity | None = None,
     positions: Quantity | None = None,

--- a/openff/interchange/foyer/_create.py
+++ b/openff/interchange/foyer/_create.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 if has_foyer:
     try:
-        pass
+        from foyer import Forcefield  # noqa
     except ModuleNotFoundError:
         pass
 

--- a/openff/interchange/foyer/_create.py
+++ b/openff/interchange/foyer/_create.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy
-from numpy.typing import NDArray
 from openff.toolkit import Quantity, Topology
 
 from openff.interchange import Interchange
@@ -22,9 +23,13 @@ from openff.interchange.foyer._valence import (
 )
 from openff.interchange.models import TopologyKey
 
+if TYPE_CHECKING:
+    from foyer import Forcefield
+    from numpy.typing import NDArray
+
 if has_foyer:
     try:
-        from foyer import Forcefield
+        pass
     except ModuleNotFoundError:
         pass
 

--- a/openff/interchange/foyer/_nonbonded.py
+++ b/openff/interchange/foyer/_nonbonded.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from openff.toolkit import Quantity, Topology
 from pydantic import Field, PrivateAttr
@@ -10,9 +10,11 @@ from openff.interchange.foyer._base import _copy_params
 from openff.interchange.foyer._guard import has_foyer
 from openff.interchange.models import PotentialKey, TopologyKey
 
+if TYPE_CHECKING:
+    from foyer import Forcefield
+
 if has_foyer:
     try:
-        from foyer import Forcefield
         from foyer.atomtyper import find_atomtypes
         from foyer.topology_graph import TopologyGraph
     except ModuleNotFoundError:

--- a/openff/interchange/foyer/_valence.py
+++ b/openff/interchange/foyer/_valence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal
 
 from openff.toolkit import Topology
@@ -36,7 +38,7 @@ class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler, BondCollection):
     def store_matches(
         self,
         atom_slots: dict[TopologyKey, PotentialKey],
-        topology: "Topology",
+        topology: Topology,
     ) -> None:
         """Populate self.key_map with key-val pairs of [TopologyKey, PotentialKey]."""
         for bond in topology.bonds:
@@ -74,7 +76,7 @@ class FoyerHarmonicAngleHandler(FoyerConnectedAtomsHandler, AngleCollection):
     def store_matches(
         self,
         atom_slots: dict[TopologyKey, PotentialKey],
-        topology: "Topology",
+        topology: Topology,
     ) -> None:
         """Populate self.key_map with key-val pairs of [TopologyKey, PotentialKey]."""
         for angle in topology.angles:
@@ -116,7 +118,7 @@ class FoyerRBProperHandler(
     def store_matches(
         self,
         atom_slots: dict[TopologyKey, PotentialKey],
-        topology: "Topology",
+        topology: Topology,
     ) -> None:
         """Populate self.key_map with key-val pairs of [TopologyKey, PotentialKey]."""
         for proper in topology.propers:

--- a/openff/interchange/foyer/_valence.py
+++ b/openff/interchange/foyer/_valence.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from openff.toolkit import Topology
 from pydantic import Field
 
 from openff.interchange.common._valence import (
@@ -18,6 +17,9 @@ from openff.interchange.foyer._base import (
     _get_potential_key_id,
 )
 from openff.interchange.models import PotentialKey, TopologyKey
+
+if TYPE_CHECKING:
+    from openff.toolkit import Topology
 
 
 class FoyerHarmonicBondHandler(FoyerConnectedAtomsHandler, BondCollection):

--- a/openff/interchange/interop/_virtual_sites.py
+++ b/openff/interchange/interop/_virtual_sites.py
@@ -2,6 +2,8 @@
 Common helpers for exporting virtual sites.
 """
 
+from __future__ import annotations
+
 import abc
 from collections import defaultdict
 from typing import TYPE_CHECKING
@@ -26,7 +28,7 @@ class _OpenMMVirtualSite(_BaseModel, abc.ABC):
     particles: list[int]
 
     @abc.abstractmethod
-    def to_openmm(self) -> "openmm.VirtualSite":
+    def to_openmm(self) -> openmm.VirtualSite:
         """Create a (subclass of) openmm.VirtualSite"""
         raise NotImplementedError()
 
@@ -63,7 +65,7 @@ class _ThreeParticleAverageSite(_OpenMMVirtualSite):
 
 
 def _virtual_site_parent_molecule_mapping(
-    interchange: "Interchange",
+    interchange: Interchange,
 ) -> dict[BaseVirtualSiteKey, int]:
     """
     Map `VirtualSiteKey`s the index of the molecule they belong to.
@@ -101,7 +103,7 @@ def _virtual_site_parent_molecule_mapping(
     return mapping
 
 
-def _get_molecule_virtual_site_map(interchange: "Interchange") -> defaultdict[int, list[BaseVirtualSiteKey]]:
+def _get_molecule_virtual_site_map(interchange: Interchange) -> defaultdict[int, list[BaseVirtualSiteKey]]:
     virtual_site_molecule_map = _virtual_site_parent_molecule_mapping(interchange)
 
     molecule_virtual_site_map = defaultdict(list)
@@ -113,7 +115,7 @@ def _get_molecule_virtual_site_map(interchange: "Interchange") -> defaultdict[in
 
 
 def get_positions_with_virtual_sites(
-    interchange: "Interchange",
+    interchange: Interchange,
     collate: bool = False,
     use_zeros: bool = False,
 ) -> Quantity:
@@ -219,7 +221,7 @@ def get_positions_with_virtual_sites(
 
 
 def _get_separation_by_atom_indices(
-    interchange: "Interchange",
+    interchange: Interchange,
     atom_indices: tuple[int, ...],
     prioritize_geometry: bool = False,
 ) -> Quantity:

--- a/openff/interchange/interop/amber/export/_export.py
+++ b/openff/interchange/interop/amber/export/_export.py
@@ -1,5 +1,7 @@
 """Interfaces with Amber."""
 
+from __future__ import annotations
+
 import textwrap
 from collections import defaultdict
 from collections.abc import Iterable
@@ -41,7 +43,7 @@ def _flatten(list_of_lists: Iterable[list[int]]) -> list[int]:
 
 
 def _get_per_atom_exclusion_lists(
-    topology: "Topology",
+    topology: Topology,
 ) -> dict[int, defaultdict[int, list[int]]]:
     """
     Get the excluded atoms of each atom in this topology.
@@ -140,7 +142,7 @@ def _get_exclusion_lists(
 
 
 def _get_bond_lists(
-    interchange: "Interchange",
+    interchange: Interchange,
     atomic_numbers: tuple,
     potential_key_to_bond_type_mapping: dict[PotentialKey, int],
 ) -> tuple[list[int], list[int]]:
@@ -165,7 +167,7 @@ def _get_bond_lists(
 
 
 def _get_angle_lists(
-    interchange: "Interchange",
+    interchange: Interchange,
     atomic_numbers: tuple,
     potential_key_to_angle_type_mapping: dict[PotentialKey, int],
 ) -> tuple[list[int], list[int]]:
@@ -191,7 +193,7 @@ def _get_angle_lists(
 
 
 def _get_dihedral_lists(
-    interchange: "Interchange",
+    interchange: Interchange,
     atomic_numbers: tuple,
     potential_key_to_dihedral_type_mapping: dict[PotentialKey, int],
     already_counted: set[tuple[int, ...]],
@@ -277,7 +279,7 @@ def _get_dihedral_lists(
 
 
 # TODO: Split this mono-function into smaller functions
-def to_prmtop(interchange: "Interchange", file_path: Path | str):
+def to_prmtop(interchange: Interchange, file_path: Path | str):
     """
     Write a .prmtop file. See http://ambermd.org/prmtop.pdf for details.
 
@@ -763,7 +765,7 @@ def to_prmtop(interchange: "Interchange", file_path: Path | str):
         prmtop.write("       0\n")
 
 
-def to_inpcrd(interchange: "Interchange", file_path: Path | str):
+def to_inpcrd(interchange: Interchange, file_path: Path | str):
     """
     Write a .prmtop file. See https://ambermd.org/FileFormats.php#restart for details.
 

--- a/openff/interchange/interop/amber/export/_export.py
+++ b/openff/interchange/interop/amber/export/_export.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import textwrap
 from collections import defaultdict
-from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy
-from openff.toolkit import Topology
 
-from openff.interchange import Interchange
 from openff.interchange.components.toolkit import _get_num_h_bonds
 from openff.interchange.constants import (
     _PME,
@@ -24,7 +22,14 @@ from openff.interchange.exceptions import (
     UnsupportedExportError,
     UnsupportedMixingRuleError,
 )
-from openff.interchange.models import PotentialKey
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from openff.toolkit import Topology
+
+    from openff.interchange import Interchange
+    from openff.interchange.models import PotentialKey
 
 
 def _write_text_blob(file, blob):

--- a/openff/interchange/interop/common.py
+++ b/openff/interchange/interop/common.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
-from openff.toolkit import Quantity
+from typing import TYPE_CHECKING
 
-from openff.interchange import Interchange
 from openff.interchange.exceptions import (
     MissingPositionsError,
     MissingVirtualSitesError,
     UnsupportedExportError,
 )
-from openff.interchange.models import BaseVirtualSiteKey
-from openff.interchange.smirnoff import SMIRNOFFVirtualSiteCollection
+
+if TYPE_CHECKING:
+    from openff.toolkit import Quantity
+
+    from openff.interchange import Interchange
+    from openff.interchange.models import BaseVirtualSiteKey
+    from openff.interchange.smirnoff import SMIRNOFFVirtualSiteCollection
 
 
 def _to_positions(

--- a/openff/interchange/interop/common.py
+++ b/openff/interchange/interop/common.py
@@ -1,5 +1,7 @@
 """Utilities for interoperability with multiple packages."""
 
+from __future__ import annotations
+
 from openff.toolkit import Quantity
 
 from openff.interchange import Interchange
@@ -13,7 +15,7 @@ from openff.interchange.smirnoff import SMIRNOFFVirtualSiteCollection
 
 
 def _to_positions(
-    interchange: "Interchange",
+    interchange: Interchange,
     include_virtual_sites: bool = True,
 ) -> Quantity:
     """Generate an array of positions of all particles, optionally excluding virtual sites."""
@@ -38,7 +40,7 @@ def _to_positions(
         return interchange.positions
 
 
-def _check_virtual_site_exclusion_policy(handler: "SMIRNOFFVirtualSiteCollection"):
+def _check_virtual_site_exclusion_policy(handler: SMIRNOFFVirtualSiteCollection):
     _SUPPORTED_EXCLUSION_POLICIES = ("parents",)
 
     if handler.exclusion_policy not in _SUPPORTED_EXCLUSION_POLICIES:

--- a/openff/interchange/interop/gromacs/export/_virtual_sites.py
+++ b/openff/interchange/interop/gromacs/export/_virtual_sites.py
@@ -2,6 +2,8 @@
 Helper functions for exporting virutal sites to GROMACS.
 """
 
+from __future__ import annotations
+
 import numpy
 from openff.toolkit import Quantity
 
@@ -24,7 +26,7 @@ from openff.interchange.smirnoff._virtual_sites import (
 
 def _create_gromacs_virtual_site(
     interchange: Interchange,
-    virtual_site: "_VirtualSite",
+    virtual_site: _VirtualSite,
     virtual_site_key: BaseVirtualSiteKey,
     particle_map: dict[int | BaseVirtualSiteKey, int],
 ) -> GROMACSVirtualSite:

--- a/openff/interchange/interop/gromacs/export/_virtual_sites.py
+++ b/openff/interchange/interop/gromacs/export/_virtual_sites.py
@@ -4,10 +4,11 @@ Helper functions for exporting virutal sites to GROMACS.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy
 from openff.toolkit import Quantity
 
-from openff.interchange import Interchange
 from openff.interchange.interop._virtual_sites import _get_separation_by_atom_indices
 from openff.interchange.interop.gromacs.models.models import (
     GROMACSVirtualSite,
@@ -15,13 +16,16 @@ from openff.interchange.interop.gromacs.models.models import (
     GROMACSVirtualSite3,
     GROMACSVirtualSite3fad,
 )
-from openff.interchange.models import BaseVirtualSiteKey
 from openff.interchange.smirnoff._virtual_sites import (
     _BondChargeVirtualSite,
     _DivalentLonePairVirtualSite,
     _MonovalentLonePairVirtualSite,
     _VirtualSite,
 )
+
+if TYPE_CHECKING:
+    from openff.interchange import Interchange
+    from openff.interchange.models import BaseVirtualSiteKey
 
 
 def _create_gromacs_virtual_site(

--- a/openff/interchange/interop/lammps/export/export.py
+++ b/openff/interchange/interop/lammps/export/export.py
@@ -1,16 +1,19 @@
 """Export to LAMMPS."""
 
 from pathlib import Path
-from typing import IO
+from typing import IO, TYPE_CHECKING
 
 import numpy
 import packaging.version
-from openff.toolkit.topology import Atom
 
 from openff.interchange import Interchange
 from openff.interchange.exceptions import UnsupportedExportError
 from openff.interchange.interop.lammps.export.provenance import get_lammps_version
-from openff.interchange.models import PotentialKey
+
+if TYPE_CHECKING:
+    from openff.toolkit.topology import Atom
+
+    from openff.interchange.models import PotentialKey
 
 
 def to_lammps(interchange: Interchange, file_path: Path | str, include_type_labels: bool = False):

--- a/openff/interchange/interop/openmm/__init__.py
+++ b/openff/interchange/interop/openmm/__init__.py
@@ -1,5 +1,7 @@
 """Interfaces with OpenMM."""
 
+from __future__ import annotations
+
 from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
@@ -34,12 +36,12 @@ __all__ = [
 
 @requires_package("openmm")
 def to_openmm_system(
-    interchange: "Interchange",
+    interchange: Interchange,
     combine_nonbonded_forces: bool = False,
     add_constrained_forces: bool = False,
     ewald_tolerance: float = 1e-4,
     hydrogen_mass: PositiveFloat = 1.007947,
-) -> "openmm.System":
+) -> openmm.System:
     """
     Convert an Interchange to an OpenmM System.
 
@@ -156,7 +158,7 @@ to_openmm = to_openmm_system
 @requires_package("openmm")
 def _to_pdb(
     file_path: Path | str | TextIO,
-    topology: "openmm.app.Topology",
+    topology: openmm.app.Topology,
     positions,
 ):
     from openff.units import ensure_quantity
@@ -178,8 +180,8 @@ def _to_pdb(
 
 @requires_package("openmm")
 def _apply_hmr(
-    system: "openmm.System",
-    interchange: "Interchange",
+    system: openmm.System,
+    interchange: Interchange,
     hydrogen_mass: PositiveFloat,
 ):
     if abs(hydrogen_mass - 1.008) < 1e-3:

--- a/openff/interchange/interop/openmm/__init__.py
+++ b/openff/interchange/interop/openmm/__init__.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, TextIO
 from openff.toolkit import Molecule
 from openff.utilities.utilities import has_package, requires_package
 
-from openff.interchange._annotations import PositiveFloat
 from openff.interchange.exceptions import (
     NegativeMassError,
     PluginCompatibilityError,
@@ -25,6 +24,7 @@ if has_package("openmm"):
 
 if TYPE_CHECKING:
     from openff.interchange import Interchange
+    from openff.interchange._annotations import PositiveFloat
 
 __all__ = [
     "from_openmm",

--- a/openff/interchange/interop/openmm/_gbsa.py
+++ b/openff/interchange/interop/openmm/_gbsa.py
@@ -1,11 +1,17 @@
+from typing import TYPE_CHECKING
+
 from openff.utilities.utilities import has_package
 
-from openff.interchange import Interchange
 from openff.interchange.exceptions import UnsupportedExportError
-from openff.interchange.smirnoff._gbsa import SMIRNOFFGBSACollection
+
+if TYPE_CHECKING:
+    import openmm
+
+    from openff.interchange import Interchange
+    from openff.interchange.smirnoff._gbsa import SMIRNOFFGBSACollection
 
 if has_package("openmm"):
-    import openmm
+    pass
 
 
 def _process_gbsa(

--- a/openff/interchange/interop/openmm/_gbsa.py
+++ b/openff/interchange/interop/openmm/_gbsa.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
-from openff.utilities.utilities import has_package
+from typing import TYPE_CHECKING
 
 from openff.interchange.exceptions import UnsupportedExportError
 
@@ -10,13 +10,10 @@ if TYPE_CHECKING:
     from openff.interchange import Interchange
     from openff.interchange.smirnoff._gbsa import SMIRNOFFGBSACollection
 
-if has_package("openmm"):
-    pass
-
 
 def _process_gbsa(
-    interchange: "Interchange",
-    system: "openmm.System",
+    interchange: Interchange,
+    system: openmm.System,
 ):
     import openmm.app
 

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
-import openmm
-import openmm.app
-import openmm.unit
 from openff.toolkit import Quantity, Topology
 from openff.units import ensure_quantity
 from openff.units.openmm import from_openmm as from_openmm_
-from openff.utilities.utilities import has_package, requires_package
+from openff.utilities.utilities import requires_package
 from pydantic import ValidationError
 
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, vdWCollection
@@ -22,27 +21,28 @@ from openff.interchange.common._valence import (
 from openff.interchange.exceptions import NoPositionsError, UnsupportedImportError
 from openff.interchange.interop.openmm._import._virtual_sites import _convert_virtual_sites
 from openff.interchange.interop.openmm._import.compat import _check_compatible_inputs
-from openff.interchange.models import ImportedVirtualSiteKey
 from openff.interchange.warnings import MissingPositionsWarning
 
-if has_package("openmm"):
+if TYPE_CHECKING:
     import openmm
     import openmm.app
-    import openmm.unit
 
-if TYPE_CHECKING:
     from openff.interchange import Interchange
+    from openff.interchange.models import ImportedVirtualSiteKey
 
 
 @requires_package("openmm")
 def from_openmm(
     *,
-    system: "openmm.System",
-    topology: Union["openmm.app.Topology", Topology],
+    system: openmm.System,
+    topology: openmm.app.Topology | Topology,
     positions: Quantity | None = None,
     box_vectors: Quantity | None = None,
-) -> "Interchange":
+) -> Interchange:
     """Create an Interchange object from OpenMM data."""
+    import openmm
+    import openmm.app
+
     from openff.interchange import Interchange
 
     _check_compatible_inputs(system=system, topology=topology)
@@ -157,9 +157,11 @@ def from_openmm(
 
 
 def _convert_constraints(
-    system: "openmm.System",
+    system: openmm.System,
     particle_map: dict[int, int | ImportedVirtualSiteKey],
 ) -> ConstraintCollection | None:
+    import openmm.unit
+
     from openff.interchange.components.potentials import Potential
     from openff.interchange.models import BondKey, PotentialKey
 
@@ -201,7 +203,7 @@ def _convert_constraints(
 
 
 def _convert_nonbonded_force(
-    force: "openmm.NonbondedForce",
+    force: openmm.NonbondedForce,
     particle_map: dict[int, int | ImportedVirtualSiteKey],
 ) -> tuple[vdWCollection, ElectrostaticsCollection]:
     from openff.units.openmm import from_openmm as from_openmm_quantity
@@ -265,7 +267,7 @@ def _convert_nonbonded_force(
 
 
 def _convert_harmonic_bond_force(
-    force: "openmm.HarmonicBondForce",
+    force: openmm.HarmonicBondForce,
 ) -> BondCollection:
     from openff.units.openmm import from_openmm as from_openmm_quantity
 
@@ -295,7 +297,7 @@ def _convert_harmonic_bond_force(
 
 
 def _convert_harmonic_angle_force(
-    force: "openmm.HarmonicAngleForce",
+    force: openmm.HarmonicAngleForce,
 ) -> AngleCollection:
     from openff.units.openmm import from_openmm as from_openmm_quantity
 
@@ -328,7 +330,7 @@ def _convert_harmonic_angle_force(
 
 
 def _convert_periodic_torsion_force(
-    force: "openmm.PeriodicTorsionForce",
+    force: openmm.PeriodicTorsionForce,
 ) -> ProperTorsionCollection:
     # TODO: Can impropers be separated out from a PeriodicTorsionForce?
     # Maybe by seeing if a quartet is in mol/top.propers or .impropers
@@ -370,7 +372,7 @@ def _convert_periodic_torsion_force(
     return proper_torsions
 
 
-def _fill_in_rigid_water_bonds(interchange: "Interchange"):
+def _fill_in_rigid_water_bonds(interchange: Interchange):
     from openff.toolkit.topology._mm_molecule import Molecule, _SimpleMolecule
 
     from openff.interchange.components.potentials import Potential

--- a/openff/interchange/interop/openmm/_import/_import.py
+++ b/openff/interchange/interop/openmm/_import/_import.py
@@ -2,6 +2,9 @@ import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Union
 
+import openmm
+import openmm.app
+import openmm.unit
 from openff.toolkit import Quantity, Topology
 from openff.units import ensure_quantity
 from openff.units.openmm import from_openmm as from_openmm_
@@ -28,10 +31,6 @@ if has_package("openmm"):
     import openmm.unit
 
 if TYPE_CHECKING:
-    import openmm
-    import openmm.app
-    import openmm.unit
-
     from openff.interchange import Interchange
 
 

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -2,6 +2,8 @@
 Helper functions for producing `openmm.Force` objects for non-bonded terms.
 """
 
+from __future__ import annotations
+
 import itertools
 import warnings
 from collections import defaultdict
@@ -53,7 +55,7 @@ class _NonbondedData(NamedTuple):
 
 
 def _process_nonbonded_forces(
-    interchange: "Interchange",
+    interchange: Interchange,
     system: openmm.System,
     combine_nonbonded_forces: bool = False,
     ewald_tolerance: float = 1e-4,
@@ -127,7 +129,7 @@ def _process_nonbonded_forces(
 
 
 def _add_particles_to_system(
-    interchange: "Interchange",
+    interchange: Interchange,
     system: openmm.System,
     molecule_virtual_site_map,
 ) -> dict[int | BaseVirtualSiteKey, int]:
@@ -183,7 +185,7 @@ def _add_particles_to_system(
     return particle_map
 
 
-def _prepare_input_data(interchange: "Interchange") -> _NonbondedData:
+def _prepare_input_data(interchange: Interchange) -> _NonbondedData:
     try:
         vdw: vdWCollection = interchange["vdW"]
     except LookupError:
@@ -243,10 +245,10 @@ def _prepare_input_data(interchange: "Interchange") -> _NonbondedData:
 
 def _create_single_nonbonded_force(
     data: _NonbondedData,
-    interchange: "Interchange",
+    interchange: Interchange,
     system: openmm.System,
     ewald_tolerance: float,
-    molecule_virtual_site_map: dict["Molecule", list[BaseVirtualSiteKey]],
+    molecule_virtual_site_map: dict[Molecule, list[BaseVirtualSiteKey]],
     openff_openmm_particle_map: dict[int | BaseVirtualSiteKey, int],
 ):
     """Create a single openmm.NonbondedForce from vdW/electrostatics/virtual site collections."""
@@ -466,7 +468,7 @@ def _create_single_nonbonded_force(
 def _create_exceptions(
     data: _NonbondedData,
     non_bonded_force: openmm.NonbondedForce,
-    interchange: "Interchange",
+    interchange: Interchange,
     openff_openmm_particle_map: dict,
     parent_virtual_particle_mapping: defaultdict[int, list[int]],
 ):
@@ -558,7 +560,7 @@ def _create_exceptions(
 
 def _create_multiple_nonbonded_forces(
     data: _NonbondedData,
-    interchange: "Interchange",
+    interchange: Interchange,
     system: openmm.System,
     ewald_tolerance: float,
     molecule_virtual_site_map: dict,
@@ -750,7 +752,7 @@ def _create_multiple_nonbonded_forces(
 
 def _create_vdw_force(
     data: _NonbondedData,
-    interchange: "Interchange",
+    interchange: Interchange,
     molecule_virtual_site_map: dict[int, list[BaseVirtualSiteKey]],
     has_virtual_sites: bool,
 ) -> openmm.CustomNonbondedForce | None:
@@ -840,7 +842,7 @@ def _create_vdw_force(
 
 def _create_electrostatics_force(
     data: _NonbondedData,
-    interchange: "Interchange",
+    interchange: Interchange,
     ewald_tolerance: float,
     molecule_virtual_site_map: dict[int, list[BaseVirtualSiteKey]],
     has_virtual_sites: bool,
@@ -938,7 +940,7 @@ def _set_particle_parameters(
     data: _NonbondedData,
     vdw_force: openmm.CustomNonbondedForce,
     electrostatics_force: openmm.NonbondedForce,
-    interchange: "Interchange",
+    interchange: Interchange,
     has_virtual_sites: bool,
     molecule_virtual_site_map: dict[int, list[BaseVirtualSiteKey]],
     openff_openmm_particle_map: dict[int | BaseVirtualSiteKey, int],
@@ -1081,7 +1083,7 @@ def _get_14_scaling_factors(data: _NonbondedData) -> tuple[float, float]:
 
 
 def _apply_switching_function(
-    vdw_collection: "vdWCollection",
+    vdw_collection: vdWCollection,
     force: openmm.NonbondedForce,
 ):
     if not hasattr(force, "setUseSwitchingFunction"):

--- a/openff/interchange/interop/openmm/_nonbonded.py
+++ b/openff/interchange/interop/openmm/_nonbonded.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 import itertools
 import warnings
 from collections import defaultdict
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-from openff.toolkit import Molecule, Quantity
 from openff.units.openmm import to_openmm as to_openmm_quantity
 from openff.utilities.utilities import has_package
 
-from openff.interchange import Interchange
 from openff.interchange.common._nonbonded import ElectrostaticsCollection, _simpler_charges, vdWCollection
 from openff.interchange.constants import _PME
 from openff.interchange.exceptions import (
@@ -30,6 +28,11 @@ from openff.interchange.models import (
     TopologyKey,
 )
 from openff.interchange.warnings import NonbondedSettingsWarning
+
+if TYPE_CHECKING:
+    from openff.toolkit import Molecule, Quantity
+
+    from openff.interchange import Interchange
 
 if has_package("openmm"):
     import openmm

--- a/openff/interchange/interop/openmm/_topology.py
+++ b/openff/interchange/interop/openmm/_topology.py
@@ -9,8 +9,10 @@ from typing import TYPE_CHECKING
 from openff.toolkit import Topology
 from openff.utilities import has_package
 
-from openff.interchange import Interchange
 from openff.interchange.models import BaseVirtualSiteKey
+
+if TYPE_CHECKING:
+    from openff.interchange import Interchange
 
 if has_package("openmm") or TYPE_CHECKING:
     import openmm.app

--- a/openff/interchange/interop/openmm/_topology.py
+++ b/openff/interchange/interop/openmm/_topology.py
@@ -2,6 +2,8 @@
 Helper functions for exporting the topology to OpenMM.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from openff.toolkit import Topology
@@ -15,10 +17,10 @@ if has_package("openmm") or TYPE_CHECKING:
 
 
 def to_openmm_topology(
-    interchange: "Interchange",
+    interchange: Interchange,
     collate: bool = False,
     ensure_unique_atom_names: str | bool = "residues",
-) -> "openmm.app.Topology":
+) -> openmm.app.Topology:
     """
     Create an OpenMM Topology containing some virtual site information (if appropriate).
 

--- a/openff/interchange/models.py
+++ b/openff/interchange/models.py
@@ -118,11 +118,11 @@ class BondKey(TopologyKey):
 
     def _tuple(self) -> tuple[int, int] | tuple[tuple[int, int], float]:
         if self.bond_order is None:
-            return cast(tuple[int, int], self.atom_indices)
+            return cast("tuple[int, int]", self.atom_indices)
         else:
             return (
                 cast(
-                    tuple[int, int],
+                    "tuple[int, int]",
                     self.atom_indices,
                 ),
                 float(self.bond_order),
@@ -156,7 +156,7 @@ class AngleKey(TopologyKey):
     )
 
     def _tuple(self) -> tuple[int, int, int]:
-        return cast(tuple[int, int, int], self.atom_indices)
+        return cast("tuple[int, int, int]", self.atom_indices)
 
 
 class ProperTorsionKey(TopologyKey):
@@ -220,11 +220,11 @@ class ProperTorsionKey(TopologyKey):
         ]
     ):
         if self.mult is None and self.phase is None and self.bond_order is None:
-            return cast(tuple[int, int, int, int], self.atom_indices)
+            return cast("tuple[int, int, int, int]", self.atom_indices)
         else:
             return (
                 cast(
-                    tuple[int, int, int, int],
+                    "tuple[int, int, int, int]",
                     self.atom_indices,
                 ),
                 self.mult,

--- a/openff/interchange/operations/_combine.py
+++ b/openff/interchange/operations/_combine.py
@@ -1,5 +1,7 @@
 """The logic behind `Interchange.combine`."""
 
+from __future__ import annotations
+
 import copy
 import logging
 import warnings
@@ -34,8 +36,8 @@ def _are_almost_equal(
 
 
 def _check_nonbonded_compatibility(
-    interchange1: "Interchange",
-    interchange2: "Interchange",
+    interchange1: Interchange,
+    interchange2: Interchange,
 ):
     if not (
         "vdW" in interchange1.collections
@@ -98,9 +100,9 @@ def _check_nonbonded_compatibility(
 
 
 def _combine(
-    input1: "Interchange",
-    input2: "Interchange",
-) -> "Interchange":
+    input1: Interchange,
+    input2: Interchange,
+) -> Interchange:
     warnings.warn(
         "Interchange object combination is complex and may produce strange results outside "
         "of use cases it has been tested in. Use with caution and thoroughly validate results!",

--- a/openff/interchange/smirnoff/_base.py
+++ b/openff/interchange/smirnoff/_base.py
@@ -155,7 +155,7 @@ class SMIRNOFFCollection(Collection, abc.ABC):
     def store_matches(
         self,
         parameter_handler: ParameterHandler,
-        topology: "Topology",
+        topology: Topology,
     ) -> None:
         """Populate self.key_map with key-val pairs of [TopologyKey, PotentialKey]."""
         if self.key_map:
@@ -199,7 +199,7 @@ class SMIRNOFFCollection(Collection, abc.ABC):
     def create(
         cls,
         parameter_handler: TP,
-        topology: "Topology",
+        topology: Topology,
     ) -> Self:
         """
         Create a SMIRNOFFCOllection from toolkit data.

--- a/openff/interchange/smirnoff/_gbsa.py
+++ b/openff/interchange/smirnoff/_gbsa.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from openff.toolkit import Quantity, Topology
 from openff.toolkit.typing.engines.smirnoff.parameters import GBSAHandler
@@ -22,6 +21,9 @@ from openff.interchange.components.potentials import Potential
 from openff.interchange.constants import kcal_mol_a2
 from openff.interchange.exceptions import InvalidParameterHandlerError
 from openff.interchange.smirnoff._base import SMIRNOFFCollection
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 _KcalMolA2 = Annotated[
     Quantity,

--- a/openff/interchange/smirnoff/_gbsa.py
+++ b/openff/interchange/smirnoff/_gbsa.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Literal
 
@@ -85,7 +87,7 @@ class SMIRNOFFGBSACollection(SMIRNOFFCollection):
     def create(
         cls,
         parameter_handler: GBSAHandler,
-        topology: "Topology",
+        topology: Topology,
     ):
         """Instantiate a `SMIRNOFFGBSACollection` from a parameter handler and a topology."""
         if type(parameter_handler) not in cls.allowed_parameter_handlers():

--- a/openff/interchange/smirnoff/_gromacs.py
+++ b/openff/interchange/smirnoff/_gromacs.py
@@ -1,15 +1,14 @@
 import itertools
 import re
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from openff.toolkit import Molecule, Quantity
-from openff.toolkit.topology import Atom
 from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 from openff.units.elements import MASSES, SYMBOLS
 
 from openff.interchange import Interchange
 from openff.interchange._annotations import PositiveFloat
-from openff.interchange.components.potentials import Collection
 from openff.interchange.components.toolkit import _get_14_pairs
 from openff.interchange.exceptions import UnsupportedExportError
 from openff.interchange.interop._virtual_sites import (
@@ -45,6 +44,11 @@ from openff.interchange.models import (
 from openff.interchange.smirnoff._virtual_sites import (
     _create_virtual_site_object,
 )
+
+if TYPE_CHECKING:
+    from openff.toolkit.topology import Atom
+
+    from openff.interchange.components.potentials import Collection
 
 type MoleculeLike = Molecule | _SimpleMolecule
 

--- a/openff/interchange/smirnoff/_nonbonded.py
+++ b/openff/interchange/smirnoff/_nonbonded.py
@@ -121,7 +121,7 @@ def _downconvert_vdw_handler(vdw_handler: vdWHandler):
 
 
 def library_charge_from_molecule(
-    molecule: "Molecule",
+    molecule: Molecule,
 ) -> LibraryChargeHandler.LibraryChargeType:
     """Given an OpenFF Molecule with charges, generate a corresponding LibraryChargeType."""
     if molecule.partial_charges is None:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1498,6 +1498,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
@@ -1889,6 +1890,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
@@ -19691,6 +19693,11 @@ packages:
   - ipython>=7.31.1 ; python_full_version >= '3.11'
   - decorator ; python_full_version >= '3.11'
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl
+  name: ruff
+  version: 0.16.4
+  sha256: 963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl
   name: virtualenv
   version: 21.7.1
@@ -19703,6 +19710,11 @@ packages:
   - python-discovery>=1.4.2
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: ruff
+  version: 0.16.4
+  sha256: f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl
   name: python-discovery
   version: 1.5.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,7 @@ openmm = "*"
 
 [feature.dev.pypi-dependencies]
 pre-commit = "*"
+ruff = "*"
 ipdb = "*"
 
 [feature.engines.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,14 @@ fallback_version = "0.0.0"
 line-length = 119
 namespace-packages = [ "openff/interchange/" ]
 [tool.ruff.lint]
-select = [ "E", "F", "I", "NPY", "RUF", "UP", "W" ]
+select = [ "E", "F", "I", "NPY", "RUF", "UP", "W", "TC" ]
 per-file-ignores."plugins/*" = [ "INP001" ]
 isort.known-first-party = [ "openff.interchange" ]
 # can't find a clean way to get Rust's globset to handle this via regex ...
 isort.known-third-party = [ "openff.toolkit", "openff.utilities", "openff.units" ]
 pydocstyle.property-decorators = [ "validator" ]
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = [ "openff.interchange.pydantic._BaseModel" ]
 
 [tool.interrogate]
 fail-under = 90


### PR DESCRIPTION
### Description

Fixes #1527, if inadvertently

- [x] Use deferred evaluation of function annotations (PEP 649/749) which manifests as `from __future__ import annotations`
  - [x] Ruff changes some code if it sees this, mostly dropping the quotes from annotations since they're not needed
- [x] Use Ruff to hide annotation-only imports behind `if typing.TYPE_CHECKING` blocks
  - [x] Some extra config is needed to work around Pydantic's funkiness (https://github.com/astral-sh/ruff/issues/18992)